### PR TITLE
queryset updates, prefetch improvements

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -388,7 +388,7 @@ When the second parameter is empty, the parent object is not included as attribu
                      Note: Setting to `False` will also prevent prefetching and reversing via `__`.
                      See also [related_name](./queries/related-name.md) for defaults
 * **related_fields** - The columns or fields to use for the foreign key. If unset or empty, the primary key(s) are used.
-* **embed_parent** (to_attr, as_attr) - When accessing the reverse relation part, return to_attr instead and embed the parent object in as_attr (when as_attr is not empty). Default None (which disables it).
+* **embed_parent** (to_attr, as_attr) - When accessing the reverse relation part, return to_attr instead and embed the parent object in as_attr (when as_attr is not empty). Default None (which disables it). For to_attr (first argument) deeply nested models can be selected via `__`.
 * **no_constraint** - Skip creating a constraint. Note: if set and index=True an index will be created instead.
 * **on_delete** - A string indicating the behaviour that should happen on delete of a specific
 model. The available values are `CASCADE`, `SET_NULL`, `RESTRICT` and those can also be imported
@@ -422,6 +422,8 @@ from `edgy`.
     Otherwise, the first parameter points not to a `RelationshipField` (e.g. embeddable, CompositeField), queries use still the model, without the prefix stripped.
 
 
+!!! Note:
+    `embed_parent` cannot traverse embeddables.
 
 #### RefForeignKey
 

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -8,6 +8,7 @@ from edgy.core.db.fields.base import BaseField, BaseForeignKey
 from edgy.core.db.fields.factories import ForeignKeyFieldFactory
 from edgy.core.db.relationships.relation import SingleRelation
 from edgy.core.terminal import Print
+from edgy.exceptions import FieldDefinitionError
 from edgy.protocols.many_relationship import ManyRelationProtocol
 
 if TYPE_CHECKING:
@@ -245,3 +246,11 @@ class ForeignKey(ForeignKeyFieldFactory):
         **kwargs: Any,
     ) -> BaseField:
         return super().__new__(cls, to=to, **kwargs)
+
+    @classmethod
+    def validate(cls, **kwargs: Any) -> None:
+        super().validate(**kwargs)
+        embed_parent = kwargs.get("embed_parent")
+        if embed_parent:
+            if "__" in embed_parent[1]:
+                raise FieldDefinitionError('"embed_parent" second argument (for embedding parent) cannot contain "__".')

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -20,6 +20,7 @@ from edgy.core.db.fields.foreign_keys import ForeignKey
 from edgy.core.db.relationships.relation import ManyRelation
 from edgy.core.terminal import Print
 from edgy.core.utils.models import create_edgy_model
+from edgy.exceptions import FieldDefinitionError
 from edgy.protocols.many_relationship import ManyRelationProtocol
 
 if TYPE_CHECKING:
@@ -285,5 +286,14 @@ class ManyToManyField(ForeignKeyFieldFactory):
         kwargs["on_update"] = CASCADE
 
         return super().__new__(cls, to=to, through=through, **kwargs)
+
+    @classmethod
+    def validate(cls, **kwargs: Any) -> None:
+        super().validate(**kwargs)
+        embed_through = kwargs.get("embed_through")
+        if embed_through:
+            if "__" in embed_through:
+                raise FieldDefinitionError('"embed_through" cannot contain "__".')
+
 
 ManyToMany = ManyToManyField

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -256,7 +256,7 @@ class SingleRelation(ManyRelationProtocol):
             assert self.instance, "instance not initialized"
             fk = self.to.meta.fields_mapping[self.to_foreign_key]
             query = {}
-            if not self.embed_parent or not isinstance(fk.owner.meta.fields_mapping[self.embed_parent[0]], RelationshipField):
+            if not self.embed_parent or not isinstance(fk.owner.meta.fields_mapping[self.embed_parent[0].split("__", 1)[0]], RelationshipField):
                 new_kwargs = kwargs
             else:
                 new_kwargs = {}

--- a/edgy/core/db/relationships/utils.py
+++ b/edgy/core/db/relationships/utils.py
@@ -1,0 +1,85 @@
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    NamedTuple,
+    Type,
+    Union,
+)
+
+from edgy.conf import settings
+from edgy.core.db.fields.base import BaseForeignKey, RelationshipField
+
+if TYPE_CHECKING:  # pragma: no cover
+    from edgy.core.db.models import Model
+
+class RelationshipCrawlResult(NamedTuple):
+    model_class: Type["Model"]
+    field_name: str
+    operator: str
+    forward_path: str
+    reverse_path: Union[str, Literal[False]]
+
+
+def crawl_relationship(model_class: Type["Model"], path: str, callback_fn: Any=None, traverse_last: bool=False) -> RelationshipCrawlResult:
+    field = None
+    forward_prefix_path = ""
+    reverse_path: Union[str, Literal[False]] = ""
+    operator: str = "exact"
+    field_name: str = path
+    while path:
+        splitted = path.split("__", 1)
+        field_name = splitted[0]
+        field = model_class.meta.fields_mapping.get(field_name)
+        if isinstance(field, RelationshipField) and len(splitted) == 2:
+            model_class, reverse_part, path = field.traverse_field(path)
+            if field.is_cross_db():
+                raise NotImplementedError("We cannot cross databases yet, this feature is planned")
+            reverse = not isinstance(field, BaseForeignKey)
+            if reverse_part and reverse_path is not False:
+                if reverse_path:
+                    reverse_path = f"{reverse_part}__{reverse_path}"
+                else:
+                    reverse_path = reverse_part
+            else:
+                reverse_path = False
+
+            if callback_fn:
+                callback_fn(model_class=model_class, field=field, reverse_path=reverse_path, forward_path=forward_prefix_path, reverse=reverse, operator=None)
+            if forward_prefix_path:
+                forward_prefix_path =  f"{forward_prefix_path}__{field_name}"
+            else:
+                forward_prefix_path = field_name
+        elif len(splitted) == 2:
+            if "__" not in splitted[1] and splitted[1] in settings.filter_operators:
+                operator = splitted[1]
+                break
+            else:
+                raise ValueError(f"Tried to cross field: {field_name} of type {field!r}, remainder: {splitted[1]}")
+        else:
+            operator = "exact"
+            break
+
+    if traverse_last and isinstance(field, RelationshipField):
+        model_class, reverse_part, path = field.traverse_field(path)
+        reverse = not isinstance(field, BaseForeignKey)
+    else:
+        reverse = False
+        reverse_part = field_name
+    if reverse_part and reverse_path is not False:
+        if reverse_path:
+            reverse_path = f"{reverse_part}__{reverse_path}"
+        else:
+            reverse_path = reverse_part
+    else:
+        reverse_path = False
+    if callback_fn and field is not None:
+        callback_fn(model_class=model_class, field=field, reverse_path=reverse_path, forward_path=forward_prefix_path, reverse=reverse, operator=operator)
+    return RelationshipCrawlResult(
+        model_class=model_class,
+        field_name=field_name,
+        operator=operator,
+        forward_path=forward_prefix_path,
+        reverse_path=reverse_path,
+    )

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -349,3 +349,15 @@ def test_assertation_error_on_missing_on_delete():
             model = edgy.ForeignKey(MyModel, on_delete=None)
 
     assert raised.value.args[0] == "on_delete must not be null."
+
+
+def test_assertation_error_on_embed_parent_double_underscore_attr():
+    with pytest.raises(FieldDefinitionError) as raised:
+
+        class MyModel(edgy.Model):
+            is_active = edgy.BooleanField(default=True)
+
+        class MyOtherModel(edgy.Model):
+            model = edgy.ForeignKey(MyModel, embed_parent=("foo", "foo__attr"))
+
+    assert raised.value.args[0] == '"embed_parent" second argument (for embedding parent) cannot contain "__".'

--- a/tests/foreign_keys/test_foreignkey_deep_embed_parent.py
+++ b/tests/foreign_keys/test_foreignkey_deep_embed_parent.py
@@ -1,0 +1,69 @@
+
+import pytest
+
+import edgy
+from edgy.testclient import DatabaseTestClient as Database
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+
+database = Database(DATABASE_URL)
+models = edgy.Registry(database=database)
+
+
+class Address(edgy.Model):
+    street = edgy.CharField(max_length=100)
+    city = edgy.CharField(max_length=100)
+
+
+class Person(edgy.Model):
+    id = edgy.IntegerField(primary_key=True)
+    email = edgy.CharField(max_length=100)
+    class Meta:
+        registry = models
+
+
+class Profile(edgy.Model):
+    id = edgy.IntegerField(primary_key=True)
+    website = edgy.CharField(max_length=100)
+    address = Address
+
+    class Meta:
+        registry = models
+
+
+
+class ProfileHolder(edgy.Model):
+    profile = edgy.OneToOneField(Profile, on_delete=edgy.CASCADE)
+    person = edgy.OneToOneField(Person, on_delete=edgy.CASCADE, embed_parent=("profile__address", "parent"), related_name="address")
+    name = edgy.CharField(max_length=100)
+
+    class Meta:
+        registry = models
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def create_test_database():
+    await models.create_all()
+    yield
+    await models.drop_all()
+
+
+@pytest.fixture(autouse=True)
+async def rollback_connections():
+    with database.force_rollback():
+        async with database:
+            yield
+
+
+async def test_embed_parent_deep():
+    profile = await Profile.query.create(website="https://edgy.com", address={"street": "Rainbowstreet 123", "city": "London"})
+    person = await Person.query.create(email="info@edgy.com")
+    profile_holder = await ProfileHolder.query.create(name="edgy", profile=profile, person=person)
+
+    person = await Person.query.get(email="info@edgy.com")
+    address_queried = await person.address.get()
+    assert address_queried.street == "Rainbowstreet 123"
+    await address_queried.parent.load()
+    assert address_queried.parent.name == profile_holder.name
+    assert address_queried.parent.pk == profile_holder.pk

--- a/tests/foreign_keys/test_many_to_many_field.py
+++ b/tests/foreign_keys/test_many_to_many_field.py
@@ -1,7 +1,7 @@
 import pytest
 
 import edgy
-from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
+from edgy.exceptions import FieldDefinitionError, RelationshipIncompatible, RelationshipNotFound
 from edgy.testclient import DatabaseTestClient as Database
 from tests.settings import DATABASE_URL
 
@@ -313,3 +313,15 @@ async def test_related_name_query_returns_nothing():
     tracks_album = await track3.track_albumtracks_set.filter(name=album.name)
 
     assert len(tracks_album) == 0
+
+
+def test_assertation_error_on_embed_through_double_underscore_attr():
+    with pytest.raises(FieldDefinitionError) as raised:
+
+        class MyModel(edgy.Model):
+            is_active = edgy.BooleanField(default=True)
+
+        class MyOtherModel(edgy.Model):
+            model = edgy.ManyToMany(MyModel, embed_through="foo__attr")
+
+    assert raised.value.args[0] == '"embed_through" cannot contain "__".'

--- a/tests/models/run_sync/test_model_sqlalchemy.py
+++ b/tests/models/run_sync/test_model_sqlalchemy.py
@@ -53,7 +53,8 @@ async def test_model_sqlalchemy_filter_operators():
         User.query.filter(User.columns.name.startswith("G")).filter(User.columns.name.endswith("e")).get()
     )
 
-    assert user == edgy.run_sync(User.query.exclude(User.columns.name != "Jack").get())
+    # not not =  ==
+    assert user == edgy.run_sync(User.query.exclude(User.columns.name != "George").get())
 
     shirt = edgy.run_sync(Product.query.create(name="100%-Cotton", rating=3))
     assert shirt == edgy.run_sync(Product.query.filter(Product.columns.name.contains("Cotton")).get())
@@ -70,7 +71,8 @@ async def test_model_sqlalchemy_filter_operators_no_get():
     users = edgy.run_sync(User.query.filter(User.columns.name.startswith("G")).filter(User.columns.name.endswith("e")))
     assert user == users[0]
 
-    assert user == edgy.run_sync(User.query.exclude(User.columns.name != "Jack").get())
+    # not not =  ==
+    assert user == edgy.run_sync(User.query.exclude(User.columns.name != "George").get())
 
     shirt = edgy.run_sync(Product.query.create(name="100%-Cotton", rating=3))
     shirts = edgy.run_sync(Product.query.filter(Product.columns.name.contains("Cotton")))

--- a/tests/models/test_model_sqlalchemy.py
+++ b/tests/models/test_model_sqlalchemy.py
@@ -53,7 +53,8 @@ async def test_model_sqlalchemy_filter_operators():
         user == await User.query.filter(User.columns.name.startswith("G")).filter(User.columns.name.endswith("e")).get()
     )
 
-    assert user == await User.query.exclude(User.columns.name != "Jack").get()
+    # not not =  ==
+    assert user == await User.query.exclude(User.columns.name != "George").get()
 
     shirt = await Product.query.create(name="100%-Cotton", rating=3)
     assert shirt == await Product.query.filter(Product.columns.name.contains("Cotton")).get()
@@ -70,7 +71,8 @@ async def test_model_sqlalchemy_filter_operators_no_get():
     users = await User.query.filter(User.columns.name.startswith("G")).filter(User.columns.name.endswith("e"))
     assert user == users[0]
 
-    assert user == await User.query.exclude(User.columns.name != "Jack").get()
+    # not not =  ==
+    assert user == await User.query.exclude(User.columns.name != "George").get()
 
     shirt = await Product.query.create(name="100%-Cotton", rating=3)
     shirts = await Product.query.filter(Product.columns.name.contains("Cotton"))


### PR DESCRIPTION
Changes
- fix tests (inversion was never noticed)
- allow traversing nested attributes with embed_parent
- allow prefetching across unidirectional relations (and simplify it)
- prefetches are now handled in parallel
- use run_sync for prefetches instead of the loop stuff
- move crawl_relationship for preventing import loop
- remove extra
- cleanup queryset
- allow multiple clauses
- fix exclude not applied on clauses
- apply or or and on clauses too
- allow mixed clauses and kwargs
