### PR TITLE
github action: remove base develop from path filters

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -51,7 +51,6 @@ jobs:
       - uses: "dorny/paths-filter@v3"
         id: filters
         with:
-          base: develop
           filters: |
             docs_src:
               - 'docs_src/**'


### PR DESCRIPTION
base develop causes errors on scheduled action (at least for forks without develop branch)