### PR TITLE
Many2Many fixes

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -9,8 +9,6 @@ on:
       - "docs/**"
   pull_request:
     branches: ["main", "release"]
-    paths-ignore:
-      - "docs/**"
   schedule:
     - cron: "0 0 * * *"
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -387,7 +387,9 @@ from `edgy`.
     from edgy import CASCADE, SET_NULL, RESTRICT
     ```
 
-
+Note: there is a `reverse_name` argument which can be used when `related_name=False` to specify a field for backward relations.
+It is useless except if related_name is False because it is otherwise overwritten.
+The `reverse_name` argument is used for finding the backward relation.
 
 #### RefForeignKey
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -16,7 +16,7 @@ Check the [primary_key](./models.md#restrictions-with-primary-keys) restrictions
 * **exclude** - An bool indicating if the field is included in model_dump
 * **default** - A value or a callable (function).
 * **index** - A boolean. Determine if a database index should be created.
-* **inherit** - A boolean. Determine if a field can be inherited in submodels. Default is False.
+* **inherit** - A boolean. Determine if a field can be inherited in submodels. Default is True. It is used by PKField, RelatedField and the injected ID Field.
 * **skip_absorption_check** - A boolean. Default False. Dangerous option! By default when defining a CompositeField with embedded fields and the `absorb_existing_fields` option it is checked that the field type of the absorbed field is compatible with the field type of the embedded field. This option skips the check.
 * **unique** - A boolean. Determine if a unique constraint should be created for the field.
 Check the [unique_together](./models.md#unique-together) for more details.
@@ -370,7 +370,8 @@ class MyModel(edgy.Model):
 ##### Parameters
 
 * **to** - A string [model](./models.md) name or a class object of that same model.
-* **related_name** - The name to use for the relation from the related object back to this one.
+* **related_name** - The name to use for the relation from the related object back to this one. Can be False to disable a reverse connection.
+                     Note: This will also prevent prefetching and reversing via `__`.
 * **related_fields** - The columns or fields to use for the foreign key. If unset or empty, the primary key(s) are used.
 * **embed_parent** (to_attr, as_attr) - When accessing the reverse relation part, return to_attr instead and embed the parent object in as_attr (when as_attr is not empty). Default None (which disables it).
 * **no_constraint** - Skip creating a constraint. Note: if set and index=True an index will be created instead.
@@ -380,6 +381,7 @@ from `edgy`.
 * **on_update** - A string indicating the behaviour that should happen on update of a specific
 model. The available values are `CASCADE`, `SET_NULL`, `RESTRICT` and those can also be imported
 from `edgy`.
+* **relation_fn** - Optionally drop a function which returns a Relation for the reverse side. This will be used by the RelatedField (if it is created). Used by Many2Many.
 
     ```python
     from edgy import CASCADE, SET_NULL, RESTRICT

--- a/docs/managers.md
+++ b/docs/managers.md
@@ -2,8 +2,13 @@
 
 The managers are a great tool that **Edgy** offers. Heavily inspired by Django, the managers
 allow you to build unique tailored queries ready to be used by your models.
+Unlike in Django Managers are instance and class aware.
+For every inheritance they are shallow copied and if used on an instance you have also an shallow copy you can customize.
 
-**Edgy** by default uses the the manager called `query` which it makes it simple to understand.
+Note: shallow copy means, deeply nested attributes or mutable attributes must be copied and not modified. As an alternative `__copy__` can be overwritten to do this for you.
+
+**Edgy** by default uses the the manager called `query` for direct queries which it makes it simple to understand.
+For related queries `query_related` is used which is by default a **RedirectManager** which redirects to `query`.
 
 Let us see an example.
 
@@ -14,11 +19,16 @@ Let us see an example.
 When querying the `User` table, the `query` (manager) is the default and **should** be always
 presented when doing it so.
 
-### Custom manager
+## Inheritance
+
+Managers can set the inherit flag to False, to prevent being used by subclasses. Things work like for fields.
+An usage would be injected managers though we have non yet.
+
+## Custom manager
 
 It is also possible to have your own custom managers and to do it so, you **should inherit**
 the **Manager** class and override the `get_queryset()`. For further customization it is possible to
-use the **BaseManager** class.
+use the **BaseManager** class which is more extensible.
 
 For those familiar with Django managers, the concept is exactly the same. 😀
 
@@ -37,7 +47,7 @@ Let us now create new manager and use it with our previous example.
 These managers can be as complex as you like with as many filters as you desire. What you need is
 simply override the `get_queryset()` and add it to your models.
 
-### Override the default manager
+## Override the default manager
 
 Overriding the default manager is also possible by creating the custom manager and overriding
 the `query` manager. By default the `query`is also used for related queries. This can be customized via setting

--- a/docs/queries/related-name.md
+++ b/docs/queries/related-name.md
@@ -38,6 +38,15 @@ the following format:
 ```text
 <table-name>s_set
 ```
+
+when non-unique. And
+
+```text
+<table-name>
+```
+
+when unique.
+
 Edgy will use the lowercased model name of the related model to create the reverse relation.
 
 Imagine you have a model `Team` that has a [ForeignKey][foreign_keys] to another model

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,7 @@ hide:
 - Allow skipping creating a ForeignKeyConstraint
   - Allow creating an Index instead
 - Add ExcludeField for masking fields in submodels
+- M2M Pass unique through to target foreignkey
 - ConditionalRedirect constant for CompositeField
 - Embeddables via CompositeField
 - Add ForeignKeyFactory
@@ -36,6 +37,7 @@ hide:
 - ForeignKeys use now global constraints and indexes
 - Breaking: clean has now the argument to_query
 - Breaking: Many2Many doesn't have a RelatedField on owner anymore
+- Breaking: use singular related_name for unique ForeignKeys (or OneToOne)
 - MetaInfo (meta) is now lazy
 - `pk` is now a PKField (a variant of the BaseCompositeField)
 - `clean` and `to_columns` of BaseField do return empty objects instead of raising NotImplementedError

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,8 @@ hide:
 - Add inherit flag for Manager, BaseFields and Models (when used as an embeddable)
 - Manager are now instance aware. You can customize the instance and they can react. They are also shallow copied for every class and instance.
 - Improved Relations (reverse side of ForeignKeys and forward side of Many2Many). Have now add and remove methods and work like RefForeignKey (you can just specify an Array with assignment targets and they will be added).
+- Allow skipping reverse RelatedFields
+- `pkcolumns` attribute of models (contains all found primary key columns)
 
 - Some new methods on BaseField:
   - embed_field: for controlling embedding a field in an CompositeField
@@ -33,13 +35,14 @@ hide:
 - Breaking: Prefetch traversal of foreign keys uses now the foreign key name. For the traversal of RelatedFields everything stays the same.
 - ForeignKeys use now global constraints and indexes
 - Breaking: clean has now the argument to_query
-- pk is now a PKField (a variant of the BaseCompositeField)
-- clean and to_columns of BaseField do return empty objects instead of raising NotImplementedError
+- Breaking: Many2Many doesn't have a RelatedField on owner anymore
+- MetaInfo (meta) is now lazy
+- `pk` is now a PKField (a variant of the BaseCompositeField)
+- `clean` and `to_columns` of BaseField do return empty objects instead of raising NotImplementedError
 - Major refactory of ForeignKeys, move logic for single ForeignKeys to subclass
-- Move FieldFactory to own file
-- Make MetaInfo lazy
+- Move FieldFactory and ForeignKeyFieldFactory to factories
 - Remove superfluous BaseOneToOneKeyField. Merged into BaseForeignKeyField.
-- remove unused attributes of MetaInfo and added some lazy evaluations for fields
+- Remove unused attributes of MetaInfo and added some lazy evaluations for fields
 
 ## 0.11.1
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,7 +20,7 @@ hide:
 - Add ForeignKeyFactory
 - Multiple primary keys and names different from "id" are possible now
 - Add inherit flag for Manager, BaseFields and Models (when used as an embeddable)
-- Manager are now instance aware. You can customize the instance and they can react. They are also shallow copied for every class and instance.
+- Managers are now instance aware. You can customize the instance and they can react. They are also shallow copied for every class and instance.
 - Improved Relations (reverse side of ForeignKeys and forward side of Many2Many). Have now add and remove methods and work like RefForeignKey (you can just specify an Array with assignment targets and they will be added).
 - Allow skipping reverse RelatedFields
 - `pkcolumns` attribute of models (contains all found primary key columns)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,8 @@ hide:
 - Add ForeignKeyFactory
 - Multiple primary keys and names different from "id" are possible now
 - Add inherit flag for Manager, BaseFields and Models (when used as an embeddable)
+- Manager are now instance aware. You can customize the instance and they can react. They are also shallow copied for every class and instance.
+- Improved Relations (reverse side of ForeignKeys and forward side of Many2Many). Have now add and remove methods and work like RefForeignKey (you can just specify an Array with assignment targets and they will be added).
 
 - Some new methods on BaseField:
   - embed_field: for controlling embedding a field in an CompositeField

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -7,6 +7,7 @@ from typing import (
     ClassVar,
     Dict,
     FrozenSet,
+    Literal,
     Optional,
     Pattern,
     Sequence,
@@ -429,7 +430,7 @@ class BaseForeignKey(BaseField):
     def __init__(
         self,
         *,
-        related_name: str = "",
+        related_name: Union[str, Literal[False]] = "",
         **kwargs: Any,
     ) -> None:
         self.related_name = related_name

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -431,9 +431,13 @@ class BaseForeignKey(BaseField):
         self,
         *,
         related_name: Union[str, Literal[False]] = "",
+        reverse_name: str = "",
         **kwargs: Any,
     ) -> None:
         self.related_name = related_name
+        # name used for backward relations
+        # only useful if related_name = False because otherwise it gets overwritten
+        self.reverse_name = reverse_name
         super().__init__(**kwargs)
 
     @property

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -1,9 +1,5 @@
 from functools import lru_cache
-from typing import (
-    Any,
-    Sequence,
-    cast,
-)
+from typing import Any, Literal, Sequence, Union, cast
 
 from edgy.core.db.constants import CASCADE, RESTRICT, SET_NULL
 from edgy.core.db.fields.base import BaseField, Field
@@ -90,7 +86,7 @@ class ForeignKeyFieldFactory(FieldFactory):
         null: bool = False,
         on_update: str = CASCADE,
         on_delete: str = RESTRICT,
-        related_name: str = "",
+        related_name: Union[str, Literal[False]] = "",
         server_onupdate: Any = None,
         default: Any = None,
         server_default: Any = None,
@@ -124,6 +120,6 @@ class ForeignKeyFieldFactory(FieldFactory):
             raise FieldDefinitionError("When SET_NULL is enabled, null must be True.")
         related_name = kwargs.get("related_name", "")
 
-        # tolerate Nones
+        # tolerate None and False
         if related_name and not isinstance(related_name, str):
             raise FieldDefinitionError("related_name must be a string.")

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -1,4 +1,16 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from edgy.core.db.constants import CASCADE
 from edgy.core.db.fields.base import BaseField, BaseForeignKey
@@ -7,6 +19,7 @@ from edgy.core.db.fields.foreign_keys import ForeignKey
 from edgy.core.db.relationships.relation import ManyRelation
 from edgy.core.terminal import Print
 from edgy.core.utils.models import create_edgy_model
+from edgy.protocols.many_relationship import ManyRelationProtocol
 
 if TYPE_CHECKING:
 
@@ -38,6 +51,12 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         self.from_foreign_key = from_foreign_key
         self.through = through
         self.embed_through = embed_through
+
+    def get_relation(self, **kwargs: Any) -> ManyRelationProtocol:
+        return ManyRelation(through=self.through, to=self.to, from_foreign_key=self.from_foreign_key, to_foreign_key=self.to_foreign_key, embed_through=self.embed_through, **kwargs)
+
+    def get_inverse_relation(self, **kwargs: Any) -> ManyRelationProtocol:
+        return ManyRelation(through=self.through, to=self.owner, from_foreign_key=self.to_foreign_key, to_foreign_key=self.from_foreign_key, embed_through=self.embed_through, **kwargs)
 
 
     def add_model_to_register(self, model: Any) -> None:
@@ -101,29 +120,33 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
 
         new_meta: MetaInfo = MetaInfo(None, tablename=tablename, registry=self.registry, multi_related=[to_name.lower()])
 
-        # Define the related names
-        owner_related_name = (
-            f"{self.related_name}_{class_name.lower()}s_set"
-            if self.related_name
-            else f"{owner_name.lower()}_{class_name.lower()}s_set"
-        )
+        to_related_name: Union[str, Literal[False]]
+        if self.related_name is False:
+            to_related_name = False
+        elif self.related_name:
+            to_related_name = f"{self.related_name}"
+        else:
+            to_related_name = f"{to_name.lower()}_{class_name.lower()}s_set"
 
-        to_related_name = (
-            f"{self.related_name}" if self.related_name else f"{to_name.lower()}_{class_name.lower()}s_set"
-        )
         fields = {
             f"{self.from_foreign_key}": ForeignKey(
                 self.owner,
                 null=True,
                 on_delete=CASCADE,
-                related_name=owner_related_name,
+                related_name=False,
                 related_fields=self.from_fields,
                 primary_key=True
             ),
-            f"{self.to_foreign_key}": ForeignKey(self.to, null=True, on_delete=CASCADE, related_name=to_related_name,
+            f"{self.to_foreign_key}": ForeignKey(
+                self.to,
+                null=True,
+                on_delete=CASCADE,
+                related_name=to_related_name,
                 related_fields=self.to_fields,
                 embed_parent=(self.from_foreign_key, self.embed_through),
-                primary_key=True),
+                primary_key=True,
+                relation_fn=self.get_inverse_relation
+            ),
         }
 
         # Create the through model
@@ -141,9 +164,9 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         """
         Meta field
         """
-        if isinstance(value, ManyRelation):
+        if isinstance(value, ManyRelationProtocol):
             return {field_name: value}
-        return {field_name: ManyRelation(through=self.through, to=self.to, from_foreign_key=self.from_foreign_key, to_foreign_key=self.to_foreign_key, embed_through=self.embed_through, refs=value)}
+        return {field_name: self.get_relation(refs=value)}
 
     def has_default(self) -> bool:
         """Checks if the field has a default value set"""
@@ -158,7 +181,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
     def __get__(self, instance: "Model", owner: Any = None) -> ManyRelation:
         if instance:
             if self.name not in instance.__dict__:
-                instance.__dict__[self.name] = ManyRelation(through=self.through, to=self.to, from_foreign_key=self.from_foreign_key, to_foreign_key=self.to_foreign_key, embed_through=self.embed_through, instance=instance)
+                instance.__dict__[self.name] = self.get_relation()
             if instance.__dict__[self.name].instance is None:
                 instance.__dict__[self.name].instance = instance
             return instance.__dict__[self.name]  # type: ignore

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -134,6 +134,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
                 null=True,
                 on_delete=CASCADE,
                 related_name=False,
+                reverse_name=self.name,
                 related_fields=self.from_fields,
                 primary_key=True
             ),

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -125,8 +125,10 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
             to_related_name = False
         elif self.related_name:
             to_related_name = f"{self.related_name}"
+            self.reverse_name = to_related_name
         else:
             to_related_name = f"{to_name.lower()}_{class_name.lower()}s_set"
+            self.reverse_name = to_related_name
 
         fields = {
             f"{self.from_foreign_key}": ForeignKey(

--- a/edgy/core/db/fields/one_to_one_keys.py
+++ b/edgy/core/db/fields/one_to_one_keys.py
@@ -24,7 +24,6 @@ class OneToOneField(ForeignKey):
         for argument in ["index", "unique"]:
             if argument in kwargs:
                 terminal.write_warning(f"Declaring {argument} on a OneToOneField has no effect.")
-        kwargs["index"] = False
         kwargs["unique"] = True
 
         return super().__new__(cls, to=to, **kwargs)

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -286,6 +286,7 @@ def _set_related_name_for_foreign_keys(
                 f"Multiple related_name with the same value '{related_name}' found to the same target. Related names must be different."
             )
         foreign_key.related_name = related_name
+        foreign_key.reverse_name = related_name
 
         related_field = RelatedField(
             foreign_key_name=name,
@@ -620,7 +621,7 @@ class BaseModelMeta(ModelMetaclass):
                     if not isinstance(value, Index):
                         raise ValueError("Meta.indexes must be a list of Index types.")
 
-        for value in list(fields.values()):
+        for value in fields.values():
             if isinstance(value, BaseManyToManyForeignKeyField):
                 value.create_through_model()
 

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -273,29 +273,31 @@ def _set_related_name_for_foreign_keys(
         return
 
     for name, foreign_key in foreign_keys.items():
-        default_related_name = getattr(foreign_key, "related_name", None)
+        related_name = getattr(foreign_key, "related_name", None)
+        if related_name is False:
+            # skip related_field
+            continue
 
-        if not default_related_name:
-            default_related_name = f"{model_class.__name__.lower()}s_set"
+        if not related_name:
+            related_name = f"{model_class.__name__.lower()}s_set"
 
-        elif default_related_name in foreign_key.target.meta.fields_mapping:
+        elif related_name in foreign_key.target.meta.fields_mapping:
             raise ForeignKeyBadConfigured(
-                f"Multiple related_name with the same value '{default_related_name}' found to the same target. Related names must be different."
+                f"Multiple related_name with the same value '{related_name}' found to the same target. Related names must be different."
             )
-        foreign_key.related_name = default_related_name
+        foreign_key.related_name = related_name
 
         related_field = RelatedField(
             foreign_key_name=name,
-            name=default_related_name,
+            name=related_name,
             owner=foreign_key.target,
             related_from=model_class,
-            embed_parent=foreign_key.embed_parent,
         )
 
         # Set the related name
         target = foreign_key.target
-        target.meta.fields_mapping[default_related_name] = related_field
-        target.meta.related_fields[default_related_name] = related_field
+        target.meta.fields_mapping[related_name] = related_field
+        target.meta.related_fields[related_name] = related_field
 
 
 def _handle_annotations(base: Type, base_annotations: Dict[str, Any]) -> None:

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -279,9 +279,12 @@ def _set_related_name_for_foreign_keys(
             continue
 
         if not related_name:
-            related_name = f"{model_class.__name__.lower()}s_set"
+            if foreign_key.unique:
+                related_name = f"{model_class.__name__.lower()}"
+            else:
+                related_name = f"{model_class.__name__.lower()}s_set"
 
-        elif related_name in foreign_key.target.meta.fields_mapping:
+        if related_name in foreign_key.target.meta.fields_mapping:
             raise ForeignKeyBadConfigured(
                 f"Multiple related_name with the same value '{related_name}' found to the same target. Related names must be different."
             )

--- a/edgy/core/db/models/row.py
+++ b/edgy/core/db/models/row.py
@@ -217,6 +217,8 @@ class ModelRow(EdgyBaseModel):
                 if isinstance(field, BaseForeignKey):
                     model_class = field.target
                     reverse_part = field.related_name
+                    if reverse_part is False:
+                        raise ValueError("Missing related_name on prefetch path")
                 elif isinstance(field, RelatedField):
                     model_class = field.related_from
                     reverse_part = field.foreign_key_name
@@ -282,7 +284,9 @@ class ModelRow(EdgyBaseModel):
         field = cls.meta.fields_mapping[prefetch_related.related_name]
         if isinstance(field, BaseForeignKey):
             related_field = field.target.meta.fields_mapping[field.related_name]
-            reverse_part = field.related_name
+            if related_field.related_name is False:
+                raise ValueError("Missing related_name on prefetch path")
+            reverse_part = cast(str, field.related_name)
         else:
             related_field = field
             reverse_part = field.foreign_key_name

--- a/edgy/core/db/models/row.py
+++ b/edgy/core/db/models/row.py
@@ -216,9 +216,9 @@ class ModelRow(EdgyBaseModel):
                 field = cls.meta.fields_mapping[first_part]
                 if isinstance(field, BaseForeignKey):
                     model_class = field.target
-                    reverse_part = field.related_name
-                    if reverse_part is False:
-                        raise ValueError("Missing related_name on prefetch path")
+                    reverse_part = field.reverse_name
+                    if not reverse_part:
+                        raise Exception("No backward relation possible (missing related_name)")
                 elif isinstance(field, RelatedField):
                     model_class = field.related_from
                     reverse_part = field.foreign_key_name
@@ -284,9 +284,9 @@ class ModelRow(EdgyBaseModel):
         field = cls.meta.fields_mapping[prefetch_related.related_name]
         if isinstance(field, BaseForeignKey):
             related_field = field.target.meta.fields_mapping[field.related_name]
-            if related_field.related_name is False:
-                raise ValueError("Missing related_name on prefetch path")
-            reverse_part = cast(str, field.related_name)
+            reverse_part = related_field.reverse_name
+            if not reverse_part:
+                raise Exception("No backward relation possible (missing related_name)")
         else:
             related_field = field
             reverse_part = field.foreign_key_name

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -63,11 +63,11 @@ def crawl_relationship(model_class: Type["Model"], name: str, callback_fn: Any=N
                 raise ValueError(f"Field: {field_name} of {name} not found")
         if isinstance(field, BaseForeignKey):
             model_class = field.target
-            if field.related_name is not False and reverse_path is not False:
+            if field.reverse_name and reverse_path is not False:
                 if reverse_path:
-                    reverse_path = f"{field.related_name}__{reverse_path}"
+                    reverse_path = f"{field.reverse_name}__{reverse_path}"
                 else:
-                    reverse_path = field.related_name
+                    reverse_path = field.reverse_name
             else:
                 reverse_path = False
             if callback_fn:
@@ -79,10 +79,11 @@ def crawl_relationship(model_class: Type["Model"], name: str, callback_fn: Any=N
             field_name = splitted.popleft()
         elif isinstance(field, RelatedField):
             model_class = field.related_from
-            if reverse_path:
-                reverse_path = f"{field.related_name}__{reverse_path}"
-            else:
-                reverse_path = field.foreign_key_name
+            if reverse_path is not False:
+                if reverse_path:
+                    reverse_path = f"{field.related_name}__{reverse_path}"
+                else:
+                    reverse_path = field.foreign_key_name
             if callback_fn:
                 callback_fn(model_class=model_class, field=field, reverse_path=reverse_path, forward_path=forward_path, inverse=True, operator=None)
             if forward_path:

--- a/edgy/core/db/relationships/related_field.py
+++ b/edgy/core/db/relationships/related_field.py
@@ -1,10 +1,10 @@
 import functools
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Type, Union, cast
 
 from edgy.core.db.fields.base import BaseField
 from edgy.core.db.fields.foreign_keys import BaseForeignKeyField
-from edgy.core.db.relationships.relation import SingleRelation
+from edgy.protocols.many_relationship import ManyRelationProtocol
 
 if TYPE_CHECKING:
     from edgy import Model, ReflectModel
@@ -20,12 +20,10 @@ class RelatedField(BaseField):
         *,
         foreign_key_name: str,
         related_from: Union[Type["Model"], Type["ReflectModel"]],
-        embed_parent: Optional[Tuple[str, str]]=None,
         **kwargs: Any
     ) -> None:
         self.foreign_key_name = foreign_key_name
         self.related_from = related_from
-        self.embed_parent = embed_parent
         super().__init__(
             inherit=False,
             exclude=True,
@@ -49,14 +47,14 @@ class RelatedField(BaseField):
         """
         Meta field
         """
-        if isinstance(value, SingleRelation):
+        if isinstance(value, ManyRelationProtocol):
             return {field_name: value}
-        return {field_name: SingleRelation(to=self.related_from, to_foreign_key=self.foreign_key_name, embed_parent=self.embed_parent, refs=value)}
+        return {field_name: self.get_relation(refs=value)}
 
-    def __get__(self, instance: "Model", owner: Any = None) -> SingleRelation:
+    def __get__(self, instance: "Model", owner: Any = None) -> ManyRelationProtocol:
         if instance:
             if self.name not in instance.__dict__:
-                instance.__dict__[self.name] = SingleRelation(to=self.related_from, to_foreign_key=self.foreign_key_name, embed_parent=self.embed_parent, instance=instance)
+                instance.__dict__[self.name] = self.get_relation()
             if instance.__dict__[self.name].instance is None:
                 instance.__dict__[self.name].instance = instance
             return instance.__dict__[self.name]  # type: ignore
@@ -73,6 +71,9 @@ class RelatedField(BaseField):
     def foreign_key(self) -> BaseForeignKeyField:
         return cast(BaseForeignKeyField, self.related_from.meta.fields_mapping[self.foreign_key_name])
 
+    def get_relation(self, **kwargs: Any) -> ManyRelationProtocol:
+        return self.foreign_key.get_relation(**kwargs)
+
     @property
     def is_cross_db(self) -> bool:
         return self.foreign_key.is_cross_db
@@ -81,22 +82,6 @@ class RelatedField(BaseField):
         if not for_query:
             return {}
         return self.related_to.meta.pk.clean("pk", value, for_query=for_query)  # type: ignore
-
-    def wrap_args(self, func: Any) -> Any:
-        @functools.wraps(func)
-        def wrapped(*args: Any, **kwargs: Any) -> Any:
-            # invert, so use the foreign_key_name
-            # will be parsed later
-            query: Dict[str, Any] = {}
-            for column_name in self.foreign_key.get_column_names():
-                related_name = self.foreign_key.from_fk_field_name(self.foreign_key_name, column_name)
-                query[related_name] = getattr(self.instance, related_name)
-            kwargs[self.foreign_key_name] =  query
-
-            self.queryset.embed_parent = self.embed_parent
-            return func(*args, **kwargs)
-
-        return wrapped
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self}>"

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -28,7 +28,7 @@ class ManyRelation(ManyRelationProtocol):
         through: Union[Type["Model"], Type["ReflectModel"]],
         embed_through: str = "",
         refs: Any = (),
-        instance: Optional[Union[Type["Model"], Type["ReflectModel"]]] = None,
+        instance: Optional[Union["Model", "ReflectModel"]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -38,7 +38,7 @@ class ManyRelation(ManyRelationProtocol):
         self.from_foreign_key = from_foreign_key
         self.to_foreign_key = to_foreign_key
         self.embed_through = embed_through
-        self.refs: Sequence[Union[Type["Model"], Type["ReflectModel"]]] = []
+        self.refs: Sequence[Union["Model", "ReflectModel"]] = []
         if not isinstance(refs, Sequence):
             refs = [refs]
         for v in refs:
@@ -154,7 +154,7 @@ class SingleRelation(ManyRelationProtocol):
         to: Union[Type["Model"], Type["ReflectModel"]],
         embed_parent: Optional[Tuple[str, str]]=None,
         refs: Any = (),
-        instance: Optional[Union[Type["Model"], Type["ReflectModel"]]] = None,
+        instance: Optional[Union["Model", "ReflectModel"]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -162,7 +162,7 @@ class SingleRelation(ManyRelationProtocol):
         self.instance = instance
         self.to_foreign_key = to_foreign_key
         self.embed_parent = embed_parent
-        self.refs: Sequence[Union[Type["Model"], Type["ReflectModel"]]] = []
+        self.refs: Sequence[Union["Model","ReflectModel"]] = []
         if not isinstance(refs, Sequence):
             refs = [refs]
         for v in refs:

--- a/edgy/protocols/many_relationship.py
+++ b/edgy/protocols/many_relationship.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:  # pragma: nocover
     from edgy import Model
@@ -6,6 +6,8 @@ if TYPE_CHECKING:  # pragma: nocover
 
 @runtime_checkable
 class ManyRelationProtocol(Protocol):
+    instance: Any
+
     """Defines the what needs to be implemented when using the ManyRelationProtocol"""
     async def save_related(self) -> None: ...
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_field.py
@@ -168,6 +168,7 @@ async def test_raises_RelationshipNotFound():
 
 
 async def test_many_to_many_many_fields():
+    assert "album_albumtracks_set" not in Album.meta.fields_mapping
     track1 = await Track.query.create(title="The Bird", position=1)
     track2 = await Track.query.create(title="Heart don't stand a chance", position=2)
     track3 = await Track.query.create(title="The Waters", position=3)

--- a/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
@@ -1,0 +1,62 @@
+import pytest
+
+import edgy
+from edgy.testclient import DatabaseTestClient as Database
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+
+database = Database(DATABASE_URL)
+models = edgy.Registry(database=database)
+
+
+
+class Track(edgy.Model):
+    id = edgy.IntegerField(primary_key=True)
+    title = edgy.CharField(max_length=100)
+    position = edgy.IntegerField()
+
+    class Meta:
+        registry = models
+
+
+class Album(edgy.Model):
+    id = edgy.IntegerField(primary_key=True)
+    tracks = edgy.ManyToMany("Track", related_name=False)
+
+    class Meta:
+        registry = models
+
+@pytest.fixture(autouse=True, scope="function")
+async def create_test_database():
+    await models.create_all()
+    yield
+    await models.drop_all()
+
+
+@pytest.fixture(autouse=True)
+async def rollback_connections():
+    with database.force_rollback():
+        async with database:
+            yield
+
+
+async def test_no_relation():
+    for field in Track.meta.fields_mapping:
+        assert not field.endswith("_set")
+
+
+async def test_no_related_name():
+    album = await Album.query.create(name="Malibu")
+    album2 = await Album.query.create(name="Santa Monica")
+
+    track1 = await Track.query.create(title="The Bird", position=1)
+    track2 = await Track.query.create(title="Heart don't stand a chance", position=2)
+    track3 = await Track.query.create(title="The Waters", position=3)
+
+    await album.tracks.add(track1)
+    await album.tracks.add(track2)
+    await album2.tracks.add(track3)
+
+    album_tracks = await album.tracks.all()
+    assert len(album_tracks) == 2

--- a/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
@@ -59,6 +59,7 @@ async def rollback_connections():
 
 
 async def test_related_name_query():
+    assert "album_tracks_albumtracks_set" not in Album.meta.fields_mapping
     album = await Album.query.create(name="Malibu")
     album2 = await Album.query.create(name="Santa Monica")
 

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -70,7 +70,7 @@ class Profile(edgy.Model):
 class Person(edgy.Model):
     id = edgy.IntegerField(primary_key=True)
     email = edgy.CharField(max_length=100)
-    profile = edgy.OneToOneField(Profile, on_delete=edgy.CASCADE)
+    profile = edgy.OneToOneField(Profile, on_delete=edgy.CASCADE, related_name=False)
 
     class Meta:
         registry = models
@@ -97,6 +97,11 @@ async def rollback_connections():
     with database.force_rollback():
         async with database:
             yield
+
+
+async def test_no_relation():
+    for field in Profile.meta.fields_mapping:
+        assert not field.startswith("person")
 
 
 async def test_new_create():


### PR DESCRIPTION
Changes
- allow skipping a RelatedField by specifying related_name=False
  - can specify a reverse_name for allowing a backward relation
- Many2Many fields doesn't create an extra backward relation to the owner but specify instead reverse_name (see docs)
- ForeignKey have relation_fn argument which is used for creating the backward relation which is created by RelatedField
  - this is used by M2M for initializing an ManyRelation on the reverse end
- m2m unique is used for target foreign key
- unique changes default related_name to singular
- update docs