### PR TITLE
Cleanup names, bugfixes & add release notes

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -661,26 +661,29 @@ Derives from the same as [CharField](#charfield) and validates the value of an U
 
 ## Custom Fields
 
-### Simple fields
+### Factory fields
 
 If you merely want to customize an existing field in `edgy.core.db.fields` you can just inherit from it and provide the customization via the `FieldFactory` (or you can use `FieldFactory` directly for handling a new sqlalchemy type).
-Valid methods to overwrite are `__new__`, `get_column_type`, `get_pydantic_type`, `get_constraints` and `validate` as well as you can overwrite many field methods
+Valid methods to overwrite are `__new__`, `get_column_type`, `get_pydantic_type`, `get_constraints`, `build_field` and `validate` as well as you can overwrite many field methods
 by defining them on the factory (see `edgy.core.db.fields.factories` for allowed methods). Field methods overwrites must be classmethods which take as first argument after
 the class itself the field object and a keyword arg original_fn which can be None in case none was defined.
 
-For examples look in the mentioned path (replace dots with slashes).
+For examples have a look in `edgy/core/db/fields/core.py`.
 
 
 !!! Note
     You can extend in the factory the overwritable methods. The overwritten methods are not permanently overwritten. After init it is possible to change them again.
     A simple example is in `edgy/core/db/fields/exclude_field.py`. The magic behind this is in  `edgy/core/db/fields/factories.py`.
 
+!!! Tip
+    For global constraints you can overwrite the `get_global_constraints` field method via the factory overwrite. This differs from `get_constraints` which is defined on factories.
+
 ### Extended, special fields
 
 If you want to customize the entire field (e.g. checks), you have to split the field in 2 parts:
 
 - One inherits from `edgy.db.fields.base.BaseField` (or one of the derived classes) and provides the missing parts. It shall not be used for the Enduser (though possible).
-- One inherits from `edgy.db.fields.factories.FieldFactory`. Here the _bases attribute is adjusted to point to the Field from the first step.
+- One inherits from `edgy.db.fields.factories.FieldFactory`. Here the field_bases attribute is adjusted to point to the Field from the first step.
 
 Fields have to inherit from `edgy.db.fields.base.BaseField` and to provide following methods to work:
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -695,7 +695,7 @@ Additional they can provide following methods:
 * `__get__(self, instance, owner=None)` - Descriptor protocol like get access customization. Second parameter contains the class where the field was specified.
 * `__set__(self, instance, value)` - Descriptor protocol like set access customization. Dangerous to use. Better use to_model.
 * `to_model(self, field_name, phase="")` - like clean, just for setting attributes or initializing a model. It is also used when setting attributes or in initialization (phase contains the phase where it is called). This way it is much more powerful than `__set__`
-* `get_embedded_fields(self, field_name, fields_mapping)` - Define internal fields.
+* `get_embedded_fields(self, field_name, fields)` - Define internal fields.
 * `get_default_values(self, field_name, cleaned_data, is_update=False)` - returns the default values for the field. Can provide default values for embedded fields. If your field spans only one column you can also use the simplified get_default_value instead. This way you don't have to check for collisions. By default get_default_value is used internally.
 * `get_default_value(self)` - return default value for one column fields.
 * `get_global_constraints(self, field_name, columns)` - takes as second parameter (self excluded) the columns defined by this field (by get_columns). Returns a global constraint, which can be multi-column.
@@ -723,7 +723,7 @@ Dangerous! There can be many side-effects.
 The only safe thing to do is to update or replace a field and call `meta.invalidate()` afterwards. The type should match.
 
 Adding or excluding fields, or replacing the fields mappings are dangerous and could require a pydantic model rebuild.
-Also replacing `fields` with a new dict requires replacing `meta.fields_mapping` with the same dict (in this case a `meta.invalidate()` is automatically issued).
+Also replacing `fields` with a new dict requires replacing `meta.fields` with the same dict (in this case a `meta.invalidate()` is automatically issued).
 
 If you just want to remove a field ExcludeField or the inherit flags are the ways to go.
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -723,7 +723,7 @@ Dangerous! There can be many side-effects.
 The only safe thing to do is to update or replace a field and call `meta.invalidate()` afterwards. The type should match.
 
 Adding or excluding fields, or replacing the fields mappings are dangerous and could require a pydantic model rebuild.
-Also replacing `fields` with a new dict requires replacing `meta.fields` with the same dict (in this case a `meta.invalidate()` is automatically issued).
+In case of an assignment of a new field mapping (dict) to `meta.fields` a `meta.invalidate()` is automatically issued.
 
 If you just want to remove a field ExcludeField or the inherit flags are the ways to go.
 

--- a/docs/references/foreignkey.md
+++ b/docs/references/foreignkey.md
@@ -4,7 +4,7 @@
 ::: edgy.ForeignKey
     options:
         filters:
-        - "!^_type"
+        - "!^field_type"
         - "!^model_config"
         - "!^__slots__"
         - "!^__getattr__"

--- a/docs/references/many-to-many.md
+++ b/docs/references/many-to-many.md
@@ -7,4 +7,4 @@
         - "!^model_config"
         - "!^__slots__"
         - "!^__getattr__"
-        - "!^_type"
+        - "!^field_type"

--- a/docs/references/one-to-one.md
+++ b/docs/references/one-to-one.md
@@ -4,7 +4,7 @@
 ::: edgy.OneToOne
     options:
         filters:
-        - "!^_type"
+        - "!^field_type"
         - "!^model_config"
         - "!^__slots__"
         - "!^__getattr__"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,7 +18,7 @@ hide:
 ### Changed
 
 - `get_default_values` has now an extra keyword argument `is_update`
-- `meta.fields_mapping` is now `meta.fields`.-
+- `meta.fields_mapping` was renamed to `meta.fields`.-
 - Factories have now different named configuration variables.
 - Refactoring of fields and models
   - BaseModelType and BaseFieldType are now added and should be used for typings.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,7 @@ hide:
 ### Changed
 
 - `get_default_values` has now an extra keyword argument `is_update`
+- `meta.fields_mapping` is now `meta.fields`.-
 - Factories have now different named configuration variables.
 - Refactoring of fields and models
   - BaseModelType and BaseFieldType are now added and should be used for typings.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,17 +9,29 @@ hide:
 
 ### Added
 
-- `default_timezone`, `force_timezone`, `remove_timezone` for DateTimeField
+- `default_timezone`, `force_timezone`, `remove_timezone` for DateTimeField.
 - `default_timezone`, `force_timezone` for DateField.
--  Add attribute `inject_default_on_partial_update`.
+- Add attribute `inject_default_on_partial_update`.
+- Allow factories overwriting field methods.
+- Deep embedding via embed_parent possible.
 
 ### Changed
 
 - `get_default_values` has now an extra keyword argument `is_update`
+- Factories have now different named configuration variables.
+- Refactoring of fields and models
+  - BaseModelType and BaseFieldType are now added and should be used for typings.
+  - `get_column` works now via extractor.
+  - Renamed internals
+  - Splitted model_references and column values extraction.
+- Comparisons of models use now only primary keys.
 
 ### Fixed
 
-- `auto_now` and `auto_now_add` now also work for date fields
+- `auto_now` and `auto_now_add` now also work for date fields.
+- `BinaryField` had a wrong type.
+- Metaclasses with keyword arguments are now possible.
+- Relaxed Prefetching, tables can now appear multiple times.
 
 ## 0.12.0
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -26,6 +26,7 @@ hide:
   - Renamed internals.
   - Splitted model_references and column values extraction.
 - Comparisons of models use now only primary keys.
+- Deprecate on model forwards signals, fields. Use now meta.signals, meta.fields.
 
 ### Fixed
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -23,7 +23,7 @@ hide:
 - Refactoring of fields and models
   - BaseModelType and BaseFieldType are now added and should be used for typings.
   - `get_column` works now via extractor.
-  - Renamed internals
+  - Renamed internals.
   - Splitted model_references and column values extraction.
 - Comparisons of models use now only primary keys.
 

--- a/docs_src/signals/receiver/disconnect.py
+++ b/docs_src/signals/receiver/disconnect.py
@@ -18,6 +18,3 @@ async def after_creation(sender, instance, **kwargs):
 
 # Disconnect the given function
 User.meta.signals.post_save.disconnect(after_creation)
-
-# Signals are also exposed via instance
-user.signals.post_save.disconnect(after_creation)

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -245,7 +245,7 @@ class BaseCompositeField(BaseField):
     def get_default_values(
         self, field_name: str, cleaned_data: Dict[str, Any], is_update: bool = False
     ) -> Any:
-        # fields should provide their own default which is used as long as they are in the fields_mapping
+        # fields should provide their own default which is used as long as they are in the fields mapping
         return {}
 
 
@@ -278,7 +278,7 @@ class PKField(BaseCompositeField):
         d = {}
         for key in pknames:
             translated_name = self.translate_name(key)
-            field = instance.meta.fields_mapping.get(key)
+            field = instance.meta.fields.get(key)
             if field and hasattr(field, "__get__"):
                 d[translated_name] = field.__get__(instance, owner)
             else:
@@ -316,7 +316,7 @@ class PKField(BaseCompositeField):
             and not isinstance(value, (dict, BaseModel))
         ):
             pkname = pknames[0]
-            field = self.owner.meta.fields_mapping[pkname]
+            field = self.owner.meta.fields[pkname]
             return field.clean(f"{prefix}{pkname}", value, for_query=for_query)
         retdict = super().clean(field_name, value, for_query=for_query)
         if self.is_incomplete:
@@ -349,13 +349,13 @@ class PKField(BaseCompositeField):
             # we first only redirect both
             and not isinstance(value, (dict, BaseModel))
         ):
-            field = self.owner.meta.fields_mapping[pknames[0]]
+            field = self.owner.meta.fields[pknames[0]]
             return field.to_model(pknames[0], value, phase=phase)
         return super().to_model(field_name, value, phase=phase)
 
     def get_composite_fields(self) -> Dict[str, BaseFieldType]:
         return {
-            field: self.owner.meta.fields_mapping[field]
+            field: self.owner.meta.fields[field]
             for field in cast(Sequence[str], self.owner.pknames)
         }
 

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -116,9 +116,6 @@ class BaseField(BaseFieldType, FieldInfo):
         field_copy.owner = owner  # type: ignore
         return field_copy
 
-    def get_constraints(self) -> Any:
-        return self.constraints
-
     def get_default_value(self) -> Any:
         # single default
         default = getattr(self, "default", None)

--- a/edgy/core/db/fields/composite_field.py
+++ b/edgy/core/db/fields/composite_field.py
@@ -232,7 +232,7 @@ class CompositeField(FieldFactory):
     Meta field that aggregates multiple fields in a pseudo field
     """
 
-    _bases = (ConcreteCompositeField,)
+    field_bases = (ConcreteCompositeField,)
 
     @classmethod
     def get_pydantic_type(cls, **kwargs: Any) -> Any:

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -30,7 +30,7 @@ CLASS_DEFAULTS = ["cls", "__class__", "kwargs"]
 class CharField(FieldFactory, str):
     """String field representation that constructs the Field class and populates the values"""
 
-    _type = str
+    field_type = str
 
     def __new__(  # type: ignore
         cls,
@@ -74,7 +74,7 @@ class CharField(FieldFactory, str):
 class TextField(FieldFactory, str):
     """String representation of a text field which means no max_length required"""
 
-    _type = str
+    field_type = str
 
     def __new__(
         cls,
@@ -114,7 +114,7 @@ class IntegerField(Number, int):
     Integer field factory that construct Field classes and populated their values.
     """
 
-    _type = int
+    field_type = int
 
     def __new__(  # type: ignore
         cls,
@@ -140,7 +140,7 @@ class IntegerField(Number, int):
 class FloatField(Number, float):
     """Representation of a int32 and int64"""
 
-    _type = float
+    field_type = float
 
     def __new__(  # type: ignore
         cls,
@@ -178,7 +178,7 @@ class SmallIntegerField(IntegerField):
 
 
 class DecimalField(Number, decimal.Decimal):
-    _type = decimal.Decimal
+    field_type = decimal.Decimal
 
     def __new__(  # type: ignore
         cls,
@@ -217,7 +217,7 @@ class DecimalField(Number, decimal.Decimal):
 class BooleanField(FieldFactory, int):
     """Representation of a boolean"""
 
-    _type = bool
+    field_type = bool
 
     def __new__(  # type: ignore
         cls,
@@ -319,8 +319,8 @@ class AutoNowMixin(FieldFactory):
 class DateTimeField(AutoNowMixin, datetime.datetime):
     """Representation of a datetime field"""
 
-    _type = datetime.datetime
-    _bases = (TimezonedField, Field)
+    field_type = datetime.datetime
+    field_bases = (TimezonedField, Field)
 
     def __new__(  # type: ignore
         cls,
@@ -359,8 +359,8 @@ class DateTimeField(AutoNowMixin, datetime.datetime):
 class DateField(AutoNowMixin, datetime.date):
     """Representation of a date field"""
 
-    _type = datetime.date
-    _bases = (TimezonedField, Field)
+    field_type = datetime.date
+    field_bases = (TimezonedField, Field)
 
     def __new__(  # type: ignore
         cls,
@@ -388,7 +388,7 @@ class DateField(AutoNowMixin, datetime.date):
 class TimeField(FieldFactory, datetime.time):
     """Representation of a time field"""
 
-    _type = datetime.time
+    field_type = datetime.time
 
     def __new__(cls, **kwargs: Any) -> BaseFieldType:  # type: ignore
         kwargs = {
@@ -405,7 +405,7 @@ class TimeField(FieldFactory, datetime.time):
 class JSONField(FieldFactory, pydantic.Json):  # type: ignore
     """Representation of a JSONField"""
 
-    _type = Any
+    field_type = Any
 
     @classmethod
     def get_column_type(cls, **kwargs: Any) -> Any:
@@ -415,7 +415,7 @@ class JSONField(FieldFactory, pydantic.Json):  # type: ignore
 class BinaryField(FieldFactory, bytes):
     """Representation of a binary"""
 
-    _type = bytes
+    field_type = bytes
 
     def __new__(cls, *, max_length: Optional[int] = None, **kwargs: Any) -> BaseFieldType:  # type: ignore
         kwargs = {
@@ -432,7 +432,7 @@ class BinaryField(FieldFactory, bytes):
 class UUIDField(FieldFactory, uuid.UUID):
     """Representation of a uuid"""
 
-    _type = uuid.UUID
+    field_type = uuid.UUID
 
     def __new__(cls, **kwargs: Any) -> BaseFieldType:  # type: ignore
         kwargs = {
@@ -450,7 +450,7 @@ class UUIDField(FieldFactory, uuid.UUID):
 class ChoiceField(FieldFactory):
     """Representation of an Enum"""
 
-    _type = enum.Enum
+    field_type = enum.Enum
 
     def __new__(  # type: ignore
         cls,
@@ -486,7 +486,7 @@ class PasswordField(CharField):
 
 
 class EmailField(CharField):
-    _type = EmailStr
+    field_type = EmailStr
 
     @classmethod
     def get_column_type(self, **kwargs: Any) -> sqlalchemy.String:
@@ -500,7 +500,7 @@ class URLField(CharField):
 
 
 class IPAddressField(FieldFactory, str):
-    _type = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+    field_type = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
     def __new__(  # type: ignore
         cls,

--- a/edgy/core/db/fields/exclude_field.py
+++ b/edgy/core/db/fields/exclude_field.py
@@ -18,7 +18,7 @@ class ExcludeField(FieldFactory, Type[None]):
     Meta field that masks fields
     """
 
-    _type: Any = Any
+    field_type: Any = Any
 
     def __new__(  # type: ignore
         cls,

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -52,9 +52,9 @@ class FieldFactoryMeta(type):
 class FieldFactory(metaclass=FieldFactoryMeta):
     """The base for all model fields to be used with Edgy"""
 
-    _bases: Sequence[Any] = (Field,)
-    _type: Any = None
-    _methods_overwritable_by_factory: FrozenSet[str] = frozenset(
+    field_bases: Sequence[Any] = (Field,)
+    field_type: Any = None
+    methods_overwritable_by_factory: FrozenSet[str] = frozenset(
         default_methods_overwritable_by_factory
     )
 
@@ -84,7 +84,7 @@ class FieldFactory(metaclass=FieldFactoryMeta):
         )
 
         for key in dir(cls):
-            if key in cls._methods_overwritable_by_factory and hasattr(cls, key):
+            if key in cls.methods_overwritable_by_factory and hasattr(cls, key):
                 fn = getattr(cls, key)
                 original_fn = getattr(new_field_obj, key, None)
                 # use original func, not the wrapper
@@ -122,18 +122,18 @@ class FieldFactory(metaclass=FieldFactoryMeta):
     @classmethod
     def get_pydantic_type(cls, **kwargs: Any) -> Any:
         """Returns the type for pydantic"""
-        return cls._type
+        return cls.field_type
 
     @staticmethod
     @lru_cache(None)
     def _get_field_cls(cls: "FieldFactory") -> BaseFieldType:
-        return cast(BaseFieldType, type(cls.__name__, cast(Any, cls._bases), {}))
+        return cast(BaseFieldType, type(cls.__name__, cast(Any, cls.field_bases), {}))
 
 
 class ForeignKeyFieldFactory(FieldFactory):
     """The base for all model fields to be used with Edgy"""
 
-    _type: Any = Any
+    field_type: Any = Any
 
     def __new__(
         cls,

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -75,7 +75,7 @@ class BaseForeignKeyField(BaseForeignKey):
         columns: Dict[str, Optional[sqlalchemy.Column]] = {}
         if self.related_fields:
             for field_name in self.related_fields:
-                if field_name in target.meta.fields_mapping:
+                if field_name in target.meta.fields:
                     for column in target.meta.field_to_columns[field_name]:
                         columns[column.key] = column
                 else:

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -242,8 +242,8 @@ class BaseForeignKeyField(BaseForeignKey):
 
 
 class ForeignKey(ForeignKeyFieldFactory):
-    _bases = (BaseForeignKeyField,)
-    _type: Any = Any
+    field_bases = (BaseForeignKeyField,)
+    field_type: Any = Any
 
     def __new__(  # type: ignore
         cls,

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -297,8 +297,8 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
 
 
 class ManyToManyField(ForeignKeyFieldFactory):
-    _type: Any = Any
-    _bases = (BaseManyToManyForeignKeyField,)
+    field_type: Any = Any
+    field_bases = (BaseManyToManyForeignKeyField,)
 
     def __new__(  # type: ignore
         cls,

--- a/edgy/core/db/fields/ref_foreign_key.py
+++ b/edgy/core/db/fields/ref_foreign_key.py
@@ -26,8 +26,8 @@ class BaseRefForeignKeyField(BaseForeignKey):
 
 
 class RefForeignKey(ForeignKeyFieldFactory, list):
-    _bases = (BaseRefForeignKeyField,)
-    _type = list
+    field_bases = (BaseRefForeignKeyField,)
+    field_type = list
 
     @classmethod
     def is_class_and_subclass(cls, value: typing.Any, _type: typing.Any) -> bool:

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -120,14 +120,14 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         return []
 
     def get_embedded_fields(
-        self, field_name: str, fields_mapping: Dict[str, BaseFieldType]
+        self, field_name: str, fields: Dict[str, BaseFieldType]
     ) -> Dict[str, BaseFieldType]:
         """
         Define extra fields on the fly. Often no owner is available yet.
 
         Args:
             field_name: the field name (can be different from name)
-            fields_mapping: the existing fields
+            fields: the existing fields
 
         Note: the returned fields are changed after return, so you should
               return new fields or copies. Also set the owner of the field to them before returning

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -127,9 +127,13 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
     def can_load(self) -> bool:
         return all(self.__dict__.get(field) is not None for field in self.identifying_db_fields)
 
-    @cached_property
+    @property
     def signals(self) -> "Broadcaster":
-        return self.__class__.signals  # type: ignore
+        return self.meta.signals
+
+    @property
+    def fields(self) -> Dict[str, "BaseFieldType"]:
+        return self.meta.fields
 
     @property
     def table(self) -> sqlalchemy.Table:

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -73,7 +73,7 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
         kwargs = {**kwargs}
         new_kwargs: Dict[str, Any] = {}
 
-        fields = cls.meta.fields_mapping
+        fields = cls.meta.fields
         # phase 1: transform
         for field_name in cls.meta.input_modifying_fields:
             fields[field_name].modify_input(field_name, kwargs)
@@ -94,7 +94,7 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
         return {
             k: v
             for k, v in kwargs.items()
-            if k in self.meta.fields_mapping or k in self.meta.model_references
+            if k in self.meta.fields or k in self.meta.model_references
         }
 
     @property
@@ -175,7 +175,7 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
 
     def identifying_clauses(self) -> Iterable[Any]:
         for field_name in self.identifying_db_fields:
-            field = self.meta.fields_mapping.get(field_name)
+            field = self.meta.fields.get(field_name)
             if field is not None:
                 for column, value in field.clean(field_name, self.__dict__[field_name]).items():
                     yield getattr(self.table.columns, column) == value
@@ -191,7 +191,7 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
         if cls.__proxy_model__:
             return cls.__proxy_model__
 
-        fields = {key: copy.copy(field) for key, field in cls.meta.fields_mapping.items()}
+        fields = {key: copy.copy(field) for key, field in cls.meta.fields.items()}
         proxy_model = ProxyModel(
             name=cls.__name__,
             module=cls.__module__,
@@ -250,7 +250,7 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
                     continue
                 if getattr(field_name, "exclude", False):
                     continue
-            field: BaseFieldType = self.meta.fields_mapping[field_name]
+            field: BaseFieldType = self.meta.fields[field_name]
             try:
                 retval = field.__get__(self, self.__class__)
             except AttributeError:
@@ -308,7 +308,7 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
 
         columns: List[sqlalchemy.Column] = []
         global_constraints: List[Any] = []
-        for name, field in cls.meta.fields_mapping.items():
+        for name, field in cls.meta.fields.items():
             current_columns = field.get_columns(name)
             columns.extend(current_columns)
             global_constraints.extend(field.get_global_constraints(name, current_columns))
@@ -359,8 +359,8 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
         return sqlalchemy.Index(index.name, *index.fields)  # type: ignore
 
     def __setattr__(self, key: str, value: Any) -> None:
-        fields_mapping = self.meta.fields_mapping
-        field = fields_mapping.get(key, None)
+        fields = self.meta.fields
+        field = fields.get(key, None)
         if field is not None:
             if hasattr(field, "__set__"):
                 # not recommended, better to use to_model instead
@@ -390,7 +390,7 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
                 self.__dict__[name] = manager
             return self.__dict__[name]
 
-        field = self.meta.fields_mapping.get(name)
+        field = self.meta.fields.get(name)
         if field is not None and hasattr(field, "__get__"):
             # no need to set an descriptor object
             return field.__get__(self, self.__class__)

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -1,5 +1,6 @@
 import contextlib
 import copy
+import warnings
 from functools import cached_property
 from typing import (
     TYPE_CHECKING,
@@ -129,10 +130,20 @@ class EdgyBaseModel(ModelParser, BaseModel, BaseModelType, metaclass=BaseModelMe
 
     @property
     def signals(self) -> "Broadcaster":
+        warnings.warn(
+            "'signals' has been deprecated, use 'meta.signals' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.meta.signals
 
     @property
     def fields(self) -> Dict[str, "BaseFieldType"]:
+        warnings.warn(
+            "'fields' has been deprecated, use 'meta.fields' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.meta.fields
 
     @property

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -191,9 +191,9 @@ class MetaInfo:
     @property
     def fields_mapping(self) -> Dict[str, BaseFieldType]:
         warnings.warn(
-            "'fields_mapping' has been deprecated, use 'fields' instead",
+            "'fields_mapping' has been deprecated, use 'fields' instead.",
             DeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
         return self.fields
 
@@ -783,6 +783,11 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
         """
         Returns the signals of a class
         """
+        warnings.warn(
+            "'signals' has been deprecated, use 'meta.signals' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         meta: MetaInfo = cls.meta
         return meta.signals
 
@@ -809,4 +814,10 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
 
     @property
     def fields(cls) -> Dict[str, BaseFieldType]:
-        return cast(Dict[str, BaseFieldType], cls.meta.fields)
+        warnings.warn(
+            "'fields' has been deprecated, use 'meta.fields' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        meta: MetaInfo = cls.meta
+        return meta.fields

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -1,6 +1,7 @@
 import contextlib
 import copy
 import inspect
+import warnings
 from abc import ABCMeta
 from collections import UserDict, deque
 from typing import (
@@ -189,6 +190,11 @@ class MetaInfo:
 
     @property
     def fields_mapping(self) -> Dict[str, BaseFieldType]:
+        warnings.warn(
+            "'fields_mapping' has been deprecated, use 'fields' instead",
+            DeprecationWarning,
+            stacklevel=1,
+        )
         return self.fields
 
     @property

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -691,7 +691,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
         meta.model = new_class
 
         # Sets the foreign key fields
-        if not new_class.is_proxy_model and meta.foreign_key_fields:
+        if not new_class.__is_proxy_model__ and meta.foreign_key_fields:
             _set_related_name_for_foreign_keys(meta.foreign_key_fields, new_class)
 
         # Update the model references with the validations of the model
@@ -699,7 +699,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
         # Generates a proxy model for each model created
         # Making sure the core model where the fields are inherited
         # And mapped contains the main proxy_model
-        if not new_class.is_proxy_model and not meta.abstract:
+        if not new_class.__is_proxy_model__ and not meta.abstract:
             proxy_model = new_class.generate_proxy_model()
             new_class.__proxy_model__ = proxy_model
             new_class.__proxy_model__.__parent__ = new_class

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -611,7 +611,6 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
             return model_class(cls, name, bases, attrs, **kwargs)
 
         new_class = cast("Type[Model]", model_class(cls, name, bases, attrs, **kwargs))
-        new_class.fields = fields
 
         # Update the model_fields are updated to the latest
         new_class.model_fields = {**new_class.model_fields, **model_fields}
@@ -801,3 +800,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
     @property
     def columns(cls) -> sqlalchemy.sql.ColumnCollection:
         return cast("sqlalchemy.sql.ColumnCollection", cls.table.columns)
+
+    @property
+    def fields(cls) -> Dict[str, BaseFieldType]:
+        return cast(Dict[str, BaseFieldType], cls.meta.fields)

--- a/edgy/core/db/models/mixins/model_parser.py
+++ b/edgy/core/db/models/mixins/model_parser.py
@@ -39,12 +39,10 @@ class ModelParser:
         if model_cls.meta.input_modifying_fields:
             extracted_values = {**extracted_values}
             for field_name in model_cls.meta.input_modifying_fields:
-                model_cls.meta.fields_mapping[field_name].modify_input(
-                    field_name, extracted_values
-                )
+                model_cls.meta.fields[field_name].modify_input(field_name, extracted_values)
         # phase 2: validate fields and set defaults for readonly
         need_second_pass: List[BaseFieldType] = []
-        for field_name, field in model_cls.meta.fields_mapping.items():
+        for field_name, field in model_cls.meta.fields.items():
             if (
                 not is_partial or (field.inject_default_on_partial_update and is_update)
             ) and field.read_only:

--- a/edgy/core/db/models/mixins/model_parser.py
+++ b/edgy/core/db/models/mixins/model_parser.py
@@ -39,7 +39,9 @@ class ModelParser:
         if model_cls.meta.input_modifying_fields:
             extracted_values = {**extracted_values}
             for field_name in model_cls.meta.input_modifying_fields:
-                model_cls.fields[field_name].modify_input(field_name, extracted_values)
+                model_cls.meta.fields_mapping[field_name].modify_input(
+                    field_name, extracted_values
+                )
         # phase 2: validate fields and set defaults for readonly
         need_second_pass: List[BaseFieldType] = []
         for field_name, field in model_cls.meta.fields_mapping.items():

--- a/edgy/core/db/models/mixins/row.py
+++ b/edgy/core/db/models/mixins/row.py
@@ -53,7 +53,7 @@ class ModelRowMixin:
         for related in select_related:
             field_name = related.split("__", 1)[0]
             try:
-                field = cls.meta.fields_mapping[field_name]
+                field = cls.meta.fields[field_name]
             except KeyError:
                 raise QuerySetError(
                     detail=f'Selected field "{field_name}" does not exist on {cls}.'
@@ -185,7 +185,7 @@ class ModelRowMixin:
     def __check_prefetch_collision(model: "Model", related: "Prefetch") -> None:
         if (
             hasattr(model, related.to_attr)
-            or related.to_attr in model.meta.fields_mapping
+            or related.to_attr in model.meta.fields
             or related.to_attr in model.meta.managers
         ):
             raise QuerySetError(

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -45,7 +45,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         """
         Update operation of the database fields.
         """
-        await self.signals.pre_update.send_async(self.__class__, instance=self)
+        await self.meta.signals.pre_update.send_async(self.__class__, instance=self)
 
         # empty updates shouldn't cause an error
         if kwargs:
@@ -54,7 +54,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
             )
             expression = self.table.update().values(**kwargs).where(*self.identifying_clauses())
             await self.database.execute(expression)
-        await self.signals.post_update.send_async(self.__class__, instance=self)
+        await self.meta.signals.post_update.send_async(self.__class__, instance=self)
 
         # Update the model instance.
         for key, value in kwargs.items():
@@ -69,12 +69,12 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
 
     async def delete(self) -> None:
         """Delete operation from the database"""
-        await self.signals.pre_delete.send_async(self.__class__, instance=self)
+        await self.meta.signals.pre_delete.send_async(self.__class__, instance=self)
 
         expression = self.table.delete().where(*self.identifying_clauses())
         await self.database.execute(expression)
 
-        await self.signals.post_delete.send_async(self.__class__, instance=self)
+        await self.meta.signals.post_delete.send_async(self.__class__, instance=self)
 
     async def load(self) -> None:
         # Build the select expression.
@@ -156,7 +156,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         When creating a user it will make sure it can update existing or
         create a new one.
         """
-        await self.signals.pre_save.send_async(self.__class__, instance=self)
+        await self.meta.signals.pre_save.send_async(self.__class__, instance=self)
 
         extracted_fields = self.extract_db_fields()
 
@@ -191,11 +191,13 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
                 extracted_fields if values is None else values
             )
 
-            await self.signals.pre_update.send_async(self.__class__, instance=self, kwargs=kwargs)
+            await self.meta.signals.pre_update.send_async(
+                self.__class__, instance=self, kwargs=kwargs
+            )
             await self.update(**kwargs)
 
             # Broadcast the update complete
-            await self.signals.post_update.send_async(self.__class__, instance=self)
+            await self.meta.signals.post_update.send_async(self.__class__, instance=self)
 
         # Save the model references
         if model_references:
@@ -210,7 +212,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         ):
             await self.load()
 
-        await self.signals.post_save.send_async(self.__class__, instance=self)
+        await self.meta.signals.post_save.send_async(self.__class__, instance=self)
         return self
 
 

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -60,7 +60,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-        for field in self.meta.fields_mapping:
+        for field in self.meta.fields:
             _val = self.__dict__.get(field)
             if isinstance(_val, ManyRelationProtocol):
                 _val.instance = self
@@ -104,7 +104,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
             column = self.table.autoincrement_column
             if column is not None:
                 setattr(self, column.key, autoincrement_value)
-        for field in self.meta.fields_mapping:
+        for field in self.meta.fields:
             _val = self.__dict__.get(field)
             if isinstance(_val, ManyRelationProtocol):
                 _val.instance = self
@@ -207,7 +207,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         # Refresh the results
         if any(
             field.server_default is not None
-            for name, field in self.meta.fields_mapping.items()
+            for name, field in self.meta.fields.items()
             if name not in extracted_fields
         ):
             await self.load()

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -207,7 +207,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         # Refresh the results
         if any(
             field.server_default is not None
-            for name, field in self.fields.items()
+            for name, field in self.meta.fields_mapping.items()
             if name not in extracted_fields
         ):
             await self.load()

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -136,7 +136,7 @@ class BaseModelType(ABC):
         """
         fields_mapping = self.meta.fields_mapping
         model_references = self.meta.model_references
-        columns = self.__class__.columns
+        columns = self.table.columns
 
         if only is not None:
             return {k: v for k, v in self.__dict__.items() if k in only}

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -134,7 +134,7 @@ class BaseModelType(ABC):
         Extracts all the db fields, model references and fields.
         Related fields are not included because they are disjoint.
         """
-        fields_mapping = self.meta.fields_mapping
+        fields = self.meta.fields
         model_references = self.meta.model_references
         columns = self.table.columns
 
@@ -144,7 +144,7 @@ class BaseModelType(ABC):
         return {
             k: v
             for k, v in self.__dict__.items()
-            if k in fields_mapping or hasattr(columns, k) or k in model_references
+            if k in fields or hasattr(columns, k) or k in model_references
         }
 
     def get_instance_name(self) -> str:

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -53,7 +53,7 @@ class BaseModelType(ABC):
     Meta: ClassVar[DescriptiveMeta] = DescriptiveMeta()
 
     __parent__: ClassVar[Union[Type["BaseModelType"], None]] = None
-    is_proxy_model: ClassVar[bool] = False
+    __is_proxy_model__: ClassVar[bool] = False
     __reflected__: ClassVar[bool] = False
 
     @property

--- a/edgy/core/db/models/utils.py
+++ b/edgy/core/db/models/utils.py
@@ -27,7 +27,7 @@ def build_pknames(model_class: Any) -> None:
     """
     meta = model_class.meta
     pknames: Set[str] = set()
-    for field_name, field in meta.fields_mapping.items():
+    for field_name, field in meta.fields.items():
         if field.primary_key:
             pknames.add(field_name)
     model_class._pknames = tuple(sorted(pknames))

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -319,7 +319,7 @@ class BaseQuerySet(
 
         # Making sure for queries we use the main class and not the proxy
         # And enable the parent
-        if self.model_class.is_proxy_model:
+        if self.model_class.__is_proxy_model__:
             self.model_class = self.model_class.__parent__
 
         kwargs = clean_query_kwargs(self.model_class, kwargs)

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -166,7 +166,7 @@ class BaseQuerySet(
                     raise QuerySetError(
                         detail=f'Selected field "{field_name}" does not exist on {model_class}.'
                     ) from None
-                field = model_class.fields[field_name]
+                field = model_class.meta.fields_mapping[field_name]
                 if isinstance(field, RelationshipField):
                     model_class, reverse_part, select_path = field.traverse_field(select_path)
                 else:

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -950,7 +950,7 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
     async def delete(self) -> None:
         queryset: QuerySet = self._clone()
 
-        await self.model_class.signals.pre_delete.send_async(self.__class__, instance=self)
+        await self.model_class.meta.signals.pre_delete.send_async(self.__class__, instance=self)
 
         expression = queryset.table.delete()
         for filter_clause in queryset.filter_clauses:
@@ -959,7 +959,7 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
         queryset._set_query_expression(expression)
         await queryset.database.execute(expression)
 
-        await self.model_class.signals.post_delete.send_async(self.__class__, instance=self)
+        await self.model_class.meta.signals.post_delete.send_async(self.__class__, instance=self)
 
     async def update(self, **kwargs: Any) -> None:
         """
@@ -970,7 +970,7 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
         kwargs = queryset.extract_column_values(kwargs, model_class=queryset.model_class)
 
         # Broadcast the initial update details
-        await self.model_class.signals.pre_update.send_async(
+        await self.model_class.meta.signals.pre_update.send_async(
             self.__class__, instance=self, kwargs=kwargs
         )
 
@@ -983,7 +983,7 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
         await queryset.database.execute(expression)
 
         # Broadcast the update executed
-        await self.model_class.signals.post_update.send_async(self.__class__, instance=self)
+        await self.model_class.meta.signals.post_update.send_async(self.__class__, instance=self)
 
     async def get_or_create(
         self, defaults: Dict[str, Any], **kwargs: Any

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -40,7 +40,7 @@ def clean_query_kwargs(model: Type["Model"], kwargs: Dict[str, Any]) -> Dict[str
     new_kwargs: Dict[str, Any] = {}
     for key, val in kwargs.items():
         model_class, field_name, _, _, _ = crawl_relationship(model, key)
-        field = model_class.meta.fields_mapping.get(field_name)
+        field = model_class.meta.fields.get(field_name)
         if field is not None:
             new_kwargs.update(field.clean(key, val, for_query=True))
         else:
@@ -161,12 +161,12 @@ class BaseQuerySet(
             while select_path:
                 field_name = select_path.split("__", 1)[0]
                 try:
-                    field = model_class.meta.fields_mapping[field_name]
+                    field = model_class.meta.fields[field_name]
                 except KeyError:
                     raise QuerySetError(
                         detail=f'Selected field "{field_name}" does not exist on {model_class}.'
                     ) from None
-                field = model_class.meta.fields_mapping[field_name]
+                field = model_class.meta.fields[field_name]
                 if isinstance(field, RelationshipField):
                     model_class, reverse_part, select_path = field.traverse_field(select_path)
                 else:
@@ -177,7 +177,7 @@ class BaseQuerySet(
                     foreign_key = field
                     reverse = False
                 else:
-                    foreign_key = model_class.meta.fields_mapping[reverse_part]
+                    foreign_key = model_class.meta.fields[reverse_part]
                     reverse = True
                 if foreign_key.is_cross_db():
                     raise NotImplementedError(

--- a/edgy/core/db/querysets/clauses.py
+++ b/edgy/core/db/querysets/clauses.py
@@ -25,7 +25,7 @@ class _EnhancedClausesHelper:
         if not isinstance(columns_or_model, ColumnCollection) and hasattr(
             columns_or_model, "columns"
         ):
-            columns_or_model = columns_or_model.columns
+            columns_or_model = columns_or_model.table.columns
         return self.op(*(getattr(columns_or_model, item[0]) == item[1] for item in kwargs.items()))
 
 

--- a/edgy/core/db/relationships/related_field.py
+++ b/edgy/core/db/relationships/related_field.py
@@ -70,9 +70,7 @@ class RelatedField(RelationshipField):
 
     @functools.cached_property
     def foreign_key(self) -> BaseForeignKeyField:
-        return cast(
-            BaseForeignKeyField, self.related_from.meta.fields_mapping[self.foreign_key_name]
-        )
+        return cast(BaseForeignKeyField, self.related_from.meta.fields[self.foreign_key_name])
 
     def traverse_field(self, path: str) -> Tuple[Any, str, str]:
         return self.foreign_key.reverse_traverse_field(path)

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -69,7 +69,7 @@ class ManyRelation(ManyRelationProtocol):
 
     async def save_related(self) -> None:
         # TODO: improve performance
-        fk = self.through.meta.fields_mapping[self.from_foreign_key]
+        fk = self.through.meta.fields[self.from_foreign_key]
         while self.refs:
             ref = self.refs.pop()
             ref.__dict__.update(fk.clean(fk.name, self.instance))
@@ -92,7 +92,7 @@ class ManyRelation(ManyRelationProtocol):
         @functools.wraps(func)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
             assert self.instance, "instance not initialized"
-            fk = self.through.meta.fields_mapping[self.from_foreign_key]
+            fk = self.through.meta.fields[self.from_foreign_key]
             query = {}
             if self.embed_through == "":
                 new_kwargs = kwargs
@@ -154,9 +154,9 @@ class ManyRelation(ManyRelationProtocol):
         . Removes the field if there is
         """
         if self.reverse:
-            fk = self.through.meta.fields_mapping[self.from_foreign_key]
+            fk = self.through.meta.fields[self.from_foreign_key]
         else:
-            fk = self.through.meta.fields_mapping[self.to_foreign_key]
+            fk = self.through.meta.fields[self.to_foreign_key]
         if child is None:
             if fk.unique:
                 try:
@@ -227,7 +227,7 @@ class SingleRelation(ManyRelationProtocol):
 
         if isinstance(value, (target, target.proxy_model)):
             return value
-        related_columns = self.to.meta.fields_mapping[self.to_foreign_key].related_columns.keys()
+        related_columns = self.to.meta.fields[self.to_foreign_key].related_columns.keys()
         if len(related_columns) == 1 and not isinstance(value, (dict, BaseModel)):
             value = {next(iter(related_columns)): value}
         if isinstance(value, dict):
@@ -262,10 +262,10 @@ class SingleRelation(ManyRelationProtocol):
         @functools.wraps(func)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
             assert self.instance, "instance not initialized"
-            fk = self.to.meta.fields_mapping[self.to_foreign_key]
+            fk = self.to.meta.fields[self.to_foreign_key]
             query = {}
             if not self.embed_parent or not isinstance(
-                fk.owner.meta.fields_mapping[self.embed_parent[0].split("__", 1)[0]],
+                fk.owner.meta.fields[self.embed_parent[0].split("__", 1)[0]],
                 RelationshipField,
             ):
                 new_kwargs = kwargs
@@ -309,7 +309,7 @@ class SingleRelation(ManyRelationProtocol):
         . Validates if there is a relationship between the entities.
         . Removes the field if there is
         """
-        fk = self.to.meta.fields_mapping[self.to_foreign_key]
+        fk = self.to.meta.fields[self.to_foreign_key]
         if child is None:
             if fk.unique:
                 try:

--- a/edgy/core/db/relationships/utils.py
+++ b/edgy/core/db/relationships/utils.py
@@ -33,7 +33,7 @@ def crawl_relationship(
     while path:
         splitted = path.split("__", 1)
         field_name = splitted[0]
-        field = model_class.meta.fields_mapping.get(field_name)
+        field = model_class.meta.fields.get(field_name)
         if isinstance(field, RelationshipField) and len(splitted) == 2:
             model_class, reverse_part, path = field.traverse_field(path)
             if field.is_cross_db():

--- a/edgy/core/marshalls/metaclasses.py
+++ b/edgy/core/marshalls/metaclasses.py
@@ -69,7 +69,7 @@ class MarshallMeta(ModelMetaclass):
             }
         elif base_fields_include is not None and "__all__" in base_fields_include:
             base_model_fields = {
-                k: v for k, v in model.meta.fields_mapping.items() if k not in model_fields
+                k: v for k, v in model.meta.fields.items() if k not in model_fields
             }
             show_pk = True
         else:
@@ -88,7 +88,7 @@ class MarshallMeta(ModelMetaclass):
         for k, v in attrs.items():
             if isinstance(v, BaseMarshallField):  # noqa: SIM102
                 # Make sure the custom fields are flagged.
-                if k not in model.meta.fields_mapping:
+                if k not in model.meta.fields:
                     custom_fields[k] = v
 
         # Handle the check of the custom fields

--- a/edgy/core/utils/models.py
+++ b/edgy/core/utils/models.py
@@ -34,7 +34,7 @@ def create_edgy_model(
     core_definitions = {
         "__module__": __module__,
         "__qualname__": qualname,
-        "is_proxy_model": __proxy__,
+        "__is_proxy_model__": __proxy__,
     }
     if not __definitions__:
         __definitions__ = {}

--- a/tests/fields/test_composite_fields.py
+++ b/tests/fields/test_composite_fields.py
@@ -114,7 +114,7 @@ def test_get_columns_inner_fields_mixed():
 )
 async def test_assign(rollback_connections, assign_object):
     obj = await MyModel2.query.create(first_name="edgy", last_name="edgytoo")
-    assert obj.meta.fields_mapping["last_name"].skip_absorption_check is True
+    assert obj.meta.fields["last_name"].skip_absorption_check is True
     assert obj.composite["first_name"] == "edgy"
     assert obj.composite["last_name"] == "edgytoo"
     assert obj.composite2["age"] is None
@@ -168,7 +168,7 @@ def test_dump_composite_dict():
         embedded_first_name="edgy2embedded",
         embedded_last_name="edgytoo2embedded",
     )
-    assert obj.meta.fields_mapping["embedded_first_name"].exclude
+    assert obj.meta.fields["embedded_first_name"].exclude
     assert obj.model_dump() == {
         "first_name": "edgy",
         "last_name": "edgytoo",
@@ -259,8 +259,8 @@ def test_inheritance():
             ],
         )
 
-    assert "age" not in ConcreteModel1.meta.fields_mapping
-    assert ConcreteModel1.meta.fields_mapping["last_name"].max_length == 51
+    assert "age" not in ConcreteModel1.meta.fields
+    assert ConcreteModel1.meta.fields["last_name"].max_length == 51
 
     class ConcreteModel2(AbstractModel):
         composite2: Dict[str, Any] = edgy.CompositeField(
@@ -271,8 +271,8 @@ def test_inheritance():
             absorb_existing_fields=True,
         )
 
-    assert "age" in ConcreteModel2.meta.fields_mapping
-    assert ConcreteModel2.meta.fields_mapping["last_name"].max_length == 255
+    assert "age" in ConcreteModel2.meta.fields
+    assert ConcreteModel2.meta.fields["last_name"].max_length == 255
 
     class ConcreteModel3(AbstractModel):
         composite3: Dict[str, Any] = edgy.CompositeField(
@@ -282,8 +282,8 @@ def test_inheritance():
             ],
         )
 
-    assert ConcreteModel3.meta.fields_mapping["last_name"].max_length == 50
-    assert "age" in ConcreteModel3.meta.fields_mapping
+    assert ConcreteModel3.meta.fields["last_name"].max_length == 50
+    assert "age" in ConcreteModel3.meta.fields
 
 
 def test_copying():

--- a/tests/fields/test_composite_fields.py
+++ b/tests/fields/test_composite_fields.py
@@ -114,7 +114,7 @@ def test_get_columns_inner_fields_mixed():
 )
 async def test_assign(rollback_connections, assign_object):
     obj = await MyModel2.query.create(first_name="edgy", last_name="edgytoo")
-    assert obj.fields["last_name"].skip_absorption_check is True
+    assert obj.meta.fields_mapping["last_name"].skip_absorption_check is True
     assert obj.composite["first_name"] == "edgy"
     assert obj.composite["last_name"] == "edgytoo"
     assert obj.composite2["age"] is None
@@ -168,7 +168,7 @@ def test_dump_composite_dict():
         embedded_first_name="edgy2embedded",
         embedded_last_name="edgytoo2embedded",
     )
-    assert obj.fields["embedded_first_name"].exclude
+    assert obj.meta.fields_mapping["embedded_first_name"].exclude
     assert obj.model_dump() == {
         "first_name": "edgy",
         "last_name": "edgytoo",

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -204,7 +204,7 @@ def test_autonow_field(mocker):
         pass
 
     class Bar(DateTimeField):
-        _bases = (Foo,)
+        field_bases = (Foo,)
 
     spy = mocker.spy(Foo, "get_default_values")
 

--- a/tests/fields/test_inheritance.py
+++ b/tests/fields/test_inheritance.py
@@ -60,9 +60,9 @@ def test_overwriting_fields_with_fields():
     class ConcreteModel2(ConcreteModel1):
         first_name: str = CharField(max_length=50)
 
-    assert ConcreteModel1.meta.fields_mapping["first_name"].max_length == 255
-    assert isinstance(ConcreteModel1.meta.fields_mapping["last_name"], IntegerField)
-    assert ConcreteModel2.meta.fields_mapping["first_name"].max_length == 50
+    assert ConcreteModel1.meta.fields["first_name"].max_length == 255
+    assert isinstance(ConcreteModel1.meta.fields["last_name"], IntegerField)
+    assert ConcreteModel2.meta.fields["first_name"].max_length == 50
 
 
 def test_deleting_fields():
@@ -79,7 +79,7 @@ def test_deleting_fields():
     class ConcreteModel2(ConcreteModel1):
         first_name: Type[None] = ExcludeField()
 
-    assert ConcreteModel1.meta.fields_mapping["first_name"].max_length == 255
+    assert ConcreteModel1.meta.fields["first_name"].max_length == 255
     model1 = ConcreteModel1(first_name="edgy", last_name="edgy")
     model2 = ConcreteModel2(first_name="edgy", last_name="edgy")
     assert model1.first_name == "edgy"
@@ -115,18 +115,18 @@ def test_mixins_non_inherited():
         pass
 
     assert not ConcreteModel1.meta.abstract
-    assert "field" in ConcreteModel1.meta.fields_mapping
+    assert "field" in ConcreteModel1.meta.fields
 
     class ConcreteModel2(ConcreteModel1):
         field3 = CharField(max_length=255, inherit=False)
 
     assert not ConcreteModel2.meta.abstract
-    assert "field" not in ConcreteModel2.meta.fields_mapping
+    assert "field" not in ConcreteModel2.meta.fields
 
     class ConcreteModel3(Mixin2, ConcreteModel1):
         pass
 
-    assert "field" in ConcreteModel3.meta.fields_mapping
+    assert "field" in ConcreteModel3.meta.fields
 
 
 def test_mixins_mixed_inherited():
@@ -146,10 +146,10 @@ def test_mixins_mixed_inherited():
         pass
 
     assert not ConcreteModel1.meta.abstract
-    assert ConcreteModel1.meta.fields_mapping["field"].max_length == 255
+    assert ConcreteModel1.meta.fields["field"].max_length == 255
 
     class ConcreteModel2(ConcreteModel1):
         pass
 
     assert not ConcreteModel2.meta.abstract
-    assert ConcreteModel2.meta.fields_mapping["field"].max_length == 250
+    assert ConcreteModel2.meta.fields["field"].max_length == 250

--- a/tests/fields/test_multi_column_fields.py
+++ b/tests/fields/test_multi_column_fields.py
@@ -60,8 +60,8 @@ class MultiColumnFieldInner(BaseField):
 
 
 class MultiColumnField(FieldFactory):
-    _bases = (MultiColumnFieldInner,)
-    _type = Any
+    field_bases = (MultiColumnFieldInner,)
+    field_type = Any
 
     @classmethod
     def get_column_type(cls, **kwargs: Any) -> Any:

--- a/tests/foreign_keys/m2m_string/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_field.py
@@ -171,7 +171,7 @@ async def test_raises_RelationshipNotFound():
 
 
 async def test_many_to_many_many_fields():
-    assert "album_albumtracks_set" not in Album.meta.fields_mapping
+    assert "album_albumtracks_set" not in Album.meta.fields
     track1 = await Track.query.create(title="The Bird", position=1)
     track2 = await Track.query.create(title="Heart don't stand a chance", position=2)
     track3 = await Track.query.create(title="The Waters", position=3)

--- a/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
@@ -42,7 +42,7 @@ async def rollback_connections():
 
 
 async def test_no_relation():
-    for field in Track.meta.fields_mapping:
+    for field in Track.meta.fields:
         assert not field.endswith("_set")
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
@@ -59,7 +59,7 @@ async def rollback_connections():
 
 
 async def test_related_name_query():
-    assert "album_tracks_albumtracks_set" not in Album.meta.fields_mapping
+    assert "album_tracks_albumtracks_set" not in Album.meta.fields
     album = await Album.query.create(name="Malibu")
     album2 = await Album.query.create(name="Santa Monica")
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_field.py
@@ -171,7 +171,7 @@ async def test_raises_RelationshipNotFound():
 
 
 async def test_many_to_many_many_fields():
-    assert "album_albumtracks_set" not in Album.meta.fields_mapping
+    assert "album_albumtracks_set" not in Album.meta.fields
     track1 = await Track.query.create(title="The Bird", position=1)
     track2 = await Track.query.create(title="Heart don't stand a chance", position=2)
     track3 = await Track.query.create(title="The Waters", position=3)

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_no_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_no_related_name.py
@@ -42,7 +42,7 @@ async def rollback_connections():
 
 
 async def test_no_relation():
-    for field in Track.meta.fields_mapping:
+    for field in Track.meta.fields:
         assert not field.endswith("_set")
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_related_name.py
@@ -59,7 +59,7 @@ async def rollback_connections():
 
 
 async def test_related_name_query():
-    assert "album_tracks_albumtracks_set" not in Album.meta.fields_mapping
+    assert "album_tracks_albumtracks_set" not in Album.meta.fields
     album = await Album.query.create(name="Malibu")
     album2 = await Album.query.create(name="Santa Monica")
 

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -100,7 +100,7 @@ async def rollback_connections():
 
 
 async def test_no_relation():
-    for field in Profile.meta.fields_mapping:
+    for field in Profile.meta.fields:
         assert not field.startswith("person")
 
 

--- a/tests/models/run_sync/test_model_class.py
+++ b/tests/models/run_sync/test_model_class.py
@@ -47,11 +47,11 @@ async def rollback_connections():
 
 
 def test_model_class():
-    assert sorted(User.meta.fields_mapping.keys()) == sorted(["pk", "id", "name", "language"])
-    assert isinstance(User.meta.fields_mapping["id"], Field)
-    assert User.meta.fields_mapping["id"].primary_key is True
-    assert isinstance(User.meta.fields_mapping["name"], Field)
-    assert User.meta.fields_mapping["name"].max_length == 100
+    assert sorted(User.meta.fields.keys()) == sorted(["pk", "id", "name", "language"])
+    assert isinstance(User.meta.fields["id"], Field)
+    assert User.meta.fields["id"].primary_key is True
+    assert isinstance(User.meta.fields["name"], Field)
+    assert User.meta.fields["name"].max_length == 100
 
     assert User(id=1) != Product(id=1)
     assert User(id=1) != User(id=2)
@@ -60,8 +60,8 @@ def test_model_class():
     assert str(User(id=1)) == "User(id=1)"
     assert repr(User(id=1)) == "<User: User(id=1)>"
 
-    assert isinstance(User.query.meta.fields_mapping["id"], Field)
-    assert isinstance(User.query.meta.fields_mapping["name"], Field)
+    assert isinstance(User.query.meta.fields["id"], Field)
+    assert isinstance(User.query.meta.fields["name"], Field)
 
 
 def test_model_pk():

--- a/tests/models/run_sync/test_model_class.py
+++ b/tests/models/run_sync/test_model_class.py
@@ -47,11 +47,11 @@ async def rollback_connections():
 
 
 def test_model_class():
-    assert sorted(User.fields.keys()) == sorted(["pk", "id", "name", "language"])
-    assert isinstance(User.fields["id"], Field)
-    assert User.fields["id"].primary_key is True
-    assert isinstance(User.fields["name"], Field)
-    assert User.fields["name"].max_length == 100
+    assert sorted(User.meta.fields_mapping.keys()) == sorted(["pk", "id", "name", "language"])
+    assert isinstance(User.meta.fields_mapping["id"], Field)
+    assert User.meta.fields_mapping["id"].primary_key is True
+    assert isinstance(User.meta.fields_mapping["name"], Field)
+    assert User.meta.fields_mapping["name"].max_length == 100
 
     assert User(id=1) != Product(id=1)
     assert User(id=1) != User(id=2)
@@ -60,8 +60,8 @@ def test_model_class():
     assert str(User(id=1)) == "User(id=1)"
     assert repr(User(id=1)) == "<User: User(id=1)>"
 
-    assert isinstance(User.query.fields["id"], Field)
-    assert isinstance(User.query.fields["name"], Field)
+    assert isinstance(User.query.meta.fields_mapping["id"], Field)
+    assert isinstance(User.query.meta.fields_mapping["name"], Field)
 
 
 def test_model_pk():

--- a/tests/models/test_embeddables.py
+++ b/tests/models/test_embeddables.py
@@ -58,29 +58,29 @@ async def rollback_connections(create_test_database):
 
 
 def test_fields():
-    assert "id" in MyModel1.meta.fields_mapping
-    assert "id2" not in MyModel1.meta.fields_mapping
+    assert "id" in MyModel1.meta.fields
+    assert "id2" not in MyModel1.meta.fields
     assert "id" in MyModel1.pkcolumns
     assert "id2" not in MyModel1.pkcolumns
-    assert "model1" in MyModel1.meta.fields_mapping
-    assert "model1_first_name" in MyModel1.meta.fields_mapping
+    assert "model1" in MyModel1.meta.fields
+    assert "model1_first_name" in MyModel1.meta.fields
     # prefixed _ is removed
-    assert "model1_last_name" in MyModel1.meta.fields_mapping
-    assert "model2" in MyModel1.meta.fields_mapping
-    assert "model2_first_name" in MyModel1.meta.fields_mapping
+    assert "model1_last_name" in MyModel1.meta.fields
+    assert "model2" in MyModel1.meta.fields
+    assert "model2_first_name" in MyModel1.meta.fields
 
-    assert "id2" in MyModel2.meta.fields_mapping
-    assert "id" not in MyModel2.meta.fields_mapping
+    assert "id2" in MyModel2.meta.fields
+    assert "id" not in MyModel2.meta.fields
     assert "id2" in MyModel2.pkcolumns
     assert "id" not in MyModel2.pkcolumns
-    assert "model1" in MyModel2.meta.fields_mapping
-    assert "model2" not in MyModel2.meta.fields_mapping
-    assert "model3" in MyModel2.meta.fields_mapping
-    assert "model1_first_name" in MyModel2.meta.fields_mapping
-    assert "model2_first_name" not in MyModel2.meta.fields_mapping
-    assert "model3_first_name" not in MyModel2.meta.fields_mapping
-    assert "model3_model1_first_name" in MyModel2.meta.fields_mapping
-    assert isinstance(MyModel2.meta.fields_mapping["model3_model1_last_name"], edgy.ExcludeField)
+    assert "model1" in MyModel2.meta.fields
+    assert "model2" not in MyModel2.meta.fields
+    assert "model3" in MyModel2.meta.fields
+    assert "model1_first_name" in MyModel2.meta.fields
+    assert "model2_first_name" not in MyModel2.meta.fields
+    assert "model3_first_name" not in MyModel2.meta.fields
+    assert "model3_model1_first_name" in MyModel2.meta.fields
+    assert isinstance(MyModel2.meta.fields["model3_model1_last_name"], edgy.ExcludeField)
 
 
 @pytest.mark.parametrize(
@@ -88,9 +88,9 @@ def test_fields():
     [MyModel1, MyModel2],
 )
 def test_field_types(model):
-    for field in model.meta.fields_mapping.values():
+    for field in model.meta.fields.values():
         assert not isinstance(field, BaseManager)
-    for field in model.meta.fields_mapping.values():
+    for field in model.meta.fields.values():
         assert isinstance(field, BaseField)
     for manager in model.meta.managers.values():
         assert isinstance(manager, BaseManager)
@@ -101,7 +101,7 @@ def test_field_types(model):
     [MyModel1, MyModel2],
 )
 def test_field_names(model):
-    for field_name, field in model.meta.fields_mapping.items():
+    for field_name, field in model.meta.fields.items():
         assert field_name == field.name
 
 

--- a/tests/models/test_lazyness.py
+++ b/tests/models/test_lazyness.py
@@ -41,7 +41,7 @@ def test_control_lazyness():
 
     # init pk stuff
     assert "id" not in Product.meta.columns_to_field.data
-    assert not User.meta.fields_mapping["pk"].fieldless_pkcolumns
+    assert not User.meta.fields["pk"].fieldless_pkcolumns
     assert "id" in User.meta.columns_to_field.data
 
     # invalidate

--- a/tests/models/test_lazyness.py
+++ b/tests/models/test_lazyness.py
@@ -41,7 +41,7 @@ def test_control_lazyness():
 
     # init pk stuff
     assert "id" not in Product.meta.columns_to_field.data
-    assert not User.fields["pk"].fieldless_pkcolumns
+    assert not User.meta.fields_mapping["pk"].fieldless_pkcolumns
     assert "id" in User.meta.columns_to_field.data
 
     # invalidate

--- a/tests/models/test_model_class.py
+++ b/tests/models/test_model_class.py
@@ -48,10 +48,10 @@ async def rollback_connections():
 
 def test_model_class():
     assert sorted(User.fields.keys()) == sorted(["pk", "id", "name", "language"])
-    assert isinstance(User.fields["id"], Field)
-    assert User.fields["id"].primary_key is True
-    assert isinstance(User.fields["name"], Field)
-    assert User.fields["name"].max_length == 100
+    assert isinstance(User.meta.fields_mapping["id"], Field)
+    assert User.meta.fields_mapping["id"].primary_key is True
+    assert isinstance(User.meta.fields_mapping["name"], Field)
+    assert User.meta.fields_mapping["name"].max_length == 100
 
     assert User(id=1) != Product(id=1)
     assert User(id=1) != User(id=2)
@@ -60,8 +60,8 @@ def test_model_class():
     assert str(User(id=1)) == "User(id=1)"
     assert repr(User(id=1)) == "<User: User(id=1)>"
 
-    assert isinstance(User.query.fields["id"], Field)
-    assert isinstance(User.query.fields["name"], Field)
+    assert isinstance(User.query.meta.fields_mapping["id"], Field)
+    assert isinstance(User.query.meta.fields_mapping["name"], Field)
 
 
 def test_model_pk():

--- a/tests/models/test_model_class.py
+++ b/tests/models/test_model_class.py
@@ -48,10 +48,10 @@ async def rollback_connections():
 
 def test_model_class():
     assert sorted(User.fields.keys()) == sorted(["pk", "id", "name", "language"])
-    assert isinstance(User.meta.fields_mapping["id"], Field)
-    assert User.meta.fields_mapping["id"].primary_key is True
-    assert isinstance(User.meta.fields_mapping["name"], Field)
-    assert User.meta.fields_mapping["name"].max_length == 100
+    assert isinstance(User.meta.fields["id"], Field)
+    assert User.meta.fields["id"].primary_key is True
+    assert isinstance(User.meta.fields["name"], Field)
+    assert User.meta.fields["name"].max_length == 100
 
     assert User(id=1) != Product(id=1)
     assert User(id=1) != User(id=2)
@@ -60,8 +60,8 @@ def test_model_class():
     assert str(User(id=1)) == "User(id=1)"
     assert repr(User(id=1)) == "<User: User(id=1)>"
 
-    assert isinstance(User.query.meta.fields_mapping["id"], Field)
-    assert isinstance(User.query.meta.fields_mapping["name"], Field)
+    assert isinstance(User.query.meta.fields["id"], Field)
+    assert isinstance(User.query.meta.fields["name"], Field)
 
 
 def test_model_pk():

--- a/tests/signals/test_signals.py
+++ b/tests/signals/test_signals.py
@@ -121,8 +121,8 @@ async def test_signals():
     assert logs[0].instance["name"] == "Saffier"
     assert logs[1].signal == "post_update"
 
-    user.signals.pre_update.disconnect(pre_updating)
-    user.signals.post_update.disconnect(post_updating)
+    user.meta.signals.pre_update.disconnect(pre_updating)
+    user.meta.signals.post_update.disconnect(post_updating)
 
     # Disconnect the signals
     user = await user.update(name="Saffier")
@@ -134,10 +134,10 @@ async def test_signals():
     logs = await Log.query.filter(signal__icontains="delete").all()
     assert len(logs) == 2
 
-    user.signals.pre_delete.disconnect(pre_deleting)
-    user.signals.post_delete.disconnect(post_deleting)
-    user.signals.pre_save.disconnect(pre_saving)
-    user.signals.post_save.disconnect(post_saving)
+    user.meta.signals.pre_delete.disconnect(pre_deleting)
+    user.meta.signals.post_delete.disconnect(post_deleting)
+    user.meta.signals.pre_save.disconnect(pre_saving)
+    user.meta.signals.post_save.disconnect(post_saving)
 
     users = await User.query.all()
     assert len(users) == 1
@@ -161,8 +161,8 @@ async def test_staticmethod_signals():
 
     assert len(logs) == 2
 
-    user.signals.pre_save.disconnect(Static.pre_save_one)
-    user.signals.pre_save.disconnect(Static.pre_save_two)
+    user.meta.signals.pre_save.disconnect(Static.pre_save_one)
+    user.meta.signals.pre_save.disconnect(Static.pre_save_two)
 
 
 async def test_custom_signal():


### PR DESCRIPTION
Changes:

- Factories have now different named variables
- Renamed is_proxy_model to `__is_proxy_model__`
- Rename meta.fields_mapping to meta.fields (otherwise names get too long (provide fallback))
- Internally all references are updated from Model.columns to Model.table.columns
- Internally all references are updated from Model.signals to Model.meta.signals
- Internally all references are updated from Model.fields to Model.meta.fields

Fixed:

- extract_db_fields uses now the assigned table if one is assigned.

Updated release notes.