### PR TITLE
managers with instance attribute

### DIFF
--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -387,7 +387,9 @@ class EdgyBaseModel(BaseModel, DateParser, ModelParser, metaclass=BaseModelMeta)
         manager = self.meta.managers.get(name)
         if manager is not None:
             if name not in self.__dict__:
-                self.__dict__[name] = copy.copy(manager)
+                manager = copy.copy(manager)
+                manager.instance = self
+                self.__dict__[name] = manager
             return self.__dict__[name]
 
         field = self.meta.fields_mapping.get(name)

--- a/edgy/core/db/models/managers.py
+++ b/edgy/core/db/models/managers.py
@@ -30,10 +30,11 @@ class Manager:
     ```
     """
 
-    def __init__(self, model_class: Any = None, inherit: bool=True, name: str = ""):
+    def __init__(self, model_class: Any = None, inherit: bool=True, name: str = "", instance: Any=None):
         self.model_class = model_class
         self.inherit = inherit
         self.name = name
+        self.instance = instance
 
     def get_queryset(self) -> "QuerySet":
         """

--- a/edgy/core/db/models/managers.py
+++ b/edgy/core/db/models/managers.py
@@ -4,7 +4,15 @@ from edgy.core.db.context_vars import get_tenant, set_tenant
 from edgy.core.db.querysets.base import QuerySet
 
 
-class Manager:
+class BaseManager:
+    def __init__(self, model_class: Any = None, inherit: bool=True, name: str = "", instance: Any=None):
+        self.model_class = model_class
+        self.inherit = inherit
+        self.name = name
+        self.instance = instance
+
+
+class Manager(BaseManager):
     """
     Base Manager for the Edgy Models.
     To create a custom manager, the best approach is to inherit from the ModelManager.
@@ -29,12 +37,6 @@ class Manager:
         ...
     ```
     """
-
-    def __init__(self, model_class: Any = None, inherit: bool=True, name: str = "", instance: Any=None):
-        self.model_class = model_class
-        self.inherit = inherit
-        self.name = name
-        self.instance = instance
 
     def get_queryset(self) -> "QuerySet":
         """

--- a/edgy/core/db/models/managers.py
+++ b/edgy/core/db/models/managers.py
@@ -1,15 +1,22 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional, Type, Union
 
 from edgy.core.db.context_vars import get_tenant, set_tenant
 from edgy.core.db.querysets.base import QuerySet
 
+if TYPE_CHECKING:
+    from edgy.core.db.models.base import EdgyBaseModel
 
 class BaseManager:
-    def __init__(self, model_class: Any = None, inherit: bool=True, name: str = "", instance: Any=None):
-        self.model_class = model_class
+    def __init__(self, owner: Optional[Union[Type["EdgyBaseModel"]]] = None, inherit: bool=True, name: str = "", instance: Optional[Union["EdgyBaseModel"]]=None):
+        self.owner = owner
         self.inherit = inherit
         self.name = name
         self.instance = instance
+
+    @property
+    def model_class(self) -> Any:
+        # legacy name
+        return self.owner
 
 
 class Manager(BaseManager):
@@ -48,10 +55,10 @@ class Manager(BaseManager):
         if tenant:
             set_tenant(None)
             return QuerySet(
-                self.model_class,
-                table=self.model_class.table_schema(tenant),  # type: ignore
+                self.owner,
+                table=self.owner.table_schema(tenant),  # type: ignore
             )
-        return QuerySet(self.model_class)
+        return QuerySet(self.owner)
 
     def __getattr__(self, name: str) -> Any:
         """
@@ -63,4 +70,4 @@ class Manager(BaseManager):
         try:
             return getattr(self.get_queryset(), name)
         except AttributeError:
-            return getattr(self.model_class, name)
+            return getattr(self.owner, name)

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -559,7 +559,7 @@ class BaseModelMeta(ModelMetaclass):
             value.owner = new_class
         # set the model_class of managers
         for value in meta.managers.values():
-            value.model_class = new_class
+            value.owner = new_class
 
 
         # Validate meta for uniques and indexes

--- a/tests/managers/test_manager_simple.py
+++ b/tests/managers/test_manager_simple.py
@@ -54,14 +54,21 @@ async def rollback_connections():
 
 async def test_can_create_record():
     await User.mang.create(password="12345", username="user", email="test@test.com")
+    assert User.mang.instance is None
 
     users = await User.mang.all()
 
     assert len(users) == 0
 
     user = await User.mang.create(password="12345", username="user2", email="test1@test.com", is_admin=False)
+    assert user.mang.instance is user
+    User.mang._fooobar = True
+    assert hasattr(User.mang, "_fooobar")
+    assert not hasattr(user.mang, "_fooobar")
 
     users = await User.mang.all()
 
     assert len(users) == 1
     assert users[0].pk == user.pk
+    # new instances have now the attribute
+    assert hasattr(users[0].mang, "_fooobar")

--- a/tests/managers/test_managers.py
+++ b/tests/managers/test_managers.py
@@ -57,9 +57,12 @@ async def rollback_connections():
 
 async def test_model_crud():
     users = await User.query.all()
+    assert User.query.instance is None
     assert users == []
 
     user = await User.query.create(name="Test")
+    assert User.query.instance is None
+    assert user.query.instance is user
     users = await User.query.all()
     assert user.name == "Test"
     assert user.pk is not None


### PR DESCRIPTION
Now managers of an instance have also the attribute instance

I think this has potential. We could use managers as base for RelatedFields and Relations.

I splitted also Manager and BaseManager (without `__getattr__` magic)