### PR TITLE
timezone support

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -246,7 +246,6 @@ class MyModel(edgy.Model):
     Internally the DateTimeField logic is used and only the date element returned.
     This implies the field can handle the same types like DateTimeField.
 
-
 ##### Parameters
 
 * **auto_now** - A boolean indicating the `auto_now` enabled. Useful for auto updates.
@@ -291,7 +290,6 @@ DateTimeField supports int, float, string (isoformat), date object and of course
 
 !!! Note:
     `auto_now` and `auto_now_add` set the `read_only` flag by default. You can explicitly set `read_only` to `False` to be still able to update the field manually.
-
 
 #### DecimalField
 
@@ -434,19 +432,16 @@ from `edgy`.
     This is no concern for webservers where models are initialized once.
     `unique` uses internally an index and `index=False` will be ignored.
 
-
 !!! Note:
     There is a `reverse_name` argument which can be used when `related_name=False` to specify a field for reverse relations.
     It is useless except if related_name is `False` because it is otherwise overwritten.
     The `reverse_name` argument is used for finding the reverse field of the relationship.
-
 
 !!! Note:
     When `embed_parent` is set, queries start to use the second parameter of `embed_parent` **if it is a RelationshipField**.
     If it is empty, queries cannot access the parent anymore when the first parameter points to a `RelationshipField`.
     This is mode is analogue to ManyToMany fields.
     Otherwise, the first parameter points not to a `RelationshipField` (e.g. embeddable, CompositeField), queries use still the model, without the prefix stripped.
-
 
 !!! Note:
     `embed_parent` cannot traverse embeddables.
@@ -499,7 +494,6 @@ class MyModel(edgy.Model):
 
 !!! Note:
     If **through** is an abstract model it will be used as a template (a new model is generated with through as base).
-
 
 !!! Note:
     The index parameter is passed through to the ForeignKey fields but is not required. The intern ForeignKey fields

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -242,11 +242,27 @@ class MyModel(edgy.Model):
 
 ```
 
+!!! Note:
+    Internally the DateTimeField logic is used and only the date element returned.
+    This implies the field can handle the same types like DateTimeField.
+
+
 ##### Parameters
 
 * **auto_now** - A boolean indicating the `auto_now` enabled. Useful for auto updates.
 * **auto_now_add** - A boolean indicating the `auto_now_add` enabled. This will ensure that it is
 only added once.
+* **default_timezone** - ZoneInfo containing the timezone which is added to naive datetimes and used for `auto_now` and `auto_now_add`.
+                         Datetimes are converted to date and lose their timezone information.
+* **force_timezone** - ZoneInfo containing the timezone in which all datetimes are converted.
+                       For naive datetimes it behaves like `default_timezone`
+                       Datetimes are converted to date and lose their timezone information.
+
+!!! Note:
+    There is no `remove_timezone` (argument will be silently ignored)
+
+!!! Note:
+    `auto_now` and `auto_now_add` set the `read_only` flag by default. You can explicitly set `read_only` to `False` to be still able to update the field manually.
 
 #### DateTimeField
 
@@ -261,11 +277,21 @@ class MyModel(edgy.Model):
 
 ```
 
+DateTimeField supports int, float, string (isoformat), date object and of course datetime as input. They are automatically converted to datetime.
+
+
 ##### Parameters
 
 * **auto_now** - A boolean indicating the `auto_now` enabled. Useful for auto updates.
-* **auto_now_add** - A boolean indicating the `auto_now_add` enabled. This will ensure that it is
-only added once.
+* **auto_now_add** - A boolean indicating the `auto_now_add` enabled. Only set when creating the object
+* **default_timezone** - ZoneInfo containing the timezone which is added to naive datetimes
+* **force_timezone** - ZoneInfo containing the timezone in which all datetimes are converted.
+                         For naive datetimes it behaves like `default_timezone`
+* **remove_timezone** - Boolean. Default False. Remove timezone information from datetime. Useful if the db should only contain naive datetimes and not convert.
+
+!!! Note:
+    `auto_now` and `auto_now_add` set the `read_only` flag by default. You can explicitly set `read_only` to `False` to be still able to update the field manually.
+
 
 #### DecimalField
 
@@ -630,14 +656,14 @@ If you want to customize the entire field (e.g. checks), you have to split the f
 Fields have to inherit from `edgy.db.fields.base.BaseField` and to provide following methods to work:
 
 * **get_columns(self, field_name)** - returns the sqlalchemy columns which should be created by this field.
-* **clean(self, field_name, value, to_query)** - returns the cleaned column values. to_query specifies if clean is used by the query sanitizer and must be more strict (no partial values).
+* **clean(self, field_name, value, to_query=False)** - returns the cleaned column values. to_query specifies if clean is used by the query sanitizer and must be more strict (no partial values).
 
 Additional they can provide following methods:
 * **`__get__(self, instance, owner=None)`** - Descriptor protocol like get access customization. Second parameter contains the class where the field was specified.
 * **`__set__(self, instance, value)`** - Descriptor protocol like set access customization. Dangerous to use. Better use to_model.
 * **to_model(self, field_name, phase="")** - like clean, just for setting attributes or initializing a model. It is also used when setting attributes or in initialization (phase contains the phase where it is called). This way it is much more powerful than `__set__`
 * **get_embedded_fields(self, field_name, fields_mapping)** - Define internal fields.
-* **get_default_values(self, field_name, cleaned_data)** - returns the default values for the field. Can provide default values for embedded fields. If your field spans only one column you can also use the simplified get_default_value instead. This way you don't have to check for collisions. By default get_default_value is used internally.
+* **get_default_values(self, field_name, cleaned_data, is_update=False)** - returns the default values for the field. Can provide default values for embedded fields. If your field spans only one column you can also use the simplified get_default_value instead. This way you don't have to check for collisions. By default get_default_value is used internally.
 * **get_default_value(self)** - return default value for one column fields.
 * **get_global_constraints(self, field_name, columns)** - takes as second parameter (self excluded) the columns defined by this field (by get_columns). Returns a global constraint, which can be multi-column.
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -670,6 +670,7 @@ Additional they can provide following methods:
 You should also provide an init method which sets following attributes:
 
 * **column_type** - either None (default) or the sqlalchemy column type
+* **inject_default_on_partial_update** - Add default value despite being a partial update. Useful for implementing `auto_now` or other fields which should change on every update.
 
 
 Note: instance checks can also be done against the `field_type` attribute in case you want to check the compatibility with other fields (composite style)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,19 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+### Added
+
+- `default_timezone`, `force_timezone`, `remove_timezone` for DateTimeField
+- `default_timezone`, `force_timezone` for DateField
+
+### Changed
+
+### Fixed
+
+- `auto_now` and `auto_now_add` now also work for date fields
+
 ## 0.12.0
 
 ### Added

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,9 +10,12 @@ hide:
 ### Added
 
 - `default_timezone`, `force_timezone`, `remove_timezone` for DateTimeField
-- `default_timezone`, `force_timezone` for DateField
+- `default_timezone`, `force_timezone` for DateField.
+-  Add attribute `inject_default_on_partial_update`.
 
 ### Changed
+
+- `get_default_values` has now an extra keyword argument `is_update`
 
 ### Fixed
 

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -199,7 +199,7 @@ class BaseField(FieldInfo):
             return default()
         return default
 
-    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any], is_update=False) -> Any:
+    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any], is_update: bool=False) -> Any:
         # for multidefaults overwrite in subclasses get_default_values to
         # parse default values differently
         # NOTE: multi value fields should always check here if defaults were already applied
@@ -310,7 +310,7 @@ class BaseCompositeField(BaseField):
 
         return result
 
-    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any], is_update=False) -> Any:
+    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any], is_update: bool=False) -> Any:
         # fields should provide their own default which is used as long as they are in the fields_mapping
         return {}
 

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -56,6 +56,7 @@ class BaseField(FieldInfo):
         self.read_only: bool = kwargs.pop("read_only", False)
         self.primary_key: bool = kwargs.pop("primary_key", False)
         self.autoincrement: bool = kwargs.pop("autoincrement", False)
+        self.inject_default_on_partial_update: bool = kwargs.pop("inject_default_on_partial_update", False)
         self.inherit = inherit
 
         super().__init__(**kwargs)
@@ -198,7 +199,7 @@ class BaseField(FieldInfo):
             return default()
         return default
 
-    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any]) -> Any:
+    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any], is_update=False) -> Any:
         # for multidefaults overwrite in subclasses get_default_values to
         # parse default values differently
         # NOTE: multi value fields should always check here if defaults were already applied
@@ -309,7 +310,7 @@ class BaseCompositeField(BaseField):
 
         return result
 
-    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any]) -> Any:
+    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any], is_update=False) -> Any:
         # fields should provide their own default which is used as long as they are in the fields_mapping
         return {}
 

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -249,7 +249,7 @@ class AutoNowMixin(FieldFactory):
 
         if auto_now_add or auto_now:
             kwargs.setdefault("read_only", True)
-            kwargs["inject_default_on_partial_update"] = True
+            kwargs["inject_default_on_partial_update"] = auto_now
 
         kwargs = {
             **kwargs,

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -5,7 +5,7 @@ import ipaddress
 import re
 import uuid
 from enum import EnumMeta
-from typing import Any, Dict, Optional, Pattern, Sequence, Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional, Pattern, Sequence, Tuple, Union
 
 import pydantic
 import sqlalchemy
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     try:
         import zoneinfo  # type: ignore[import-not-found, unused-ignore]
     except ImportError:
-        from backports import zoneinfo  # type: ignore[import-not-found, no-redef, unused-ignore]
+        zoneinfo = Any  # type: ignore[unused-ignore, no-redef, assignment]
 
 
 CLASS_DEFAULTS = ["cls", "__class__", "kwargs"]

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -5,7 +5,7 @@ import ipaddress
 import re
 import uuid
 from enum import EnumMeta
-from typing import Any, Dict, Optional, Pattern, Sequence, Tuple, Union
+from typing import Any, Dict, Optional, Pattern, Sequence, Tuple, Union, TYPE_CHECKING
 
 import pydantic
 import sqlalchemy
@@ -17,10 +17,11 @@ from edgy.core.db.fields.base import BaseField, Field
 from edgy.core.db.fields.factories import FieldFactory
 from edgy.exceptions import FieldDefinitionError
 
-try:
-    import zoneinfo
-except ImportError:
-    from backports import zoneinfo  # type: ignore
+if TYPE_CHECKING:
+    try:
+        import zoneinfo  # type: ignore[import-not-found, unused-ignore]
+    except ImportError:
+        from backports import zoneinfo  # type: ignore[import-not-found, no-redef, unused-ignore]
 
 
 CLASS_DEFAULTS = ["cls", "__class__", "kwargs"]
@@ -260,7 +261,7 @@ class AutoNowMixin(FieldFactory):
 
 class ConcreteDateTimeField(AutoNowField):
 
-    def __init__(self, *, default_timezone: Optional[zoneinfo.ZoneInfo]=None, force_timezone: Optional[zoneinfo.ZoneInfo]=None, remove_timezone: bool=False, **kwargs: Any) -> None:
+    def __init__(self, *, default_timezone: Optional["zoneinfo.ZoneInfo"]=None, force_timezone: Optional["zoneinfo.ZoneInfo"]=None, remove_timezone: bool=False, **kwargs: Any) -> None:
         self.force_timezone = force_timezone
         self.default_timezone = default_timezone
         self.remove_timezone = remove_timezone
@@ -293,6 +294,10 @@ class ConcreteDateTimeField(AutoNowField):
             return self._convert_datetime(datetime.datetime.fromisoformat(value))
         elif isinstance(value, datetime.date):
             # datetime is subclass, so check datetime first
+
+            # don't touch dates when DateField
+            if self.field_type is datetime.date:
+                return value
             return self._convert_datetime(
                 datetime.datetime(year=value.year, month=value.month, day=value.day)
             )
@@ -322,8 +327,8 @@ class DateTimeField(AutoNowMixin, datetime.datetime):
         *,
         auto_now: Optional[bool] = False,
         auto_now_add: Optional[bool] = False,
-        default_timezone: Optional[zoneinfo.ZoneInfo]=None,
-        force_timezone: Optional[zoneinfo.ZoneInfo]=None,
+        default_timezone: Optional["zoneinfo.ZoneInfo"]=None,
+        force_timezone: Optional["zoneinfo.ZoneInfo"]=None,
         remove_timezone: bool=False,
         **kwargs: Any,
     ) -> BaseField:
@@ -352,8 +357,8 @@ class DateField(AutoNowMixin, datetime.date):
         *,
         auto_now: Optional[bool] = False,
         auto_now_add: Optional[bool] = False,
-        default_timezone: Optional[zoneinfo.ZoneInfo]=None,
-        force_timezone: Optional[zoneinfo.ZoneInfo]=None,
+        default_timezone: Optional["zoneinfo.ZoneInfo"]=None,
+        force_timezone: Optional["zoneinfo.ZoneInfo"]=None,
         **kwargs: Any,
     ) -> BaseField:
         if auto_now_add or auto_now:

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -242,7 +242,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         """Checks if the field has a default value set"""
         return False
 
-    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any]) -> Any:
+    def get_default_values(self, field_name: str, cleaned_data: Dict[str, Any], is_update: bool=False) -> Any:
         """
         Meta field
         """

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -938,8 +938,7 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
         """
         queryset: "QuerySet" = self._clone()
 
-        extracted_fields = queryset._extract_values_from_field(kwargs, model_class=queryset.model_class)
-        kwargs = queryset._update_auto_now_fields(extracted_fields, queryset.model_class.fields)
+        kwargs = queryset._extract_values_from_field(kwargs, model_class=queryset.model_class)
 
         # Broadcast the initial update details
         await self.model_class.signals.pre_update.send_async(self.__class__, instance=self, kwargs=kwargs)

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -808,10 +808,11 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
         """
         Returns a single record based on the given kwargs.
         """
-        queryset: "QuerySet" = self._clone()
 
         if kwargs:
-            return await queryset.filter(**kwargs).get()
+            return await self.filter(**kwargs).get()
+
+        queryset: "QuerySet" = self._clone()
 
         expression = queryset._build_select().limit(2)
         rows = await queryset.database.fetch_all(expression)

--- a/edgy/core/utils/models.py
+++ b/edgy/core/utils/models.py
@@ -1,7 +1,6 @@
 import typing
-from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 from orjson import OPT_OMIT_MICROSECONDS, OPT_SERIALIZE_NUMPY, dumps
 from pydantic import ConfigDict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "pydantic-settings>=2.0.0,<3.0.0",
     "rich>=13.3.1,<14.0.0",
     "blinker>=1.8,<2.0",
+    "backports.zoneinfo;python_version<'3.9'"
 ]
 keywords = [
     "api",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     "pydantic-settings>=2.0.0,<3.0.0",
     "rich>=13.3.1,<14.0.0",
     "blinker>=1.8,<2.0",
-    "backports.zoneinfo;python_version<'3.9'"
 ]
 keywords = [
     "api",
@@ -102,7 +101,7 @@ mssql = ["databasez[aioodbc]"]
 all = ["edgy[test,postgres,mysql,sqlite,mssql]", "ipython", "ptpython"]
 
 [tool.hatch.envs.default]
-dependencies = ["ruff", "pre-commit>=2.17.0,<3.0.0", "twine"]
+dependencies = ["ruff", "pre-commit>=2.17.0,<3.0.0", "twine", "backports.zoneinfo;python_version<'3.9'"]
 
 [tool.hatch.envs.default.scripts]
 clean_pyc = "find . -type f -name \"*.pyc\" -delete"

--- a/tests/fields/test_date_field.py
+++ b/tests/fields/test_date_field.py
@@ -1,0 +1,56 @@
+import datetime
+
+from edgy.core.db.fields import DateField
+
+try:
+    import zoneinfo  # type: ignore[import-not-found, unused-ignore]
+except ImportError:
+    from backports import zoneinfo  # type: ignore[import-not-found, no-redef, unused-ignore]
+
+
+def test_default_timezone():
+    _date = datetime.date(year=2024, month=1, day=1)
+    _datetimen = datetime.datetime(year=2024, month=1, day=1, hour=12, minute=6)
+    _datetimel = datetime.datetime(
+        year=2024, month=1, day=1, hour=12, minute=6, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    )
+    field = DateField(name="dt", default_timezone=zoneinfo.ZoneInfo("Etc/UTC"))
+    assert field.clean(field.name, _date)["dt"] == _date
+    assert field.to_model(field.name, _datetimen)["dt"] == _datetimen.replace(
+        tzinfo=zoneinfo.ZoneInfo("Etc/UTC")
+    ).date()
+    assert field.clean(field.name, _datetimel)["dt"] == _datetimel.date()
+
+
+def test_force_timezone():
+    _date = datetime.date(year=2024, month=1, day=1)
+    _datetimen = datetime.datetime(year=2024, month=1, day=1, hour=12, minute=6)
+    _datetimel = datetime.datetime(
+        year=2024, month=1, day=1, hour=12, minute=6, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    )
+    field = DateField(name="dt", force_timezone=zoneinfo.ZoneInfo("Etc/UTC"))
+    assert field.clean(field.name, _date)["dt"] == _date
+    assert field.to_model(field.name, _datetimen)["dt"] == _datetimen.date()
+    assert field.clean(field.name, _datetimel)["dt"] == _datetimel.astimezone(
+        zoneinfo.ZoneInfo("Etc/UTC")
+    ).date()
+
+
+def test_default_force_timezone():
+    _date = datetime.date(year=2024, month=1, day=1)
+    _datetimen = datetime.datetime(year=2024, month=1, day=1, hour=12, minute=6)
+    _datetimel = datetime.datetime(
+        year=2024, month=1, day=1, hour=12, minute=6, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    )
+    field = DateField(
+        name="dt",
+        default_timezone=zoneinfo.ZoneInfo("Etc/GMT-10"),
+        force_timezone=zoneinfo.ZoneInfo("Etc/UTC"),
+    )
+    assert field.clean(field.name, _date)["dt"] == _date
+    assert field.to_model(field.name, _datetimen)["dt"] == _datetimel.astimezone(
+        zoneinfo.ZoneInfo("Etc/UTC")
+    ).date()
+    assert field.clean(field.name, _datetimel)["dt"] == _datetimel.astimezone(
+        zoneinfo.ZoneInfo("Etc/UTC")
+    ).date()

--- a/tests/fields/test_datetime_field.py
+++ b/tests/fields/test_datetime_field.py
@@ -3,9 +3,9 @@ import datetime
 from edgy.core.db.fields import DateTimeField
 
 try:
-    import zoneinfo
+    import zoneinfo  # type: ignore[import-not-found, unused-ignore]
 except ImportError:
-    from backports import zoneinfo  # type: ignore
+    from backports import zoneinfo  # type: ignore[import-not-found, no-redef, unused-ignore]
 
 
 def test_default_timezone():

--- a/tests/fields/test_datetime_field.py
+++ b/tests/fields/test_datetime_field.py
@@ -1,0 +1,101 @@
+import datetime
+
+from edgy.core.db.fields import DateTimeField
+
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo  # type: ignore
+
+
+def test_default_timezone():
+    _date = datetime.date(year=2024, month=1, day=1)
+    _datetimen = datetime.datetime(year=2024, month=1, day=1, hour=12, minute=6)
+    _datetimel = datetime.datetime(
+        year=2024, month=1, day=1, hour=12, minute=6, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    )
+    field = DateTimeField(name="dt", default_timezone=zoneinfo.ZoneInfo("Etc/UTC"))
+    assert field.clean(field.name, _date)["dt"] == datetime.datetime(
+        year=2024, month=1, day=1, tzinfo=zoneinfo.ZoneInfo("Etc/UTC")
+    )
+    assert field.to_model(field.name, _datetimen)["dt"] == _datetimen.replace(
+        tzinfo=zoneinfo.ZoneInfo("Etc/UTC")
+    )
+    assert field.clean(field.name, _datetimel)["dt"] == _datetimel
+
+
+def test_default_remove_timezone():
+    _date = datetime.date(year=2024, month=1, day=1)
+    _datetimen = datetime.datetime(year=2024, month=1, day=1, hour=12, minute=6)
+    _datetimel = datetime.datetime(
+        year=2024, month=1, day=1, hour=12, minute=6, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    )
+    field = DateTimeField(
+        name="dt", default_timezone=zoneinfo.ZoneInfo("Etc/UTC"), remove_timezone=True
+    )
+    assert field.clean(field.name, _date)["dt"] == datetime.datetime(year=2024, month=1, day=1)
+    assert field.to_model(field.name, _datetimen)["dt"] == _datetimen.replace(tzinfo=None)
+    assert field.clean(field.name, _datetimel)["dt"] == _datetimel.replace(tzinfo=None)
+
+
+def test_force_timezone():
+    _date = datetime.date(year=2024, month=1, day=1)
+    _datetimen = datetime.datetime(year=2024, month=1, day=1, hour=12, minute=6)
+    _datetimel = datetime.datetime(
+        year=2024, month=1, day=1, hour=12, minute=6, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    )
+    field = DateTimeField(name="dt", force_timezone=zoneinfo.ZoneInfo("Etc/UTC"))
+    assert field.clean(field.name, _date)["dt"] == datetime.datetime(
+        year=2024, month=1, day=1, tzinfo=zoneinfo.ZoneInfo("Etc/UTC")
+    )
+    assert field.to_model(field.name, _datetimen)["dt"] == _datetimen.replace(
+        tzinfo=zoneinfo.ZoneInfo("Etc/UTC")
+    )
+    assert field.clean(field.name, _datetimel)["dt"] == _datetimel.astimezone(
+        zoneinfo.ZoneInfo("Etc/UTC")
+    )
+
+
+def test_default_force_timezone():
+    _date = datetime.date(year=2024, month=1, day=1)
+    _datetimen = datetime.datetime(year=2024, month=1, day=1, hour=12, minute=6)
+    _datetimel = datetime.datetime(
+        year=2024, month=1, day=1, hour=12, minute=6, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    )
+    field = DateTimeField(
+        name="dt",
+        default_timezone=zoneinfo.ZoneInfo("Etc/GMT-10"),
+        force_timezone=zoneinfo.ZoneInfo("Etc/UTC"),
+    )
+    assert field.clean(field.name, _date)["dt"] == datetime.datetime(
+        year=2024, month=1, day=1, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    ).astimezone(zoneinfo.ZoneInfo("Etc/UTC"))
+    assert field.to_model(field.name, _datetimen)["dt"] == _datetimel.astimezone(
+        zoneinfo.ZoneInfo("Etc/UTC")
+    )
+    assert field.clean(field.name, _datetimel)["dt"] == _datetimel.astimezone(
+        zoneinfo.ZoneInfo("Etc/UTC")
+    )
+
+
+def test_default_force_remove_timezone():
+    _date = datetime.date(year=2024, month=1, day=1)
+    _datetimen = datetime.datetime(year=2024, month=1, day=1, hour=12, minute=6)
+    _datetimel = datetime.datetime(
+        year=2024, month=1, day=1, hour=12, minute=6, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    )
+    field = DateTimeField(
+        name="dt",
+        default_timezone=zoneinfo.ZoneInfo("Etc/GMT-10"),
+        force_timezone=zoneinfo.ZoneInfo("Etc/UTC"),
+        remove_timezone=True,
+    )
+    assert field.clean(field.name, _date)["dt"] == datetime.datetime(
+        year=2024, month=1, day=1, tzinfo=zoneinfo.ZoneInfo("Etc/GMT-10")
+    ).astimezone(zoneinfo.ZoneInfo("Etc/UTC")).replace(tzinfo=None)
+    assert field.to_model(field.name, _datetimen)["dt"] == _datetimel.astimezone(
+        zoneinfo.ZoneInfo("Etc/UTC")
+    ).replace(tzinfo=None)
+    assert field.clean(field.name, _datetimel)["dt"] == _datetimel.astimezone(
+        zoneinfo.ZoneInfo("Etc/UTC")
+    ).replace(tzinfo=None)

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -183,7 +183,7 @@ def test_can_create_date_field():
     field = DateField(auto_now=True)
 
     assert isinstance(field, BaseField)
-    assert field.default == datetime.date.today
+    assert field.default == datetime.datetime.now
     assert field.read_only is True
 
 


### PR DESCRIPTION
Changes:
- one copy less for queries
- add `default_timezone`, `force_timezone`, `remove_timezone` to DateTimeField
- add `default_timezone`, `force_timezone` to DateField
- add `is_update` keyword argument to `get_defaults`
- remove internal helper for auto now
- add ConcreteAutoNow