### PR TITLE
foreign keys relation improvements

### DIFF
--- a/docs/queries/prefetch.md
+++ b/docs/queries/prefetch.md
@@ -11,6 +11,20 @@ problem but faces it in a different and more clear way.
 The **Edgy** way of doing it its by also calling the `prefetch_related` queryset but passing
 [Prefetch](#prefetch) instances and utilising the [related_name](./related-name.md) to do it so.
 
+Note:
+
+The syntax is like the django syntax. With `__` a foreign key or related name of a foreign key is traversed.
+Only the last part of the path must be a inversion of a foreign key (`related_name`).
+
+Note:
+
+this kind of traversal for foreign keys is new. Former versions used the `related_name` of foreign keys with the
+effect that a model could only specify a related_name once despite on a different ForeignKey.
+
+Note:
+
+ManyToMany fields create a through model which must be traversed.
+
 ## Prefetch
 
 The main object used for the `prefetch_related` query. This particular object contains a set
@@ -37,12 +51,6 @@ be stored.
 * **queryset** (Optional) - Additional queryset for the type of query being made.
 
 ### Special attention
-
-Using the `Prefetch` also means something. You **must** use the [related names](./related-name.md)
-of the [ForeignKey](../relationships.md#foreignkey) declared.
-
-!!! Warning
-    **The Prefetch does not work on [ManyToMany](./many-to-many.md) fields**.
 
 This means, imagine you have the following:
 
@@ -71,8 +79,8 @@ We have now three [related names](./related-name.md):
 {!> ../docs_src/prefetch/second/prefetch.py !}
 ```
 
-Did you notice what happened there? The [Prefetch](#prefetch) used all the [related_names](./related-name.md)
-associated with the models to perform the query and did the transversal approach.
+The [Prefetch](#prefetch) used the foreign key name and the `related_name` at the last part
+to perform the query and did the transversal approach.
 
 The `company` now has an attribute `tracks` where it contains all the associated `tracks` list.
 
@@ -90,9 +98,6 @@ as the [Prefetch](#prefetch) is another process running internally, so that mean
 any filter you want as you would normal do in a query.
 
 ### How to use
-
-Make sure you **do not skip** the [special attention](#special-attention) section as it explains
-how the `related_name` query works.
 
 Now its where the good stuff starts. How can you take advantage of the `Prefetch` object in your
 queries.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,21 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+### Added
+
+- allow multiple ForeignKeys with the same related_name in one model
+- add ExcludeField for masking fields in submodels
+- add R
+
+### Changed
+
+- Breaking: Prefetch traversal of foreign keys uses now the foreign key name. For the traversal of RelatedFields everything stays the same.
+- ForeignKeys use now global constraints
+- pk is now a CompositeField (work for multiple primary keys in one model is on the way)
+- ConditionalRedirect constant for CompositeField
+
 ## 0.11.1
 
 ### Added

--- a/docs_src/prefetch/second/prefetch.py
+++ b/docs_src/prefetch/second/prefetch.py
@@ -30,6 +30,6 @@ class Article(edgy.Model):
 
 # All the tracks that belong to a specific `Company`.
 # The tracks are associated with `albums` and `studios`
-company = await Company.query.prefetch_related(
-    Prefetch(related_name="companies__studios__tracks", to_attr="tracks")
-).get(studio=studio)
+company = await Company.query.prefetch_related(Prefetch(related_name="studio__album__tracks", to_attr="tracks")).get(
+    studio=studio
+)

--- a/docs_src/prefetch/second/prefetch_filtered.py
+++ b/docs_src/prefetch/second/prefetch_filtered.py
@@ -9,7 +9,7 @@ models = edgy.Registry(database=database)
 # where the `Track` will be also internally filtered
 company = await Company.query.prefetch_related(
     Prefetch(
-        related_name="companies__studios__tracks",
+        related_name="studio__album__tracks",
         to_attr="tracks",
         queryset=Track.query.filter(title__icontains="bird"),
     )

--- a/edgy/__init__.py
+++ b/edgy/__init__.py
@@ -6,7 +6,7 @@ from .conf.global_settings import EdgySettings
 from .core.connection.database import Database, DatabaseURL
 from .core.connection.registry import Registry
 from .core.db import fields
-from .core.db.constants import CASCADE, RESTRICT, SET_NULL
+from .core.db.constants import CASCADE, RESTRICT, SET_NULL, ConditionalRedirect
 from .core.db.datastructures import Index, UniqueConstraint
 from .core.db.fields import (
     BigIntegerField,
@@ -51,6 +51,7 @@ __all__ = [
     "BinaryField",
     "BooleanField",
     "CASCADE",
+    "ConditionalRedirect",
     "CharField",
     "ChoiceField",
     "CompositeField",

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -19,6 +19,7 @@ terminal = Print()
 
 
 class BaseManyToManyForeignKeyField(BaseForeignKey):
+    # Do we need this attribute? we check on other ways
     is_m2m: bool = True
 
     def add_model_to_register(self, model: Any) -> None:
@@ -40,7 +41,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
 
         if self.through:
             if isinstance(self.through, str):
-                self.through = self.owner.meta.registry.models[self.through]
+                self.through = self.registry.models[self.through]
 
             self.through.meta.is_multi = True
             self.through.meta.multi_related = [self.to.__name__.lower()]
@@ -106,7 +107,6 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         return {}
 
     def __get__(self, instance: "Model", owner: Any = None) -> Relation:
-        # TODO: cache in the instance
         return Relation(through=self.through, to=self.to, owner=self.owner, instance=instance)
 
 

--- a/edgy/core/db/models/managers.py
+++ b/edgy/core/db/models/managers.py
@@ -33,8 +33,9 @@ class Manager:
     def __init__(self, model_class: Any = None):
         self.model_class = model_class
 
-    def __get__(self, _: Any, owner: Any) -> Type["QuerySet"]:
-        return cast("Type[QuerySet]", self.__class__(model_class=owner))
+    def __get__(self, instance: Any, owner: Any = None) -> Type["QuerySet"]:
+        # TODO: cache in instance
+        return cast("Type[QuerySet]", self.__class__(model_class=owner if owner else instance.__class__))
 
     def get_queryset(self) -> "QuerySet":
         """

--- a/edgy/core/db/models/row.py
+++ b/edgy/core/db/models/row.py
@@ -50,9 +50,10 @@ class ModelRow(EdgyBaseModel):
             if "__" in related:
                 first_part, remainder = related.split("__", 1)
                 try:
-                    model_cls = cls.fields[first_part].target
+                    model_cls = cls.meta.fields_mapping[first_part].target
                 except KeyError:
-                    model_cls = getattr(cls, first_part).related_from
+                    model_cls = cls.meta.related_fields[first_part].related_from
+
                 item[first_part] = model_cls.from_sqla_row(
                     row,
                     select_related=[remainder],
@@ -62,9 +63,9 @@ class ModelRow(EdgyBaseModel):
                 )
             else:
                 try:
-                    model_cls = cls.fields[related].target
+                    model_cls = cls.meta.fields_mapping[related].target
                 except KeyError:
-                    model_cls = getattr(cls, related).related_from
+                    model_cls = cls.meta.related_fields[related].related_from
                 item[related] = model_cls.from_sqla_row(row, exclude_secrets=exclude_secrets, using_schema=using_schema)
 
         # Populate the related names
@@ -167,9 +168,11 @@ class ModelRow(EdgyBaseModel):
         cls,
         row: Row,
         model: Type["Model"],
+        # for advancing
         prefetch_related: Sequence["Prefetch"],
         parent_cls: Optional[Type["Model"]] = None,
-        original_prefetch: Optional["Prefetch"] = None,
+        # for going back
+        inverse_path: str = "",
         is_nested: bool = False,
     ) -> Type["Model"]:
         """
@@ -183,27 +186,35 @@ class ModelRow(EdgyBaseModel):
             parent_cls = model
 
         for related in prefetch_related:
-            if not original_prefetch:
-                original_prefetch = related
+            if not is_nested:
+                # Check for conflicting names
+                # If to_attr has the same name of any
+                if hasattr(parent_cls, related.to_attr):
+                    raise QuerySetError(
+                        f"Conflicting attribute to_attr='{related.related_name}' with '{related.to_attr}' in {parent_cls.__class__.__name__}"
+                    )
 
-            if original_prefetch and not is_nested:
-                original_prefetch = related
-
-            # Check for conflicting names
-            # If to_attr has the same name of any
-            if hasattr(parent_cls, original_prefetch.to_attr):
-                raise QuerySetError(
-                    f"Conflicting attribute to_attr='{original_prefetch.related_name}' with '{original_prefetch.to_attr}' in {parent_cls.__class__.__name__}"
-                )
+            if not is_nested:
+                inverse_path = ""
 
             if "__" in related.related_name:
                 first_part, remainder = related.related_name.split("__", 1)
-                model_cls = cls.meta.related_fields[first_part].related_to
+
+                try:
+                    model_cls = cls.meta.related_fields[first_part].related_from
+                    reverse_part = cls.meta.related_fields[first_part].foreign_key_name
+                except KeyError:
+                    model_cls = cls.meta.foreign_key_fields[first_part].target
+                    reverse_part = cls.meta.foreign_key_fields[first_part].related_name
 
                 # Build the new nested Prefetch object
                 remainder_prefetch = related.__class__(
                     related_name=remainder, to_attr=related.to_attr, queryset=related.queryset
                 )
+                if inverse_path:
+                    inverse_path = f"{reverse_part}__{inverse_path}"
+                else:
+                    inverse_path = reverse_part
 
                 # Recursively continue the process of handling the
                 # new prefetch
@@ -211,7 +222,7 @@ class ModelRow(EdgyBaseModel):
                     row,
                     model,
                     prefetch_related=[remainder_prefetch],
-                    original_prefetch=original_prefetch,
+                    inverse_path=inverse_path,
                     parent_cls=model,
                     is_nested=True,
                 )
@@ -228,13 +239,12 @@ class ModelRow(EdgyBaseModel):
                 records = asyncio.get_event_loop().run_until_complete(cls.run_query(queryset=related.queryset))
                 setattr(model, related.to_attr, records)
             else:
-                model_cls = getattr(cls, related.related_name).related_from
                 records = cls.process_nested_prefetch_related(
                     row,
                     prefetch_related=related,
-                    original_prefetch=original_prefetch,
+                    inverse_path=inverse_path,
                     parent_cls=model,
-                    queryset=original_prefetch.queryset,
+                    queryset=related.queryset,
                 )
 
                 setattr(model, related.to_attr, records)
@@ -246,33 +256,36 @@ class ModelRow(EdgyBaseModel):
         row: Row,
         prefetch_related: "Prefetch",
         parent_cls: Type["Model"],
-        original_prefetch: "Prefetch",
+        inverse_path: str,
         queryset: "QuerySet",
     ) -> List[Type["Model"]]:
         """
         Processes the nested prefetch related names.
         """
-        query_split = original_prefetch.related_name.split("__")
-        query_split.reverse()
-        query_split.pop(query_split.index(prefetch_related.related_name))
+        # Get the related field
+        try:
+            related_field = cls.meta.related_fields[prefetch_related.related_name]
+            reverse_part = cls.meta.related_fields[prefetch_related.related_name].foreign_key_name
+        except KeyError:
+            fk_field = cls.meta.foreign_key_fields[prefetch_related.related_name]
+            reverse_part = fk_field.related_name
+            related_field = fk_field.target.meta.related_fields[fk_field.related_name]
+
+        if inverse_path:
+            inverse_path = f"{reverse_part}__{inverse_path}"
+        else:
+            inverse_path = reverse_part
 
         # Get the model to query related
-        model_class = getattr(cls, prefetch_related.related_name).related_from
+        model_class = related_field.related_from
 
-        # Get the foreign key name from the model_class
-        foreign_key_name = model_class.meta.related_names_mapping[prefetch_related.related_name]
-
-        # Insert as the entry point of the query
-        query_split.insert(0, foreign_key_name)
-
-        # Build new filter
-        query = "__".join(query_split)
-
-        # Extact foreign key value
+        # TODO: related_field.clean would be better
+        # fix this later when allowing selecting fields for fireign keys
+        # Extract foreign key value
         extra = {}
         for pkname in parent_cls.pknames:
             filter_by_pk = row[pkname]
-            extra[f"{query}__{pkname}"] = filter_by_pk
+            extra[f"{inverse_path}__{pkname}"] = filter_by_pk
 
         records = asyncio.get_event_loop().run_until_complete(cls.run_query(model_class, extra, queryset))
         return records

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -40,7 +40,7 @@ class Relation(ManyRelationProtocol):
             self.to_name: None,
         }
 
-    def __get__(self, instance: Any, owner: Any) -> Any:
+    def __get__(self, instance: Any, owner: Any = None) -> Any:
         return self.__class__(instance=instance, through=self.through, to=self.to, owner=self.owner)
 
     def __getattr__(self, item: Any) -> Any:

--- a/edgy/core/utils/models.py
+++ b/edgy/core/utils/models.py
@@ -118,14 +118,6 @@ class ModelParser:
         validated.update(self._extract_model_references(extracted_values, model_cls))
         return validated
 
-    def _extract_db_fields_from_model(self, model_class: Type["Model"]) -> Dict[Any, Any]:
-        """
-        Extacts all the db fields and excludes the related_names since those
-        are simply relations.
-        """
-        related_names = model_class.meta.related_names
-        return {k: v for k, v in model_class.model_fields.items() if k not in related_names}
-
 
 def create_edgy_model(
     __name__: str,

--- a/tests/prefetch/test_prefetch_related_nested.py
+++ b/tests/prefetch/test_prefetch_related_nested.py
@@ -70,7 +70,7 @@ async def test_prefetch_related():
     stud = await Studio.query.create(album=album, name="Valentim")
 
     studio = await Studio.query.prefetch_related(
-        Prefetch(related_name="studios__tracks", to_attr="tracks"),
+        Prefetch(related_name="album__tracks", to_attr="tracks"),
     ).get(pk=stud.pk)
 
     assert len(studio.tracks) == 3
@@ -78,7 +78,7 @@ async def test_prefetch_related():
     stud = await Studio.query.create(album=album2, name="New")
 
     studio = await Studio.query.prefetch_related(
-        Prefetch(related_name="studios__tracks", to_attr="tracks"),
+        Prefetch(related_name="album__tracks", to_attr="tracks"),
     ).get(pk=stud.pk)
 
     assert len(studio.tracks) == 1
@@ -95,14 +95,12 @@ async def test_prefetch_related_nested():
 
     await Company.query.create(studio=stud)
 
-    company = await Company.query.prefetch_related(
-        Prefetch(related_name="companies__studios__tracks", to_attr="tracks")
-    )
+    company = await Company.query.prefetch_related(Prefetch(related_name="studio__album__tracks", to_attr="tracks"))
 
     assert len(company[0].tracks) == 1
 
     company = await Company.query.prefetch_related(
-        Prefetch(related_name="companies__studios__tracks", to_attr="tracks")
+        Prefetch(related_name="studio__album__tracks", to_attr="tracks")
     ).get(studio=stud)
 
     assert len(company.tracks) == 1
@@ -121,7 +119,7 @@ async def test_prefetch_related_nested_with_queryset():
 
     company = await Company.query.prefetch_related(
         Prefetch(
-            related_name="companies__studios__tracks",
+            related_name="studio__album__tracks",
             to_attr="tracks",
             queryset=Track.query.filter(title__icontains="bird"),
         )


### PR DESCRIPTION
Changes:
- progress with multiple primary keys
- cleanup of related_fields
- allow multiple related_names with the same name to the same object
- slightly not documented yet Prefetch syntax change: you have to use the foreign key name when traversing a foreign key
- docs, changelog