### PR TITLE
remove `__model_references__`

### DIFF
--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -161,8 +161,6 @@ class Model(ModelRow, DeclarativeMixin):
         await self.signals.pre_save.send_async(self.__class__, instance=self)
 
         extracted_fields = self.extract_db_fields()
-        extracted_model_references = self.extract_db_model_references()
-        extracted_fields.update(extracted_model_references)
 
         for pkname in self.pknames:
             if getattr(self, pkname, None) is None and self.fields[pkname].autoincrement:

--- a/tests/models/test_model_multiple_primary_keys.py
+++ b/tests/models/test_model_multiple_primary_keys.py
@@ -78,7 +78,5 @@ async def test_model_multiple_primary_key_idempotence():
     user = await User.query.create(language="EN", name="edgy")
     user2 = await User.query.create(language="EN", name="edgy2", parent=user)
     extracted_fields = user2.extract_db_fields()
-    extracted_model_references = user2.extract_db_model_references()
-    extracted_fields.update(extracted_model_references)
     column_values = user2._extract_values_from_field(extracted_fields)
     assert User(**column_values).model_dump() == user2.model_dump(exclude={"parent": {"language": True}})


### PR DESCRIPTION
remove `__model_references__` they are not needed at all and a source of errors

It is a radical simplification which saves also some CPU cycles by merging the setup from kwargs