### PR TITLE
Fix managers, add documentation

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -372,6 +372,7 @@ class MyModel(edgy.Model):
 * **to** - A string [model](./models.md) name or a class object of that same model.
 * **related_name** - The name to use for the relation from the related object back to this one.
 * **related_fields** - The columns or fields to use for the foreign key. If unset or empty, the primary key(s) are used.
+* **embed_parent** (to_attr, as_attr) - When accessing the reverse relation part, return to_attr instead and embed the parent object in as_attr (when as_attr is not empty). Default None (which disables it).
 * **no_constraint** - Skip creating a constraint. Note: if set and index=True an index will be created instead.
 * **on_delete** - A string indicating the behaviour that should happen on delete of a specific
 model. The available values are `CASCADE`, `SET_NULL`, `RESTRICT` and those can also be imported
@@ -426,7 +427,8 @@ class MyModel(edgy.Model):
 * **to_fields** - Provide the **related_fields** for the implicitly generated ForeignKey to the child model.
 * **related_name** - The name to use for the relation from the related object back to this one.
 * **through** - The model to be used for the relationship. Edgy generates the model by default
-if None is provided or **through** is an abstract model.
+                if None is provided or **through** is an abstract model.
+* **embed_through** - When traversing, embed the through object in this attribute. Otherwise it is not accessable.
 
 !!! Note:
     If **through** is an abstract model it will be used as a template (a new model is generated with through as base).

--- a/docs/managers.md
+++ b/docs/managers.md
@@ -47,7 +47,7 @@ an explicit `query_related` manager.
 {!> ../docs_src/models/managers/override.py !}
 ```
 
-Now with only overwritting the related manager:
+Now with only overwriting the related manager:
 
 ```python hl_lines="26 39 42 45 48"
 {!> ../docs_src/models/managers/override_related.py !}

--- a/docs/managers.md
+++ b/docs/managers.md
@@ -17,9 +17,10 @@ presented when doing it so.
 ### Custom manager
 
 It is also possible to have your own custom managers and to do it so, you **should inherit**
-the **Manager** class and override the `get_queryset()`.
+the **Manager** class and override the `get_queryset()`. For further customization it is possible to
+use the **BaseManager** class.
 
-For those familiar with Django managers, the principle is exactly the same. 😀
+For those familiar with Django managers, the concept is exactly the same. 😀
 
 **The managers must be type annotated ClassVar** or an `ImproperlyConfigured` exception will be raised.
 
@@ -39,11 +40,17 @@ simply override the `get_queryset()` and add it to your models.
 ### Override the default manager
 
 Overriding the default manager is also possible by creating the custom manager and overriding
-the `query` manager.
+the `query` manager. By default the `query`is also used for related queries. This can be customized via setting
+an explicit `query_related` manager.
 
 ```python hl_lines="26 39 42 45 48"
 {!> ../docs_src/models/managers/override.py !}
 ```
+
+Now with only overwritting the related manager:
+
+```python hl_lines="26 39 42 45 48"
+{!> ../docs_src/models/managers/override_related.py !}
 
 !!! Warning
     Be careful when overriding the default manager as you might not get all the results from the

--- a/docs/queries/queries.md
+++ b/docs/queries/queries.md
@@ -153,10 +153,10 @@ For this there is an extension of edgy's `and_` and `or_` which takes a model or
 matches kwargs against:
 
 ```python
-users = await User.query.filter(_and.from_kwargs(User, name="foo", email="foo@example.com"))
+users = await User.query.filter(and_.from_kwargs(User, name="foo", email="foo@example.com"))
 # or
 
-users = await User.query.filter(_and.from_kwargs(User, **my_dict))
+users = await User.query.filter(and_.from_kwargs(User, **my_dict))
 ```
 
 #### SQLAlchemy style

--- a/docs/references/queryset.md
+++ b/docs/references/queryset.md
@@ -10,6 +10,4 @@
         - "!^__class_getitem__"
         - "!^__get__"
         - "!^ESCAPE_CHARACTERS"
-        - "!^m2m_related"
         - "!^pknames"
-        - "!^_m2m_related"

--- a/docs/tenancy/edgy.md
+++ b/docs/tenancy/edgy.md
@@ -144,7 +144,7 @@ write `using(...)`.
 Importing is as simple as this:
 
 ```python
-from edgy.core.db.querysets.mixins import activate_schema, deativate_schema
+from edgy.core.db.querysets.mixins import activate_schema, deactivate_schema
 ```
 
 Let us see an example:

--- a/docs_src/models/managers/override_related.py
+++ b/docs_src/models/managers/override_related.py
@@ -1,0 +1,63 @@
+from typing import ClassVar
+
+import edgy
+from edgy import Database, Manager, QuerySet, Registry
+
+database = Database("sqlite:///db.sqlite")
+models = Registry(database=database)
+
+
+class InactiveManager(Manager):
+    """
+    Custom manager that will return only active users
+    """
+
+    def get_queryset(self) -> "QuerySet":
+        queryset = super().get_queryset().filter(is_active=False)
+        return queryset
+
+
+class Team(edgy.Model):
+    name = edgy.CharField(max_length=100)
+
+    class Meta:
+        registry = models
+
+
+class User(edgy.Model):
+    name: str = edgy.CharField(max_length=255)
+    email: str = edgy.EmailField(max_length=70)
+    team = edgy.ForeignKey(Team, null=True, related_name="members")
+    is_active: bool = edgy.BooleanField(default=True)
+
+    # Add the new manager only for related queries
+    query_related: ClassVar[Manager] = InactiveManager()
+
+    class Meta:
+        registry = models
+        unique_together = [("name", "email")]
+
+# Using ipython that supports await
+# Don't use this in production! Use Alembic or any tool to manage
+# The migrations for you
+await models.create_all()  # noqa
+
+# Create a Team using the default manager
+team = await Team.query.create(name="Edgy team")  # noqa
+
+# Create an inactive user
+user1 = await User.query.create(name="Edgy", email="foo@bar.com", is_active=False, team=team)  # noqa
+
+# You can also create a user using the new manager
+user2 = await User.query_related.create(name="Another Edgy", email="bar@foo.com", is_active=False, team=team)  # noqa
+
+# Create a user using the default manager
+user3 =await User.query.create(name="Edgy", email="user@edgy.com", team=team)  # noqa
+
+
+# Querying them all
+users = await User.query.all()  # noqa
+assert [user1, user2, user3] == users
+# now with team
+users2 = await team.members.all()  # noqa
+assert [user1, user2] == users2

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -345,6 +345,14 @@ class PKField(BaseCompositeField):
             d[translated_name] = getattr(instance, key, None)
         return d
 
+    def modify_input(self, name: str, kwargs: Dict[str, Any]) -> None:
+        if name not in kwargs:
+            return
+        # check for collisions
+        for pkname in self.owner.pknames:
+            if pkname in kwargs:
+                raise ValueError("Cannot specify a primary key field and the primary key itself")
+
     def embed_field(self, prefix: str, new_fieldname:str, owner: Optional[Union[Type["Model"], Type["ReflectModel"]]]=None, parent: Optional["BaseField"]=None) -> Optional[BaseField]:
         return None
 

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, TypeVar
 
 import sqlalchemy
 from pydantic import BaseModel
@@ -36,12 +36,14 @@ class BaseForeignKeyField(BaseForeignKey):
         on_delete: str,
         related_fields: Sequence[str] = (),
         no_constraint: bool = False,
+        embed_parent: Optional[Tuple[str, str]]=None,
         **kwargs: Any,
     ) -> None:
         self.related_fields = related_fields
         self.on_update = on_update
         self.on_delete = on_delete
         self.no_constraint = no_constraint
+        self.embed_parent = embed_parent
         super().__init__(**kwargs)
 
     @cached_property
@@ -73,18 +75,17 @@ class BaseForeignKeyField(BaseForeignKey):
 
         if isinstance(value, (target, target.proxy_model)):
             return value
-        if len(self.related_columns) == 1 and not isinstance(value, (dict, BaseModel)):
-            value = {next(iter(self.related_columns.keys())): value}
-        if isinstance(value, dict):
-            for key in self.related_columns.keys():
-                if value.get(key) is None:
-                    return None
-        else:
-            for key in self.related_columns.keys():
-                if getattr(value, key, None) is None:
-                    return None
+        related_columns = self.related_columns.keys()
+        if len(related_columns) == 1 and not isinstance(value, (dict, BaseModel)):
+            value = {next(iter(related_columns)): value}
+        elif isinstance(value, BaseModel):
+            return self.expand_relationship({col: getattr(value, col) for col in related_columns})
+        elif value is None:
+            return None
         instance = target.proxy_model(**value)
-        instance.identifying_columns = self.related_columns.keys()
+        instance.identifying_db_fields = related_columns
+        if not instance.can_load:
+            return None
         return instance
 
     def clean(self, name: str, value: Any, for_query: bool = False) -> Dict[str, Any]:

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -141,6 +141,8 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         """
         Meta field
         """
+        if isinstance(value, ManyRelation):
+            return {field_name: value}
         return {field_name: ManyRelation(through=self.through, to=self.to, from_foreign_key=self.from_foreign_key, to_foreign_key=self.to_foreign_key, embed_through=self.embed_through, refs=value)}
 
     def has_default(self) -> bool:

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -4,7 +4,7 @@ from edgy.core.db.constants import CASCADE
 from edgy.core.db.fields.base import BaseField, BaseForeignKey
 from edgy.core.db.fields.factories import ForeignKeyFieldFactory
 from edgy.core.db.fields.foreign_keys import ForeignKey
-from edgy.core.db.relationships.relation import Relation
+from edgy.core.db.relationships.relation import ManyRelation
 from edgy.core.terminal import Print
 from edgy.core.utils.models import create_edgy_model
 
@@ -24,15 +24,21 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         self,
         *,
         to_fields: Sequence[str] = (),
+        to_foreign_key: str = "",
         from_fields: Sequence[str] = (),
+        from_foreign_key: str = "",
         through: Union[str, Type["Model"]] = "",
+        embed_through: str="",
         **kwargs: Any,
     ) -> None:
-        self.to_fields = to_fields
-        self.from_fields = from_fields
-        self.through = through
-
         super().__init__(**kwargs)
+        self.to_fields = to_fields
+        self.to_foreign_key = to_foreign_key
+        self.from_fields = from_fields
+        self.from_foreign_key = from_foreign_key
+        self.through = through
+        self.embed_through = embed_through
+
 
     def add_model_to_register(self, model: Any) -> None:
         """
@@ -59,14 +65,38 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
             if through.meta.abstract:
                 __bases__ = (through,)
             else:
-                name = self.to.__name__.lower()
-                if name not in through.meta.multi_related:
-                    through.meta.multi_related.append(name)
+                if not self.from_foreign_key:
+                    candidate = None
+                    for field_name, field in through.meta.foreign_key_fields.items():
+                        if field.target == self.owner:
+                            if candidate:
+                                raise ValueError("multiple foreign keys to owner")
+                            else:
+                                candidate = field_name
+                    if not candidate:
+                        raise ValueError("no foreign key fo owner found")
+                    self.from_foreign_key = candidate
+                if not self.to_foreign_key:
+                    candidate = None
+                    for field_name, field in through.meta.foreign_key_fields.items():
+                        if field.target == self.to:
+                            if candidate:
+                                raise ValueError("multiple foreign keys to target")
+                            else:
+                                candidate = field_name
+                    if not candidate:
+                        raise ValueError("no foreign key fo target found")
+                    self.to_foreign_key = candidate
                 return
-
         owner_name = self.owner.__name__
         to_name = self.to.__name__
         class_name = f"{owner_name}{to_name}"
+        if not self.from_foreign_key:
+            self.from_foreign_key = owner_name.lower()
+
+        if not self.to_foreign_key:
+            self.to_foreign_key = to_name.lower()
+
         tablename = f"{owner_name.lower()}s_{to_name}s".lower()
 
         new_meta: MetaInfo = MetaInfo(None, tablename=tablename, registry=self.registry, multi_related=[to_name.lower()])
@@ -82,15 +112,18 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
             f"{self.related_name}" if self.related_name else f"{to_name.lower()}_{class_name.lower()}s_set"
         )
         fields = {
-            f"{owner_name.lower()}": ForeignKey(
+            f"{self.from_foreign_key}": ForeignKey(
                 self.owner,
                 null=True,
                 on_delete=CASCADE,
                 related_name=owner_related_name,
-                related_fields=self.from_fields
+                related_fields=self.from_fields,
+                primary_key=True
             ),
-            f"{to_name.lower()}": ForeignKey(self.to, null=True, on_delete=CASCADE, related_name=to_related_name,
-                related_fields=self.to_fields),
+            f"{self.to_foreign_key}": ForeignKey(self.to, null=True, on_delete=CASCADE, related_name=to_related_name,
+                related_fields=self.to_fields,
+                embed_parent=(self.from_foreign_key, self.embed_through),
+                primary_key=True),
         }
 
         # Create the through model
@@ -108,7 +141,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         """
         Meta field
         """
-        return {}
+        return {field_name: ManyRelation(through=self.through, to=self.to, from_foreign_key=self.from_foreign_key, to_foreign_key=self.to_foreign_key, embed_through=self.embed_through, refs=value)}
 
     def has_default(self) -> bool:
         """Checks if the field has a default value set"""
@@ -120,11 +153,21 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         """
         return {}
 
-    def __get__(self, instance: "Model", owner: Any = None) -> Relation:
-        relation = Relation(through=self.through, to=self.to, owner=self.owner, instance=instance)
+    def __get__(self, instance: "Model", owner: Any = None) -> ManyRelation:
         if instance:
-            instance.__dict__[self.name] = relation
-        return relation
+            if self.name not in instance.__dict__:
+                instance.__dict__[self.name] = ManyRelation(through=self.through, to=self.to, from_foreign_key=self.from_foreign_key, to_foreign_key=self.to_foreign_key, embed_through=self.embed_through, instance=instance)
+            if instance.__dict__[self.name].instance is None:
+                instance.__dict__[self.name].instance = instance
+            return instance.__dict__[self.name]  # type: ignore
+        raise ValueError("Missing instance")
+
+    def __set__(self, instance: "Model", value: Any) -> None:
+        relation = self.__get__(instance)
+        if not isinstance(value, Sequence):
+            value = [value]
+        for v in value:
+            relation._add_object(v)
 
 
 class ManyToManyField(ForeignKeyFieldFactory):

--- a/edgy/core/db/models/managers.py
+++ b/edgy/core/db/models/managers.py
@@ -18,7 +18,7 @@ class BaseManager:
         # legacy name
         return self.owner
 
-    def get_queryset(self) -> "QuerySet":
+    def get_queryset(self) -> QuerySet:
         """
         Returns the queryset object.
         """
@@ -74,6 +74,7 @@ class Manager(BaseManager):
         if name.startswith("_") or name == self.name:
             return super().__getattr__(name)
         try:
+            # we need to check tenant every request
             return getattr(self.get_queryset(), name)
         except AttributeError:
             return getattr(self.owner, name)

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -179,9 +179,11 @@ class Model(ModelRow, DeclarativeMixin):
                 force_save = True
 
         if force_save:
+            if values:
+                extracted_fields.update(values)
             # force save must ensure a complete mapping
             validated_values = self._extract_values_from_field(
-                extracted_values=extracted_fields if values is None else values, is_partial=False
+                extracted_values=extracted_fields, is_partial=False
             )
             kwargs = self._update_auto_now_fields(values=validated_values, fields=self.fields)
             kwargs, model_references = self.update_model_references(**kwargs)

--- a/edgy/core/db/models/utils.py
+++ b/edgy/core/db/models/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Set, Union, cast
+from typing import TYPE_CHECKING, Any, Iterable, Set, cast
 
 from edgy.core.connection.registry import Registry
 
@@ -48,52 +48,6 @@ def build_pkcolumns(model_class: Any) -> None:
     model_class._pkcolumns = tuple(sorted(pkcolumns))
 
 
-def pk_to_dict(model: "EdgyBaseModel", pk: Any, is_partial: bool = False) -> Dict[str, Any]:
-    try:
-        if len(model.pknames) == 1:
-            if isinstance(pk, dict):
-                pk = pk[model.pknames[0]]
-            elif hasattr(pk, model.pknames[0]):
-                pk = getattr(pk, model.pknames[0])
-            return {model.pknames[0]: pk}
-    except (KeyError, AttributeError) as exc:
-        if is_partial:
-            return {}
-        raise exc
-    retdict = {}
-    if isinstance(pk, dict):
-        for pkname in model.pknames:
-            try:
-                retdict[pkname] = pk[pkname]
-            except KeyError as exc:
-                if not is_partial:
-                    raise exc
-    else:
-        for pkname in model.pknames:
-            try:
-                retdict[pkname] = getattr(pk, pkname)
-            except AttributeError as exc:
-                if not is_partial:
-                    raise exc
-    return retdict
-
-
-def pk_from_model(model: "EdgyBaseModel", always_dict: bool = False) -> Union[Dict[str, Any], Any]:
-    if not always_dict and len(model.pknames) == 1:
-        return getattr(model, model.pknames[0], None)
-    else:
-        d = {}
-        has_non_null = False
-        for pkname in model.pknames:
-            d[pkname] = getattr(model, pkname, None)
-            if d[pkname] is not None:
-                has_non_null = True
-        if always_dict or has_non_null:
-            return d
-        else:
-            return None
-
-
-def pk_from_model_to_clauses(model: "EdgyBaseModel") -> Iterable[Any]:
-    for pkcolumn in model.pkcolumns:
-        yield getattr(model.table.columns, pkcolumn) == getattr(model, pkcolumn)
+def from_model_to_clauses(model: "EdgyBaseModel") -> Iterable[Any]:
+    for column in model.columns_for_load:
+        yield getattr(model.table.columns, column) == getattr(model, column)

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -934,7 +934,6 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
         Creates a record in a specific table.
         """
         queryset: "QuerySet" = self._clone()
-        # kwargs = queryset._validate_kwargs(**kwargs)
         instance = queryset.model_class(**kwargs)
         instance.table = queryset.table
         instance = await instance.save(force_save=True)

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -934,10 +934,10 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
         Creates a record in a specific table.
         """
         queryset: "QuerySet" = self._clone()
-        kwargs = queryset._validate_kwargs(**kwargs)
+        # kwargs = queryset._validate_kwargs(**kwargs)
         instance = queryset.model_class(**kwargs)
         instance.table = queryset.table
-        instance = await instance.save(force_save=True, values=kwargs)
+        instance = await instance.save(force_save=True)
         return instance
 
     async def bulk_create(self, objs: List[Dict]) -> None:

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -1,4 +1,5 @@
 import copy
+from collections import deque
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -6,6 +7,7 @@ from typing import (
     Dict,
     Generator,
     List,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -24,6 +26,7 @@ from edgy.core.db.fields.base import BaseForeignKey
 from edgy.core.db.querysets.mixins import EdgyModel, QuerySetPropsMixin, TenancyMixin
 from edgy.core.db.querysets.prefetch import PrefetchMixin
 from edgy.core.db.querysets.protocols import AwaitableQuery
+from edgy.core.db.relationships.related_field import RelatedField
 from edgy.core.utils.models import DateParser, ModelParser
 from edgy.exceptions import MultipleObjectsReturned, ObjectNotFound, QuerySetError
 from edgy.protocols.queryset import QuerySetProtocol
@@ -35,36 +38,88 @@ if TYPE_CHECKING:  # pragma: no cover
     from edgy.core.db.models import Model
 
 
+class RelationshipCrawlResult(NamedTuple):
+    model_class: Type["Model"]
+    field_name: str
+    operator: str
+    forward_path: str
+    reverse_path: str
+
+def crawl_relationship(model_class: Type["Model"], name: str, callback_fn: Any=None) -> RelationshipCrawlResult:
+    splitted = deque(name.split("__"))
+    field_name = splitted.popleft()
+    field = None
+    forward_path = ""
+    reverse_path = ""
+    operator: str = "exact"
+    while splitted:
+        field = model_class.meta.fields_mapping.get(field_name)
+        if field is None:
+            if len(splitted) == 1 and splitted[0] in settings.filter_operators:
+                operator = splitted[0]
+                break
+            else:
+                raise ValueError(f"Field: {field_name} of {name} not found")
+        if isinstance(field, BaseForeignKey):
+            model_class = field.target
+            if reverse_path:
+                reverse_path = f"{field.related_name}__{reverse_path}"
+            else:
+                reverse_path = field.related_name
+            if callback_fn:
+                callback_fn(model_class=model_class, field=field, reverse_path=reverse_path, forward_path=forward_path, inverse=False, operator=None)
+            if forward_path:
+                forward_path =  f"{forward_path}__{field_name}"
+            else:
+                forward_path = field_name
+            field_name = splitted.popleft()
+        elif isinstance(field, RelatedField):
+            model_class = field.related_from
+            if reverse_path:
+                reverse_path = f"{field.related_name}__{reverse_path}"
+            else:
+                reverse_path = field.foreign_key_name
+            if callback_fn:
+                callback_fn(model_class=model_class, field=field, reverse_path=reverse_path, forward_path=forward_path, inverse=True, operator=None)
+            if forward_path:
+                forward_path =  f"{forward_path}__{field_name}"
+            else:
+                forward_path = field_name
+            field_name = splitted.popleft()
+        elif splitted:
+            # Determine if we should treat the final part as a
+            # filter operator or as a related field.
+            if len(splitted) == 1 and splitted[0] in settings.filter_operators:
+                operator = splitted[0]
+                break
+            else:
+                raise ValueError(f"Tried to cross field: {field_name} of type {field!r}")
+        else:
+            break
+    if reverse_path:
+        reverse_path = f"{field_name}__{reverse_path}"
+    else:
+        reverse_path = field_name
+    if callback_fn and field is not None:
+        callback_fn(model_class=model_class, field=field, reverse_path=reverse_path, forward_path=forward_path, inverse=False, operator=operator)
+    return RelationshipCrawlResult(
+        model_class=model_class,
+        field_name=field_name,
+        operator=operator,
+        forward_path=forward_path,
+        reverse_path=reverse_path,
+    )
+
 def clean_query_kwargs(model: Type["Model"], kwargs: Dict[str, Any]) -> Dict[str, Any]:
     new_kwargs: Dict[str, Any] = {}
     for key, val in kwargs.items():
-        model_class = model
-        field_name = key
-        if "__" in key:
-            parts = key.split("__")
-
-            # Determine if we should treat the final part as a
-            # filter operator or as a related field.
-            if parts[-1] in settings.filter_operators:
-                field_name = parts[-2]
-                related_parts = parts[:-2]
-            else:
-                field_name = parts[-1]
-                related_parts = parts[:-1]
-            if related_parts:
-                # Walk the relationships to the actual model class
-                # against which the comparison is being made.
-                for part in related_parts:
-                    try:
-                        model_class = model_class.meta.fields_mapping[part].target
-                    except KeyError:
-                        model_class = model_class.meta.related_fields[part].related_from
-        if field_name in model_class.meta.fields_mapping:
-            new_kwargs.update(model_class.meta.fields_mapping[field_name].clean(key, val, for_query=True))
-        elif field_name in model_class.meta.related_fields:
-            new_kwargs.update(model_class.meta.related_fields[field_name].clean(key, val, for_query=True))
+        model_class, field_name, _, _, _ = crawl_relationship(model, key)
+        field = model_class.meta.fields_mapping.get(field_name)
+        if field is not None:
+            new_kwargs.update(field.clean(key, val, for_query=True))
         else:
             new_kwargs[key] = val
+            assert not isinstance(field, (BaseForeignKey, RelatedField))
     assert "pk" not in new_kwargs, "pk should be already parsed"
     return new_kwargs
 
@@ -94,7 +149,7 @@ class BaseQuerySet(
         distinct_on: Any = None,
         only_fields: Any = None,
         defer_fields: Any = None,
-        m2m_related: Any = None,
+        embed_parent: Any = None,
         using_schema: Any = None,
         table: Any = None,
         exclude_secrets: Any = False,
@@ -114,14 +169,12 @@ class BaseQuerySet(
         self._defer = [] if defer_fields is None else defer_fields
         self._expression = None
         self._cache = None
-        self._m2m_related = m2m_related  # type: ignore
+        self.embed_parent = embed_parent
         self.using_schema = using_schema
         self._exclude_secrets = exclude_secrets or False
         self.extra: Dict[str, Any] = {}
 
         # Making sure the queryset always starts without any schema associated unless specified
-        if self.is_m2m and not self._m2m_related:
-            self._m2m_related = self.model_class.meta.multi_related[0]
 
         if table is not None:
             self.table = table
@@ -183,16 +236,17 @@ class BaseQuerySet(
             select_from = queryset.table
             former_table = None
             for part in item.split("__"):
-                try:
-                    foreign_key = model_class.fields[part]
-                    model_class = foreign_key.target
+                field = model_class.fields[part]
+                if isinstance(field, BaseForeignKey):
+                    model_class = field.target
                     inverse = False
-                except KeyError:
-                    # Check related fields
-                    related_field = model_class.meta.related_fields[part]
-                    model_class = related_field.related_from
-                    foreign_key = related_field.foreign_key
+                    foreign_key = field
+                elif isinstance(field, RelatedField):
+                    model_class = field.related_from
+                    foreign_key = field.foreign_key
                     inverse = True
+                else:
+                    raise ValueError(f"{part}: invalid field type: {field!r}")
                 if foreign_key.is_cross_db:
                     raise NotImplementedError("We cannot cross databases yet, this feature is planned")
                 table = model_class.table
@@ -202,7 +256,7 @@ class BaseQuerySet(
                     *self._select_from_relationship_clause_generator(select_from, foreign_key, table, inverse, former_table)
                 )
                 former_table = table
-                tables[table.name] = table
+                tables[table.name] = table  # type: ignore
 
         return tables.values(), select_from
 
@@ -316,39 +370,11 @@ class BaseQuerySet(
         kwargs = clean_query_kwargs(self.model_class, kwargs)
 
         for key, value in kwargs.items():
-            if "__" in key:
-                parts = key.split("__")
-
-                # Determine if we should treat the final part as a
-                # filter operator or as a related field.
-                if parts[-1] in settings.filter_operators:
-                    op = parts[-1]
-                    field_name = parts[-2]
-                    related_parts = parts[:-2]
-                else:
-                    op = "exact"
-                    field_name = parts[-1]
-                    related_parts = parts[:-1]
-
-                model_class = self.model_class
-                if related_parts:
-                    # Add any implied select_related
-                    related_str = "__".join(related_parts)
-                    if related_str not in select_related:
-                        select_related.append(related_str)
-
-                    # Walk the relationships to the actual model class
-                    # against which the comparison is being made.
-                    for part in related_parts:
-                        try:
-                            model_class = model_class.meta.fields_mapping[part].target
-                        except KeyError:
-                            model_class = model_class.meta.related_fields[part].related_from
-                column = model_class.table.columns[field_name]
-
-            else:
-                op = "exact"
-                column = self.table.columns[key]
+            model_class, field_name, op, related_str, _ = crawl_relationship(self.model_class, key)
+            assert not isinstance(value, Model)
+            if related_str and related_str not in select_related:
+                select_related.append(related_str)
+            column = model_class.table.columns[field_name]
 
             # Map the operation code onto SQLAlchemy's ColumnElement
             # https://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.expression.ColumnElement
@@ -362,9 +388,6 @@ class BaseQuerySet(
                     for char in self.ESCAPE_CHARACTERS:
                         value = value.replace(char, f"\\{char}")
                 value = f"%{value}%"
-
-            if isinstance(value, Model):
-                value = value.pk
 
             clause = getattr(column, op_attr)(value)
             clause.modifiers["escape"] = "\\" if has_escaped_character else None
@@ -395,7 +418,7 @@ class BaseQuerySet(
                 order_by=self._order_by,
                 only_fields=self._only,
                 defer_fields=self._defer,
-                m2m_related=self.m2m_related,
+                embed_parent=self.embed_parent,
                 table=self.table,
                 exclude_secrets=self._exclude_secrets,
                 using_schema=self.using_schema,
@@ -446,7 +469,7 @@ class BaseQuerySet(
         queryset._group_by = copy.copy(self._group_by)
         queryset.distinct_on = copy.copy(self.distinct_on)
         queryset._expression = copy.copy(self._expression)
-        queryset._m2m_related = copy.copy(self._m2m_related)
+        queryset.embed_parent = self.embed_parent
         queryset._only = copy.copy(self._only)
         queryset._defer = copy.copy(self._defer)
         queryset._database = self.database
@@ -793,13 +816,21 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
             using_schema=queryset.using_schema,
         )
 
+    def embed_parent_in_result(self, result: Any) -> Any:
+        if not self.embed_parent:
+            return result
+        new_result = getattr(result, self.embed_parent[0])
+        if self.embed_parent[1]:
+            setattr(new_result, self.embed_parent[1], result)
+        return new_result
+
     async def _all(self, **kwargs: Any) -> List[EdgyModel]:
         """
         Executes the query.
         """
         queryset: "QuerySet" = self._clone()
-        if queryset.is_m2m:
-            queryset.distinct_on = [queryset.m2m_related]
+        if queryset.embed_parent:
+            queryset.distinct_on = [queryset.embed_parent[0]]
 
         if kwargs:
             return await queryset.filter(**kwargs).all()
@@ -829,10 +860,7 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
             for row in rows
         ]
 
-        if not queryset.is_m2m:
-            return results
-
-        all_results = [getattr(result, queryset.m2m_related) for result in results]
+        all_results = [self.embed_parent_in_result(result) for result in results]
         return all_results
 
     def all(self, **kwargs: Any) -> "QuerySet":

--- a/edgy/core/db/querysets/mixins.py
+++ b/edgy/core/db/querysets/mixins.py
@@ -50,18 +50,6 @@ class QuerySetPropsMixin:
     def pkcolumns(self) -> Sequence[str]:
         return self.model_class.pkcolumns  # type: ignore
 
-    @property
-    def is_m2m(self) -> bool:
-        return bool(self.model_class.meta.is_multi)
-
-    @property
-    def m2m_related(self) -> str:
-        return self._m2m_related
-
-    @m2m_related.setter
-    def m2m_related(self, value: str) -> None:
-        self._m2m_related = value
-
 
 class TenancyMixin:
     """
@@ -103,7 +91,7 @@ def activate_schema(tenant_name: str) -> None:
     set_schema(tenant_name)
 
 
-def deativate_schema() -> None:
+def deactivate_schema() -> None:
     """
     Deactivates the tenant for the context of the query.
     """

--- a/edgy/core/db/relationships/related_field.py
+++ b/edgy/core/db/relationships/related_field.py
@@ -49,6 +49,8 @@ class RelatedField(BaseField):
         """
         Meta field
         """
+        if isinstance(value, SingleRelation):
+            return {field_name: value}
         return {field_name: SingleRelation(to=self.related_from, to_foreign_key=self.foreign_key_name, embed_parent=self.embed_parent, refs=value)}
 
     def __get__(self, instance: "Model", owner: Any = None) -> SingleRelation:

--- a/edgy/core/db/relationships/related_field.py
+++ b/edgy/core/db/relationships/related_field.py
@@ -1,14 +1,15 @@
 import functools
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union, cast
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union, cast
 
+from edgy.core.db.fields.base import BaseField
 from edgy.core.db.fields.foreign_keys import BaseForeignKeyField
+from edgy.core.db.relationships.relation import SingleRelation
 
 if TYPE_CHECKING:
-    from edgy import Model, QuerySet, ReflectModel
-    from edgy.core.db.models.managers import BaseManager
+    from edgy import Model, ReflectModel
 
-
-class RelatedField:
+class RelatedField(BaseField):
     """
     When a `related_name` is generated, creates a RelatedField from the table pointed
     from the ForeignKey declaration and the the table declaring it.
@@ -16,26 +17,55 @@ class RelatedField:
 
     def __init__(
         self,
+        *,
         foreign_key_name: str,
-        related_name: str,
-        related_to: Union[Type["Model"], Type["ReflectModel"]],
         related_from: Union[Type["Model"], Type["ReflectModel"]],
-        instance: Optional[Union["Model", "ReflectModel"]] = None,
+        embed_parent: Optional[Tuple[str, str]]=None,
+        **kwargs: Any
     ) -> None:
         self.foreign_key_name = foreign_key_name
-        self.related_name = related_name
-        self.related_to = related_to
         self.related_from = related_from
-        self.instance = instance
+        self.embed_parent = embed_parent
+        super().__init__(
+            inherit=False,
+            exclude=True,
+            deprecated=False,
+            __type__=Any,
+            annotation=Any,
+            column_type=None,
+            null=True,
+            **kwargs
+        )
 
-    @functools.cached_property
-    def manager(self) -> "BaseManager":
-        """Returns the manager class"""
-        return self.related_from.meta.managers["query_related"]
+    @property
+    def related_to(self) ->  Union[Type["Model"], Type["ReflectModel"]]:
+        return self.owner
 
-    @functools.cached_property
-    def queryset(self) -> "QuerySet":
-        return self.manager.get_queryset()
+    @property
+    def related_name(self) ->  str:
+        return self.name
+
+    def to_model(self, field_name: str, value: Any, phase: str = "") -> Dict[str, Any]:
+        """
+        Meta field
+        """
+        return {field_name: SingleRelation(to=self.related_from, to_foreign_key=self.foreign_key_name, embed_parent=self.embed_parent, refs=value)}
+
+    def __get__(self, instance: "Model", owner: Any = None) -> SingleRelation:
+        if instance:
+            if self.name not in instance.__dict__:
+                instance.__dict__[self.name] = SingleRelation(to=self.related_from, to_foreign_key=self.foreign_key_name, embed_parent=self.embed_parent, instance=instance)
+            if instance.__dict__[self.name].instance is None:
+                instance.__dict__[self.name].instance = instance
+            return instance.__dict__[self.name]  # type: ignore
+        raise ValueError("missing instance")
+
+    def __set__(self, instance: "Model", value: Any) -> None:
+        relation = self.__get__(instance)
+        if not isinstance(value, Sequence):
+            value = [value]
+        for v in value:
+            relation._add_object(v)
 
     @functools.cached_property
     def foreign_key(self) -> BaseForeignKeyField:
@@ -45,44 +75,9 @@ class RelatedField:
     def is_cross_db(self) -> bool:
         return self.foreign_key.is_cross_db
 
-    def m2m_related(self) -> Any:
-        """
-        Guarantees the the m2m filter is done by the owner of the call
-        and not by the children.
-        """
-        if not self.related_from.meta.is_multi:
-            return
-
-        related = [
-            key
-            for key, value in self.related_from.fields.items()
-            if key != self.related_to.__name__.lower() and isinstance(value, BaseForeignKeyField)
-        ]
-        return related
-
-    def __get__(self, instance: Any, owner: Any = None) -> Any:
-        return self.__class__(
-            foreign_key_name=self.foreign_key_name,
-            related_name=self.related_name,
-            related_to=self.related_to,
-            instance=instance,
-            related_from=self.related_from,
-        )
-
-    def __getattr__(self, item: str) -> Any:
-        """
-        Gets the attribute from the queryset and if it does not
-        exist, then lookup in the model.
-        """
-        try:
-            attr = getattr(self.queryset, item)
-        except AttributeError:
-            attr = getattr(self.related_from, item)
-
-        func = self.wrap_args(attr)
-        return func
-
     def clean(self, name: str, value: Any, for_query: bool = False) -> Dict[str, Any]:
+        if not for_query:
+            return {}
         return self.related_to.meta.pk.clean("pk", value, for_query=for_query)  # type: ignore
 
     def wrap_args(self, func: Any) -> Any:
@@ -96,9 +91,7 @@ class RelatedField:
                 query[related_name] = getattr(self.instance, related_name)
             kwargs[self.foreign_key_name] =  query
 
-            related = self.m2m_related()
-            if related:
-                self.queryset.m2m_related = related[0]
+            self.queryset.embed_parent = self.embed_parent
             return func(*args, **kwargs)
 
         return wrapped

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -239,7 +239,7 @@ class SingleRelation(ManyRelationProtocol):
         if not isinstance(child, (self.to, self.to.proxy_model)):
             raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")
 
-        setattr(child, self.to_foreign_key, self)
+        setattr(child, self.to_foreign_key, self.instance)
         await child.save()
 
     async def remove(self, child: "Model") -> None:

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -1,5 +1,5 @@
 import functools
-from typing import TYPE_CHECKING, Any, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Type, Union
 
 from pydantic import ConfigDict
 
@@ -7,7 +7,7 @@ from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
 from edgy.protocols.many_relationship import ManyRelationProtocol
 
 if TYPE_CHECKING:
-    from edgy import Manager, Model, ReflectModel
+    from edgy import Model, ReflectModel
 
 
 class Relation(ManyRelationProtocol):
@@ -48,11 +48,9 @@ class Relation(ManyRelationProtocol):
         Gets the attribute from the queryset and if it does not
         exist, then lookup in the model.
         """
-        manager: Optional["Manager"] = getattr(self.through, "query_related", None)
-        if manager is None:
-            manager = self.through.query  # type: ignore
+        manager = self.through.meta.managers["query_related"]  # type: ignore
         try:
-            attr = getattr(cast("Manager", manager).get_queryset(), item)
+            attr = getattr(manager.get_queryset(), item)
         except AttributeError:
             attr = getattr(self.through, item)
 

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -239,8 +239,7 @@ class SingleRelation(ManyRelationProtocol):
         if not isinstance(child, (self.to, self.to.proxy_model)):
             raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")
 
-        setattr(child, self.to_foreign_key, self.instance)
-        await child.save()
+        await child.save(values={self.to_foreign_key: self.instance})
 
     async def remove(self, child: "Model") -> None:
         """Removes a child from the list of one to many.
@@ -251,8 +250,7 @@ class SingleRelation(ManyRelationProtocol):
         if not isinstance(child, self.to):
             raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")
 
-        setattr(child, self.to_foreign_key, None)
-        await child.save()
+        await child.save(values={self.to_foreign_key: None})
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self}>"

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -1,16 +1,17 @@
 import functools
-from typing import TYPE_CHECKING, Any, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Type, Union
 
-from pydantic import ConfigDict
+import sqlalchemy
+from pydantic import BaseModel, ConfigDict
 
 from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
 from edgy.protocols.many_relationship import ManyRelationProtocol
 
 if TYPE_CHECKING:
-    from edgy import Model, ReflectModel
+    from edgy import Model, QuerySet, ReflectModel
 
 
-class Relation(ManyRelationProtocol):
+class ManyRelation(ManyRelationProtocol):
     """
     When a `related_name` is generated, creates a RelatedField from the table pointed
     from the ForeignKey declaration and the the table declaring it.
@@ -20,37 +21,50 @@ class Relation(ManyRelationProtocol):
 
     def __init__(
         self,
+        *,
+        from_foreign_key: str,
+        to_foreign_key: str,
+        to: Union[Type["Model"], Type["ReflectModel"]],
+        through: Union[Type["Model"], Type["ReflectModel"]],
+        embed_through: str = "",
+        refs: Any = (),
         instance: Optional[Union[Type["Model"], Type["ReflectModel"]]] = None,
-        through: Optional[Union[Type["Model"], Type["ReflectModel"]]] = None,
-        to: Optional[Union[Type["Model"], Type["ReflectModel"]]] = None,
-        owner: Optional[Union[Type["Model"], Type["ReflectModel"]]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.through = through
-        self.instance = instance
         self.to = to
-        self.owner = owner
+        self.instance = instance
+        self.from_foreign_key = from_foreign_key
+        self.to_foreign_key = to_foreign_key
+        self.embed_through = embed_through
+        self.refs: Sequence[Union[Type["Model"], Type["ReflectModel"]]] = []
+        if not isinstance(refs, Sequence):
+            refs = [refs]
+        for v in refs:
+            self._add_object(v)
 
-        # Relationship parameters
-        self.owner_name = self.owner.__name__.lower()  # type: ignore
-        self.to_name = self.to.__name__.lower()  # type: ignore
-        self._relation_params = {
-            self.owner_name: None,
-            self.to_name: None,
-        }
+    def get_queryset(self) -> "QuerySet":
+        # we need to check tenant every request
+        queryset = self.through.meta.managers["query_related"].get_queryset()
+        queryset.embed_parent = (self.to_foreign_key, self.embed_through)
+        return queryset
 
-    def __get__(self, instance: Any, owner: Any = None) -> Any:
-        return self.__class__(instance=instance, through=self.through, to=self.to, owner=self.owner)
+    async def save_related(self) -> None:
+        # TODO: improve performance
+        fk = self.through.meta.fields_mapping[self.from_foreign_key]
+        while self.refs:
+            ref = self.refs.pop()
+            ref.__dict__.update(fk.clean(fk.name, self.instance))
+            await self.add(ref)
 
     def __getattr__(self, item: Any) -> Any:
         """
         Gets the attribute from the queryset and if it does not
         exist, then lookup in the model.
-        """
-        manager = self.through.meta.managers["query_related"]  # type: ignore
+        """#
         try:
-            attr = getattr(manager.get_queryset(), item)
+            attr = getattr(self.get_queryset(), item)
         except AttributeError:
             attr = getattr(self.through, item)
 
@@ -60,12 +74,159 @@ class Relation(ManyRelationProtocol):
     def wrap_args(self, func: Any) -> Any:
         @functools.wraps(func)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
-            kwargs[self.owner_name] = self.instance.pk  # type: ignore
+            fk = self.through.meta.fields_mapping[self.from_foreign_key]
+            query = {}
+            for related_name in fk.related_columns.keys():
+                query[related_name] = getattr(self.instance, related_name)
+            kwargs[self.from_foreign_key] = query
             return func(*args, **kwargs)
 
         return wrapped
 
-    async def add(self, child: Type["Model"]) -> None:
+    def expand_relationship(self, value: Any) -> Any:
+        through = self.through
+
+        if isinstance(value, (through, through.proxy_model)):
+            return value
+        instance = through.proxy_model(**{self.from_foreign_key: self.instance, self.to_foreign_key: value})
+        instance.identifying_db_fields = [self.from_foreign_key, self.to_foreign_key]
+        return instance
+
+    def _add_object(self, child: Type["Model"]) -> None:
+        self.refs.append(self.expand_relationship(child))
+
+    async def add(self, child: "Model") -> None:
+        """
+        Adds a child to the model as a list
+
+        . Validates the type of the child being added to the relationship and raises error for
+        if the type is wrong.
+        . Checks if the middle table already contains the record being added. Raises error if yes.
+        """
+        if not isinstance(child, (self.to, self.through)):
+            raise RelationshipIncompatible(f"The child is not from the types '{self.to.__name__}', '{self.through.__name__}'.")
+        child = self.expand_relationship(child)
+
+        try:
+            async with child.database.transaction():
+                await child.save(force_save=True)
+        except Exception:
+            pass
+
+    async def remove(self, child: "Model") -> None:
+        """Removes a child from the list of many to many.
+
+        . Validates if there is a relationship between the entities.
+        . Removes the field if there is
+        """
+        if not isinstance(child, (self.to, self.through)):
+            raise RelationshipIncompatible(f"The child is not from the types '{self.to.__name__}', '{self.through.__name__}'.")
+        child = self.expand_relationship(child)
+        count = await child.query.filter(sqlalchemy.and_(*child.identifying_clauses())).count()
+        if count == 0:
+            raise RelationshipNotFound(
+                detail=f"There is no relationship between '{self.from_foreign_key}' and '{self.to_foreign_key}: {getattr(child,self.to_foreign_key).pk}'."
+            )
+        else:
+            await child.delete()
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {self}>"
+
+    def __str__(self) -> str:
+        return f"{self.through.__name__}"
+
+
+
+class SingleRelation(ManyRelationProtocol):
+    """
+    When a `related_name` is generated, creates a RelatedField from the table pointed
+    from the ForeignKey declaration and the the table declaring it.
+    """
+
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+    def __init__(
+        self,
+        *,
+        to_foreign_key: str,
+        to: Union[Type["Model"], Type["ReflectModel"]],
+        embed_parent: Optional[Tuple[str, str]]=None,
+        refs: Any = (),
+        instance: Optional[Union[Type["Model"], Type["ReflectModel"]]] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.to = to
+        self.instance = instance
+        self.to_foreign_key = to_foreign_key
+        self.embed_parent = embed_parent
+        self.refs: Sequence[Union[Type["Model"], Type["ReflectModel"]]] = []
+        if not isinstance(refs, Sequence):
+            refs = [refs]
+        for v in refs:
+            self._add_object(v)
+
+    def get_queryset(self) -> "QuerySet":
+        # we need to check tenant every request
+        queryset = self.to.meta.managers["query_related"].get_queryset()
+        queryset.embed_parent = self.embed_parent
+        return queryset
+
+    def expand_relationship(self, value: Any) -> Any:
+        target = self.to
+
+        if isinstance(value, (target, target.proxy_model)):
+            return value
+        related_columns = self.to.meta.fields_mapping[self.to_foreign_key].related_columns.keys()
+        if len(related_columns) == 1 and not isinstance(value, (dict, BaseModel)):
+            value = {next(iter(related_columns)): value}
+        if isinstance(value, dict):
+            for key in related_columns:
+                if value.get(key) is None:
+                    return None
+        else:
+            for key in related_columns:
+                if getattr(value, key, None) is None:
+                    return None
+        instance = target.proxy_model(**value)
+        instance.identifying_db_fields = related_columns
+        return instance
+
+    def _add_object(self, child: Type["Model"]) -> None:
+        self.refs.append(self.expand_relationship(child))
+
+    def __getattr__(self, item: Any) -> Any:
+        """
+        Gets the attribute from the queryset and if it does not
+        exist, then lookup in the model.
+        """
+        try:
+            attr = getattr(self.get_queryset(), item)
+        except AttributeError:
+            attr = getattr(self.to, item)
+
+        func = self.wrap_args(attr)
+        return func
+
+    def wrap_args(self, func: Any) -> Any:
+        @functools.wraps(func)
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            fk = self.to.meta.fields_mapping[self.to_foreign_key]
+            query = {}
+            for column_name in fk.get_column_names():
+                related_name = fk.from_fk_field_name(fk.name, column_name)
+                query[related_name] = getattr(self.instance, related_name)
+            kwargs[self.to_foreign_key] = query
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    async def save_related(self) -> None:
+        while self.refs:
+            await self.add(self.refs.pop())
+
+    async def add(self, child: "Model") -> None:
         """
         Adds a child to the model as a list
 
@@ -74,36 +235,25 @@ class Relation(ManyRelationProtocol):
         . Checks if the middle table already contains the record being added. Raises error if yes.
         """
         if not isinstance(child, self.to):
-            raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")  # type: ignore
+            raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")
 
-        self._relation_params.update({self.owner_name: self.instance, self.to_name: child})  # type: ignore
-        exists = await self.through.query.filter(**self._relation_params).exists()  # type: ignore
+        setattr(child, self.to_foreign_key, self)
+        await child.save()
 
-        if not exists:
-            await self.through.query.create(**self._relation_params)  # type: ignore
-
-    async def remove(self, child: Type["Model"]) -> None:
-        """Removes a child from the list of many to many.
+    async def remove(self, child: "Model") -> None:
+        """Removes a child from the list of one to many.
 
         . Validates if there is a relationship between the entities.
         . Removes the field if there is
         """
         if not isinstance(child, self.to):
-            raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")  # type: ignore
+            raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")
 
-        self._relation_params.update({self.owner_name: self.instance, self.to_name: child})  # type: ignore
-        exists = await self.through.query.filter(**self._relation_params).exists()  # type: ignore
-
-        if not exists:
-            raise RelationshipNotFound(
-                detail=f"There is no relationship between '{self.owner_name}' and '{self.to_name}: {child.pk}'."
-            )
-
-        child = await self.through.query.filter(**self._relation_params).get()  # type: ignore
-        await child.delete()  # type: ignore
+        setattr(child, self.to_foreign_key, None)
+        await child.save()
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self}>"
 
     def __str__(self) -> str:
-        return f"{self.through.__name__}"  # type: ignore
+        return f"{self.to.__name__}"

--- a/edgy/core/utils/models.py
+++ b/edgy/core/utils/models.py
@@ -113,7 +113,6 @@ class ModelParser:
                 if not field.read_only and field_name not in validated:
                     if field.has_default():
                         validated.update(field.get_default_values(field_name, validated))
-
         # Update with any ModelRef
         validated.update(self._extract_model_references(extracted_values, model_cls))
         return validated

--- a/edgy/protocols/many_relationship.py
+++ b/edgy/protocols/many_relationship.py
@@ -1,10 +1,4 @@
-from typing import TYPE_CHECKING, runtime_checkable
-
-try:
-    from typing import Protocol
-except ImportError:  # pragma: nocover
-    from typing_extensions import Protocol  # type: ignore
-
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:  # pragma: nocover
     from edgy import Model
@@ -13,6 +7,7 @@ if TYPE_CHECKING:  # pragma: nocover
 @runtime_checkable
 class ManyRelationProtocol(Protocol):
     """Defines the what needs to be implemented when using the ManyRelationProtocol"""
+    async def save_related(self) -> None: ...
 
     async def add(self, child: "Model") -> None: ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ module = "docs_src.*"
 ignore_errors = true
 
 [tool.pytest.ini_options]
-addopts = ["--strict-config", "--strict-markers"]
+addopts = ["--strict-config", "--strict-markers", "--pdbcls=IPython.terminal.debugger:Pdb"]
 xfail_strict = true
 junit_family = "xunit2"
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many.py
@@ -30,7 +30,7 @@ class Track(edgy.Model):
 class Album(edgy.Model):
     id = edgy.IntegerField(primary_key=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField("Track")
+    tracks = edgy.ManyToManyField("Track", embed_through="embedded")
 
     class Meta:
         registry = models
@@ -73,6 +73,21 @@ async def test_add_many_to_many():
     total_tracks = await album.tracks.all()
 
     assert len(total_tracks) == 3
+    for track in total_tracks:
+        assert track.embedded.track.pk == track.pk
+
+async def test_add_many_to_many_new():
+    track1 = await Track.query.create(title="The Bird", position=1)
+    track2 = await Track.query.create(title="Heart don't stand a chance", position=2)
+    track3 = await Track.query.create(title="The Waters", position=3)
+
+    album = await Album.query.create(name="Malibu", tracks=[track1, track2, track3])
+
+    total_tracks = await album.tracks.all()
+    assert len(total_tracks) == 3
+    for track in total_tracks:
+        assert track.embedded.track.pk == track.pk
+
 
 
 async def test_add_many_to_many_with_repeated_field():

--- a/tests/foreign_keys/m2m_string/test_many_to_many.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many.py
@@ -148,7 +148,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the type 'Track'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/m2m_string/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_field.py
@@ -148,7 +148,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the type 'Track'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -108,8 +108,11 @@ async def test_new_create():
     await album.tracks_set.add(track1)
     await album.tracks_set.add(track2)
     tracks = await album.tracks_set.all()
-
     assert len(tracks) == 2
+
+    await album.tracks_set.remove(track2)
+    tracks = await album.tracks_set.all()
+    assert len(tracks) == 1
 
 
 async def test_new_create2():

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -25,7 +25,7 @@ class Album(edgy.Model):
 
 class Track(edgy.Model):
     id = edgy.IntegerField(primary_key=True)
-    album = edgy.ForeignKey("Album", on_delete=edgy.CASCADE)
+    album = edgy.ForeignKey("Album", on_delete=edgy.CASCADE, null=True)
     title = edgy.CharField(max_length=100)
     position = edgy.IntegerField()
 
@@ -98,6 +98,29 @@ async def rollback_connections():
         async with database:
             yield
 
+
+async def test_new_create():
+    track1 = await Track.query.create(title="The Bird", position=1)
+    track2 = await Track.query.create(title="Heart don't stand a chance", position=2)
+    await Track.query.create(title="The Waters", position=3)
+
+    album = await Album.query.create(name="Malibu")
+    await album.tracks_set.add(track1)
+    await album.tracks_set.add(track2)
+    tracks = await album.tracks_set.all()
+
+    assert len(tracks) == 2
+
+
+async def test_new_create2():
+    track1 = await Track.query.create(title="The Bird", position=1)
+    track2 = await Track.query.create(title="Heart don't stand a chance", position=2)
+    await Track.query.create(title="The Waters", position=3)
+
+    album = await Album.query.create(name="Malibu", tracks_set=[track1, track2])
+    tracks = await album.tracks_set.all()
+
+    assert len(tracks) == 2
 
 async def test_select_related():
     album = await Album.query.create(name="Malibu")

--- a/tests/foreign_keys/test_many_to_many.py
+++ b/tests/foreign_keys/test_many_to_many.py
@@ -148,7 +148,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the type 'Track'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/test_many_to_many.py
+++ b/tests/foreign_keys/test_many_to_many.py
@@ -30,7 +30,7 @@ class Track(edgy.Model):
 class Album(edgy.Model):
     id = edgy.IntegerField(primary_key=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField(Track)
+    tracks = edgy.ManyToManyField(Track, embed_through="embedded")
 
     class Meta:
         registry = models
@@ -71,9 +71,21 @@ async def test_add_many_to_many():
     await album.tracks.add(track3)
 
     total_tracks = await album.tracks.all()
-
     assert len(total_tracks) == 3
+    for track in total_tracks:
+        assert track.embedded.track.pk == track.pk
 
+async def test_add_many_to_many_new():
+    track1 = await Track.query.create(title="The Bird", position=1)
+    track2 = await Track.query.create(title="Heart don't stand a chance", position=2)
+    track3 = await Track.query.create(title="The Waters", position=3)
+
+    album = await Album.query.create(name="Malibu", tracks=[track1, track2, track3])
+
+    total_tracks = await album.tracks.all()
+    assert len(total_tracks) == 3
+    for track in total_tracks:
+        assert track.embedded.track.pk == track.pk
 
 async def test_add_many_to_many_with_repeated_field():
     track1 = await Track.query.create(title="The Bird", position=1)

--- a/tests/foreign_keys/test_many_to_many_field.py
+++ b/tests/foreign_keys/test_many_to_many_field.py
@@ -148,7 +148,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the type 'Track'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/managers/test_managers_related.py
+++ b/tests/managers/test_managers_related.py
@@ -1,0 +1,81 @@
+from typing import ClassVar
+
+import pytest
+
+import edgy
+from edgy import Manager
+from edgy.core.db.querysets import QuerySet
+from edgy.testclient import DatabaseTestClient as Database
+from tests.settings import DATABASE_URL
+
+database = Database(url=DATABASE_URL)
+models = edgy.Registry(database=database)
+
+pytestmark = pytest.mark.anyio
+
+
+class InactiveManager(Manager):
+    """
+    Custom manager that will return only active users
+    """
+
+    def get_queryset(self) -> "QuerySet":
+        queryset = super().get_queryset().filter(is_active=False)
+        return queryset
+
+
+class Team(edgy.Model):
+    name = edgy.CharField(max_length=100)
+
+    class Meta:
+        registry = models
+
+
+class User(edgy.Model):
+    name: str = edgy.CharField(max_length=255)
+    email: str = edgy.EmailField(max_length=70)
+    team = edgy.ForeignKey(Team, null=True, related_name="members")
+    is_active: bool = edgy.BooleanField(default=True)
+
+    # Add the new manager only for related queries
+    query_related: ClassVar[Manager] = InactiveManager()
+
+    class Meta:
+        registry = models
+        unique_together = [("name", "email")]
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def create_test_database():
+    await models.create_all()
+    yield
+    await models.drop_all()
+
+
+@pytest.fixture(autouse=True)
+async def rollback_connections():
+    with database.force_rollback():
+        async with database:
+            yield
+
+
+async def test_managers_related():
+    # Create a Team using the default manager
+    team = await Team.query.create(name="Edgy team")  # noqa
+
+    # Create an inactive user
+    user1 = await User.query.create(name="Edgy", email="foo@bar.com", is_active=False, team=team)  # noqa
+
+    # You can also create a user using the new manager
+    user2 = await User.query_related.create(name="Another Edgy", email="bar@foo.com", is_active=False, team=team)  # noqa
+
+    # Create a user using the default manager
+    user3 =await User.query.create(name="Edgy", email="user@edgy.com", team=team)  # noqa
+
+
+    # Querying them all
+    users = await User.query.all()  # noqa
+    assert [user1, user2, user3] == users
+    # now with team
+    users2 = await team.members.all()  # noqa
+    assert [user1, user2] == users2

--- a/tests/models/test_embeddables.py
+++ b/tests/models/test_embeddables.py
@@ -4,6 +4,7 @@ import pytest
 
 import edgy
 from edgy.core.db.fields.base import BaseField
+from edgy.core.db.models.managers import BaseManager
 from edgy.testclient import DatabaseTestClient as Database
 from tests.settings import DATABASE_URL
 
@@ -91,11 +92,11 @@ def test_fields():
 )
 def test_field_types(model):
     for field in model.meta.fields_mapping.values():
-        assert not isinstance(field, edgy.Manager)
+        assert not isinstance(field, BaseManager)
     for field in model.meta.fields_mapping.values():
         assert isinstance(field, BaseField)
     for manager in model.meta.managers.values():
-        assert isinstance(manager, edgy.Manager)
+        assert isinstance(manager, BaseManager)
 
 
 @pytest.mark.parametrize(

--- a/tests/tenancy/test_activate_tenant.py
+++ b/tests/tenancy/test_activate_tenant.py
@@ -6,7 +6,7 @@ from pydantic import __version__
 import edgy
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
-from edgy.core.db.querysets.mixins import activate_schema, deativate_schema
+from edgy.core.db.querysets.mixins import activate_schema, deactivate_schema
 from edgy.testclient import DatabaseTestClient as Database
 from tests.settings import DATABASE_URL
 
@@ -89,7 +89,7 @@ async def test_activate_related_tenant():
     assert query[0].pk == permission.pk
 
     # Deactivate the schema and set to None (default)
-    deativate_schema()
+    deactivate_schema()
 
     query = await Permission.query.all()
 

--- a/tests/tenancy/test_activate_tenant_precedent.py
+++ b/tests/tenancy/test_activate_tenant_precedent.py
@@ -6,7 +6,7 @@ from pydantic import __version__
 import edgy
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
-from edgy.core.db.querysets.mixins import activate_schema, deativate_schema
+from edgy.core.db.querysets.mixins import activate_schema, deactivate_schema
 from edgy.testclient import DatabaseTestClient as Database
 from tests.settings import DATABASE_URL
 
@@ -90,7 +90,7 @@ async def test_activate_using_takes_precedence():
     assert query[0].pk == permission.pk
 
     # Deactivate the schema and set to None (default)
-    deativate_schema()
+    deactivate_schema()
 
     query = await Permission.query.all()
 


### PR DESCRIPTION
Changes:
- add RedirectManager for fixing query_related overwrites
- fix manager retrieval
- add identifying_columns for overwriting columns used for load (Note: this lead to the removal of the pk helper functions)
- misc bugfixes related to foreign keys
- remove of pk parsing in save, no internal methods needs it anymore
- add documentation related to query_related
- fix m2m magic
- allow embedding through models
- proper add, remove support for reverse end of m2m

FIXMEs:

- document assigning tables, normally this should never happen. The table of the modelClass should be used and also this table should never be overwritten