### PR TITLE
Fix compatibility with databasez >= 0.9 & env configurable TestClient

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.5.2
+    rev: v0.5.7
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,17 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+### Added
+
+- Testclient can be configured via environment variables.
+
+
+### Fixed
+
+- Compatibility with newer databasez releases (>0.9).
+
 ## 0.13.0
 
 ### Added

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -52,33 +52,6 @@ has some which are used across the codebase and those can be overriden easily.
 
     <sup>Default: `"~/.config/ptpython/config.py"`</sup>
 
-* **postgres_dialects** - Set of available Postgres dialects supported by Edgy.
-
-    <sup>Default: `{"postgres", "postgresql"}`</sup>
-
-* **mysql_dialects** - Set of available MySQL dialects supported by Edgy.
-
-    <sup>Default: `{"mysql"}`</sup>
-
-* **sqlite_dialects** - Set of available SQLite dialects supported by Edgy.
-
-    <sup>Default: `{"sqlite"}`</sup>
-
-* **mssql_dialects** - Set of available MSSQL dialects supported by Edgy.
-
-    <sup>Default: `{"mssql"}`</sup>
-
-* **postgres_drivers** - Set of available Postgres drivers supported by Edgy.
-
-    <sup>Default: `{"aiopg", "asyncpg"}`</sup>
-
-* **mysql_drivers** - Set of available MySQL drivers supported by Edgy.
-
-    <sup>Default: `{"aiomysql", "asyncmy"}`</sup>
-
-* **sqlite_drivers** - Set of available SQLite drivers supported by Edgy.
-
-    <sup>Default: `{aiosqlite}`</sup>
 
 #### How to use it
 

--- a/docs/test-client.md
+++ b/docs/test-client.md
@@ -37,6 +37,11 @@ that rollbacks once the database is disconnected.
 
     <sup>Default: `False`</sup>
 
+* **lazy_setup** - This sets up the db first up on connect not in init.
+
+    <sup>Default: `True`</sup>
+
+
 * **use_existing** - Uses the existing `test_` database if previously created and not dropped.
 
     <sup>Default: `False`</sup>
@@ -44,6 +49,18 @@ that rollbacks once the database is disconnected.
 * **drop_database** - Ensures that after the tests, the database is dropped.
 
     <sup>Default: `False`</sup>
+
+* **test_prefix** - Allow a custom test prefix or leave empty to use the url instead without changes.
+
+    <sup>Default: `testclient_default_test_prefix` (defaults to `test_`)</sup>
+
+### Configuration via Environment
+
+Most parameters defaults can be changed via capitalized environment names with `EDGY_TESTCLIENT_`.
+
+E.g. `EDGY_TESTCLIENT_DEFAULT_PREFIX=foobar` or `EDGY_TESTCLIENT_FORCE_ROLLBACK=true`.
+
+This is used for the tests.
 
 ### How to use it
 

--- a/edgy/conf/global_settings.py
+++ b/edgy/conf/global_settings.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Dict, List, Set
+from typing import Dict, List
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -8,24 +8,6 @@ class EdgySettings(BaseSettings):
     model_config = SettingsConfigDict(extra="allow", ignored_types=(cached_property,))
     ipython_args: List[str] = ["--no-banner"]
     ptpython_config_file: str = "~/.config/ptpython/config.py"
-
-    # Dialects
-    postgres_dialects: Set[str] = {"postgres", "postgresql"}
-    mysql_dialects: Set[str] = {"mysql"}
-    sqlite_dialects: Set[str] = {"sqlite"}
-    mssql_dialects: Set[str] = {"mssql"}
-
-    # Drivers
-    postgres_drivers: Set[str] = {"aiopg", "asyncpg"}
-    mysql_drivers: Set[str] = {"aiomysql", "asyncmy"}
-    sqlite_drivers: Set[str] = {"aiosqlite"}
-
-    @property
-    def mssql_drivers(self) -> Set[str]:
-        """
-        Do not override this one as SQLAlchemy doesn't support async for MSSQL.
-        """
-        return {"aioodbc"}
 
     # General settings
     filter_operators: Dict[str, str] = {

--- a/edgy/core/connection/registry.py
+++ b/edgy/core/connection/registry.py
@@ -84,6 +84,7 @@ class Registry:
     async def create_all(self) -> None:
         if self.db_schema:
             await self.schema.create_schema(self.db_schema, True)
+        # database can be also a TestClient, so use the Database and copy to not have strange error
         async with Database(
             self.database, force_rollback=False
         ) as database, database.transaction():
@@ -92,6 +93,7 @@ class Registry:
     async def drop_all(self) -> None:
         if self.db_schema:
             await self.schema.drop_schema(self.db_schema, True, True)
+        # database can be also a TestClient, so use the Database and copy to not have strange error
         async with Database(
             self.database, force_rollback=False
         ) as database, database.transaction():

--- a/edgy/core/connection/schemas.py
+++ b/edgy/core/connection/schemas.py
@@ -50,6 +50,7 @@ class Schema:
             except ProgrammingError as e:
                 raise SchemaError(detail=e.orig.args[0]) from e  # type: ignore
 
+        # database can be also a TestClient, so use the Database and copy to not have strange error
         async with Database(
             self.registry.database, force_rollback=False
         ) as database, database.transaction():
@@ -70,6 +71,7 @@ class Schema:
             except DBAPIError as e:
                 raise SchemaError(detail=e.orig.args[0]) from e  # type: ignore
 
+        # database can be also a TestClient, so use the Database and copy to not have strange error
         async with Database(
             self.registry.database, force_rollback=False
         ) as database, database.transaction():

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -102,10 +102,9 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
             setattr(self, k, v)
         # sqlalchemy supports only one autoincrement column
         if autoincrement_value:
-            if isinstance(autoincrement_value, Row):
-                assert len(autoincrement_value) == 1
-                autoincrement_value = autoincrement_value[0]
             column = self.table.autoincrement_column
+            if column is not None and isinstance(autoincrement_value, Row):
+                autoincrement_value = autoincrement_value._mapping[column.name]
             # can be explicit set, which causes an invalid value returned
             if column is not None and column.key not in kwargs:
                 setattr(self, column.key, autoincrement_value)

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -900,7 +900,7 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
 
         expression = queryset.table.insert().values(new_objs)
         queryset._set_query_expression(expression)
-        await queryset.database.execute(expression)
+        await queryset.database.execute_many(expression)
 
     async def bulk_update(self, objs: List[EdgyModel], fields: List[str]) -> None:
         """
@@ -943,7 +943,7 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
         }
         expression = expression.values(values_placeholder)
         queryset._set_query_expression(expression)
-        await queryset.database.execute(expression, update_list)
+        return await queryset.database.execute_many(expression, update_list)
 
     async def delete(self) -> None:
         queryset: QuerySet = self._clone()

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -943,7 +943,7 @@ class QuerySet(BaseQuerySet, QuerySetProtocol):
         }
         expression = expression.values(values_placeholder)
         queryset._set_query_expression(expression)
-        return await queryset.database.execute_many(expression, update_list)
+        await queryset.database.execute_many(expression, update_list)
 
     async def delete(self) -> None:
         queryset: QuerySet = self._clone()

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Tuple, Type,
 
 import sqlalchemy
 from pydantic import BaseModel, ConfigDict
+from sqlalchemy.exc import IntegrityError
 
 from edgy.core.db.fields.base import RelationshipField
 from edgy.exceptions import ObjectNotFound, RelationshipIncompatible, RelationshipNotFound
@@ -143,7 +144,7 @@ class ManyRelation(ManyRelationProtocol):
         try:
             async with child.database.transaction():
                 return await child.save(force_save=True)
-        except Exception:
+        except IntegrityError:
             pass
         return None
 
@@ -299,7 +300,6 @@ class SingleRelation(ManyRelationProtocol):
         """
         if not isinstance(child, (self.to, self.to.proxy_model)):
             raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")
-
         await child.save(values={self.to_foreign_key: self.instance})
         return child
 

--- a/edgy/core/utils/sync.py
+++ b/edgy/core/utils/sync.py
@@ -1,16 +1,13 @@
 import asyncio
 from typing import Any, Awaitable
 
+import nest_asyncio
 
-def run_sync(async_function: Awaitable) -> Any:
+nest_asyncio.apply()
+
+
+def run_sync(awaitable: Awaitable) -> Any:
     """
     Runs the queries in sync mode
     """
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
-    if loop:
-        return loop.run_until_complete(async_function)
-    else:
-        return asyncio.run(async_function)
+    return asyncio.run(awaitable)

--- a/edgy/testclient.py
+++ b/edgy/testclient.py
@@ -1,1 +1,40 @@
-from databasez.testclient import DatabaseTestClient as DatabaseTestClient  # noqa
+import os
+import typing
+from typing import TYPE_CHECKING, Any
+
+from databasez.testclient import DatabaseTestClient as _DatabaseTestClient
+
+if TYPE_CHECKING:
+    import sqlalchemy
+    from databasez import Database, DatabaseURL
+
+default_test_prefix: str = "test_"
+# for allowing empty
+if "EDGY_TESTCLIENT_TEST_PREFIX" in os.environ:
+    default_test_prefix: str = os.environ["EDGY_TESTCLIENT_TEST_PREFIX"]
+
+default_use_existing: bool = (
+    os.environ.get("EDGY_TESTCLIENT_USE_EXISTING") or ""
+).lower() == "true"
+default_drop_database: bool = (
+    os.environ.get("EDGY_TESTCLIENT_DROP_DATABASE") or ""
+).lower() == "true"
+
+
+class DatabaseTestClient(_DatabaseTestClient):
+    def __init__(
+        self,
+        url: typing.Union[str, "DatabaseURL", "sqlalchemy.URL", "Database"],
+        *,
+        use_existing: bool = default_use_existing,
+        drop_database: bool = default_drop_database,
+        test_prefix: str = default_test_prefix,
+        **options: Any,
+    ):
+        super().__init__(
+            url,
+            use_existing=use_existing,
+            drop_database=drop_database,
+            test_prefix=test_prefix,
+            **options,
+        )

--- a/edgy/testclient.py
+++ b/edgy/testclient.py
@@ -28,6 +28,7 @@ class DatabaseTestClient(_DatabaseTestClient):
 
     Note: the default of lazy_setup is True here. This enables the simple Registry syntax.
     """
+
     testclient_lazy_setup: bool = (
         os.environ.get("EDGY_TESTCLIENT_LAZY_SETUP", "true") or ""
     ).lower() == "true"

--- a/edgy/testclient.py
+++ b/edgy/testclient.py
@@ -8,10 +8,11 @@ if TYPE_CHECKING:
     import sqlalchemy
     from databasez import Database, DatabaseURL
 
+# TODO: move this to the settings
 default_test_prefix: str = "test_"
 # for allowing empty
 if "EDGY_TESTCLIENT_TEST_PREFIX" in os.environ:
-    default_test_prefix: str = os.environ["EDGY_TESTCLIENT_TEST_PREFIX"]
+    default_test_prefix = os.environ["EDGY_TESTCLIENT_TEST_PREFIX"]
 
 default_use_existing: bool = (
     os.environ.get("EDGY_TESTCLIENT_USE_EXISTING") or ""
@@ -22,6 +23,19 @@ default_drop_database: bool = (
 
 
 class DatabaseTestClient(_DatabaseTestClient):
+    """
+    Adaption of DatabaseTestClient for edgy.
+
+    Note: the default of lazy_setup is True here. This enables the simple Registry syntax.
+    """
+    testclient_lazy_setup: bool = (
+        os.environ.get("EDGY_TESTCLIENT_LAZY_SETUP", "true") or ""
+    ).lower() == "true"
+    testclient_force_rollback: bool = (
+        os.environ.get("EDGY_TESTCLIENT_FORCE_ROLLBACK") or ""
+    ).lower() == "true"
+
+    # TODO: replace by testclient default overwrites
     def __init__(
         self,
         url: typing.Union[str, "DatabaseURL", "sqlalchemy.URL", "Database"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ mssql = ["databasez[aioodbc]"]
 all = ["edgy[test,postgres,mysql,sqlite,mssql]", "ipython", "ptpython"]
 
 [tool.hatch.envs.default]
-dependencies = ["pre-commit>=2.17.0,<3.0.0"]
+dependencies = ["pre-commit>=2.17.0,<4.0.0"]
 
 [tool.hatch.envs.default.scripts]
 clean_pyc = "find . -type f -name \"*.pyc\" -delete"
@@ -129,6 +129,7 @@ features = ["all", "testing"]
 
 [tool.hatch.envs.test.env-vars]
 EDGY_TESTCLIENT_TEST_PREFIX = ""
+EDGY_TESTCLIENT_USE_EXISTING = "true"
 
 
 [tool.hatch.envs.test.scripts]
@@ -141,6 +142,7 @@ features = ["all", "testing"]
 
 [tool.hatch.envs.hatch-test.env-vars]
 EDGY_TESTCLIENT_TEST_PREFIX = ""
+EDGY_TESTCLIENT_USE_EXISTING = "true"
 
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "nest_asyncio",
     "alembic>=1.11.3,<2.0.0",
     "click>=8.1.3,<9.0.0",
-    "databasez>=0.8.5",
+    "databasez>=0.9.2",
     "loguru>=0.7.0,<0.10.0",
     "pydantic>=2.5.3,<3.0.0",
     "pydantic-settings>=2.0.0,<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,12 +126,21 @@ serve = "mkdocs serve --dev-addr localhost:8000"
 # required for cli tests and check_types
 features = ["all", "testing"]
 
+
+[tool.hatch.envs.test.env-vars]
+EDGY_TESTCLIENT_TEST_PREFIX = ""
+
+
 [tool.hatch.envs.test.scripts]
 check_types = "mypy -p edgy"
 
 [tool.hatch.envs.hatch-test]
 # needs docker services running
 features = ["all", "testing"]
+
+
+[tool.hatch.envs.hatch-test.env-vars]
+EDGY_TESTCLIENT_TEST_PREFIX = ""
 
 
 [tool.hatch.version]

--- a/tests/clauses/test_and_clauses.py
+++ b/tests/clauses/test_and_clauses.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.core.db.querysets.clauses import Q, and_
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/clauses/test_and_clauses.py
+++ b/tests/clauses/test_and_clauses.py
@@ -5,7 +5,7 @@ from edgy.core.db.querysets.clauses import Q, and_
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/clauses/test_or_clauses.py
+++ b/tests/clauses/test_or_clauses.py
@@ -5,7 +5,7 @@ from edgy.core.db.querysets.clauses import or_
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(url=DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(url=DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/clauses/test_or_clauses.py
+++ b/tests/clauses/test_or_clauses.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.core.db.querysets.clauses import or_
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(url=DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/cli/main.py
+++ b/tests/cli/main.py
@@ -9,7 +9,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(DATABASE_URL, drop_database=True)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="", drop_database=True)
 models = edgy.Registry(database=database)
 
 basedir = os.path.abspath(os.path.dirname(__file__))

--- a/tests/cli/main.py
+++ b/tests/cli/main.py
@@ -9,7 +9,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(DATABASE_URL, test_prefix="", drop_database=True)
+database = DatabaseTestClient(DATABASE_URL, drop_database=True)
 models = edgy.Registry(database=database)
 
 basedir = os.path.abspath(os.path.dirname(__file__))

--- a/tests/cli/main_extra.py
+++ b/tests/cli/main_extra.py
@@ -9,7 +9,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(DATABASE_URL, drop_database=True)
+database = DatabaseTestClient(DATABASE_URL, drop_database=True, test_prefix="")
 models = edgy.Registry(database=database)
 
 basedir = os.path.abspath(os.path.dirname(__file__))

--- a/tests/cli/main_extra.py
+++ b/tests/cli/main_extra.py
@@ -9,7 +9,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(DATABASE_URL, drop_database=True, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL, drop_database=True)
 models = edgy.Registry(database=database)
 
 basedir = os.path.abspath(os.path.dirname(__file__))

--- a/tests/cli/test_custom_template.py
+++ b/tests/cli/test_custom_template.py
@@ -1,11 +1,15 @@
+import asyncio
 import contextlib
 import os
 import shutil
 
 import pytest
+import sqlalchemy
 from esmerald import Esmerald
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from tests.cli.utils import run_cmd
+from tests.settings import DATABASE_URL
 
 app = Esmerald(routes=[])
 
@@ -39,7 +43,19 @@ def test_alembic_version():
         assert isinstance(v, int)
 
 
+async def cleanup_prepare_db():
+    engine = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(sqlalchemy.text("DROP DATABASE test_edgy"))
+    except Exception:
+        pass
+    async with engine.connect() as conn:
+        await conn.execute(sqlalchemy.text("CREATE DATABASE test_edgy"))
+
+
 def test_migrate_upgrade(create_folders):
+    asyncio.run(cleanup_prepare_db())
     (o, e, ss) = run_cmd("tests.cli.main:app", "edgy init -t ./custom")
     assert ss == 0
 

--- a/tests/contrib/multi_tenancy/test_mt_models.py
+++ b/tests/contrib/multi_tenancy/test_mt_models.py
@@ -10,10 +10,10 @@ from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields
 from edgy.exceptions import ModelSchemaError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/contrib/multi_tenancy/test_mt_models.py
+++ b/tests/contrib/multi_tenancy/test_mt_models.py
@@ -13,7 +13,7 @@ from edgy.exceptions import ModelSchemaError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/contrib/multi_tenancy/test_tenant_models_using.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_using.py
@@ -5,10 +5,10 @@ import pytest
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/contrib/multi_tenancy/test_tenant_models_using.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_using.py
@@ -8,7 +8,7 @@ from edgy.core.db import fields
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/contrib/multi_tenancy/test_tenant_models_using_operations.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_using_operations.py
@@ -6,10 +6,10 @@ from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields
 from edgy.exceptions import ObjectNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/contrib/multi_tenancy/test_tenant_models_using_operations.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_using_operations.py
@@ -9,7 +9,7 @@ from edgy.exceptions import ObjectNotFound
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/contrib/multi_tenancy/test_tenant_models_working.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_working.py
@@ -5,10 +5,10 @@ import pytest
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/contrib/multi_tenancy/test_tenant_models_working.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_working.py
@@ -8,7 +8,7 @@ from edgy.core.db import fields
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_exclude.py
+++ b/tests/exclude_secrets/test_exclude.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_exclude.py
+++ b/tests/exclude_secrets/test_exclude.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_exclude_nested.py
+++ b/tests/exclude_secrets/test_exclude_nested.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_exclude_nested.py
+++ b/tests/exclude_secrets/test_exclude_nested.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_exclude_repeated.py
+++ b/tests/exclude_secrets/test_exclude_repeated.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_exclude_repeated.py
+++ b/tests/exclude_secrets/test_exclude_repeated.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_secrets.py
+++ b/tests/exclude_secrets/test_secrets.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_secrets.py
+++ b/tests/exclude_secrets/test_secrets.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_secrets_fk.py
+++ b/tests/exclude_secrets/test_secrets_fk.py
@@ -3,10 +3,10 @@ import datetime
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/exclude_secrets/test_secrets_fk.py
+++ b/tests/exclude_secrets/test_secrets_fk.py
@@ -6,7 +6,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/fields/test_composite_fields.py
+++ b/tests/fields/test_composite_fields.py
@@ -4,11 +4,11 @@ import pytest
 from pydantic import BaseModel
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/fields/test_composite_fields.py
+++ b/tests/fields/test_composite_fields.py
@@ -8,7 +8,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/fields/test_foreignkeys.py
+++ b/tests/fields/test_foreignkeys.py
@@ -9,7 +9,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/fields/test_foreignkeys.py
+++ b/tests/fields/test_foreignkeys.py
@@ -4,12 +4,12 @@ import edgy
 from edgy import ForeignKey, Model, OneToOne, OneToOneField
 from edgy.core.db import fields
 from edgy.exceptions import FieldDefinitionError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/fields/test_multi_column_fields.py
+++ b/tests/fields/test_multi_column_fields.py
@@ -11,7 +11,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/fields/test_multi_column_fields.py
+++ b/tests/fields/test_multi_column_fields.py
@@ -7,11 +7,11 @@ import edgy
 from edgy.core.db.fields.base import BaseField
 from edgy.core.db.fields.core import FieldFactory
 from edgy.core.db.fields.types import ColumnDefinitionModel
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_field.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_field.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 
@@ -45,14 +45,14 @@ class Studio(edgy.Model):
         registry = models
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 async def create_test_database():
     await models.create_all()
     yield
     await models.drop_all()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="function")
 async def rollback_connections():
     with database.force_rollback():
         async with database:

--- a/tests/foreign_keys/m2m_string/test_many_to_many_field_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_field_related_name.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many_field_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_field_related_name.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_field.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_field.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_field_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_field_related_name.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_field_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_field_related_name.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_no_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_no_related_name.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_no_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_no_related_name.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_related_name.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_related_name.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_fk_related_name.py
+++ b/tests/foreign_keys/test_fk_related_name.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_fk_related_name.py
+++ b/tests/foreign_keys/test_fk_related_name.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -8,7 +8,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -3,12 +3,12 @@ from sqlalchemy.exc import IntegrityError
 
 import edgy
 from edgy.exceptions import FieldDefinitionError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_foreignkey_deep_embed_parent.py
+++ b/tests/foreign_keys/test_foreignkey_deep_embed_parent.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_foreignkey_deep_embed_parent.py
+++ b/tests/foreign_keys/test_foreignkey_deep_embed_parent.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_foreignkey_embed_parent.py
+++ b/tests/foreign_keys/test_foreignkey_embed_parent.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_foreignkey_embed_parent.py
+++ b/tests/foreign_keys/test_foreignkey_embed_parent.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_foreignkey_unique_and_no_constraint.py
+++ b/tests/foreign_keys/test_foreignkey_unique_and_no_constraint.py
@@ -8,7 +8,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_foreignkey_unique_and_no_constraint.py
+++ b/tests/foreign_keys/test_foreignkey_unique_and_no_constraint.py
@@ -3,12 +3,12 @@ from sqlalchemy.exc import IntegrityError
 
 import edgy
 from edgy.exceptions import FieldDefinitionError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many.py
+++ b/tests/foreign_keys/test_many_to_many.py
@@ -8,7 +8,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many.py
+++ b/tests/foreign_keys/test_many_to_many.py
@@ -3,12 +3,12 @@ import pytest
 import edgy
 from edgy.core.db.relationships.relation import ManyRelation
 from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_field.py
+++ b/tests/foreign_keys/test_many_to_many_field.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.exceptions import FieldDefinitionError, RelationshipIncompatible, RelationshipNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_field_old.py
+++ b/tests/foreign_keys/test_many_to_many_field_old.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_field_old.py
+++ b/tests/foreign_keys/test_many_to_many_field_old.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_field_related_name.py
+++ b/tests/foreign_keys/test_many_to_many_field_related_name.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_field_related_name.py
+++ b/tests/foreign_keys/test_many_to_many_field_related_name.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_field_related_name_old.py
+++ b/tests/foreign_keys/test_many_to_many_field_related_name_old.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_field_related_name_old.py
+++ b/tests/foreign_keys/test_many_to_many_field_related_name_old.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_old.py
+++ b/tests/foreign_keys/test_many_to_many_old.py
@@ -8,7 +8,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_old.py
+++ b/tests/foreign_keys/test_many_to_many_old.py
@@ -3,12 +3,12 @@ import pytest
 import edgy
 from edgy.core.db.relationships.relation import ManyRelation
 from edgy.exceptions import RelationshipIncompatible, RelationshipNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/test_many_to_many_related_name.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/test_many_to_many_related_name.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_related_name_old.py
+++ b/tests/foreign_keys/test_many_to_many_related_name_old.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_related_name_old.py
+++ b/tests/foreign_keys/test_many_to_many_related_name_old.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_unique.py
+++ b/tests/foreign_keys/test_many_to_many_unique.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_many_to_many_unique.py
+++ b/tests/foreign_keys/test_many_to_many_unique.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.core.db.relationships.relation import ManyRelation
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/foreign_keys/test_ref_foreignkey.py
+++ b/tests/foreign_keys/test_ref_foreignkey.py
@@ -4,12 +4,12 @@ from pydantic import __version__
 import edgy
 from edgy import ModelRef
 from edgy.exceptions import ModelReferenceError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pydantic_version = __version__[:3]

--- a/tests/foreign_keys/test_ref_foreignkey.py
+++ b/tests/foreign_keys/test_ref_foreignkey.py
@@ -9,7 +9,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pydantic_version = __version__[:3]

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -10,7 +10,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -5,12 +5,12 @@ import pytest
 
 import edgy
 from edgy.core.db.datastructures import Index
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/indexes/test_indexes_errors.py
+++ b/tests/indexes/test_indexes_errors.py
@@ -10,7 +10,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/indexes/test_indexes_errors.py
+++ b/tests/indexes/test_indexes_errors.py
@@ -10,7 +10,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/integration/test_esmerald_create_and_return_model.py
+++ b/tests/integration/test_esmerald_create_and_return_model.py
@@ -10,7 +10,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/integration/test_esmerald_create_and_return_model.py
+++ b/tests/integration/test_esmerald_create_and_return_model.py
@@ -7,10 +7,10 @@ from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/integration/test_esmerald_create_and_return_model_list_fk.py
+++ b/tests/integration/test_esmerald_create_and_return_model_list_fk.py
@@ -10,7 +10,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/integration/test_esmerald_create_and_return_model_list_fk.py
+++ b/tests/integration/test_esmerald_create_and_return_model_list_fk.py
@@ -7,10 +7,10 @@ from httpx import ASGITransport, AsyncClient
 from pydantic import __version__, field_validator
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/integration/test_esmerald_fk_reference_middleware.py
+++ b/tests/integration/test_esmerald_fk_reference_middleware.py
@@ -10,7 +10,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/integration/test_esmerald_fk_reference_middleware.py
+++ b/tests/integration/test_esmerald_fk_reference_middleware.py
@@ -7,10 +7,10 @@ from httpx import ASGITransport, AsyncClient
 from pydantic import __version__
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/integration/test_esmerald_models_validation_error.py
+++ b/tests/integration/test_esmerald_models_validation_error.py
@@ -7,7 +7,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/integration/test_esmerald_models_validation_error.py
+++ b/tests/integration/test_esmerald_models_validation_error.py
@@ -4,10 +4,10 @@ from esmerald.testclient import EsmeraldTestClient
 from pydantic import __version__
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/integration/test_esmerald_tenant.py
+++ b/tests/integration/test_esmerald_tenant.py
@@ -15,7 +15,7 @@ from edgy.exceptions import ObjectNotFound
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/integration/test_esmerald_tenant.py
+++ b/tests/integration/test_esmerald_tenant.py
@@ -12,10 +12,10 @@ from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin, TenantUserMixin
 from edgy.core.db import fields, set_tenant
 from edgy.exceptions import ObjectNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/integration/test_esmerald_tenant_user.py
+++ b/tests/integration/test_esmerald_tenant_user.py
@@ -15,7 +15,7 @@ from edgy.exceptions import ObjectNotFound
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/integration/test_esmerald_tenant_user.py
+++ b/tests/integration/test_esmerald_tenant_user.py
@@ -12,10 +12,10 @@ from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin, TenantUserMixin
 from edgy.core.db import fields, set_tenant
 from edgy.exceptions import ObjectNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/managers/test_manager_error.py
+++ b/tests/managers/test_manager_error.py
@@ -7,7 +7,7 @@ from edgy.exceptions import ImproperlyConfigured
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_manager_error.py
+++ b/tests/managers/test_manager_error.py
@@ -4,10 +4,10 @@ import edgy
 from edgy import Manager
 from edgy.core.db.querysets import QuerySet
 from edgy.exceptions import ImproperlyConfigured
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_manager_simple.py
+++ b/tests/managers/test_manager_simple.py
@@ -6,10 +6,10 @@ import pytest
 import edgy
 from edgy import Manager
 from edgy.core.db.querysets import QuerySet
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_manager_simple.py
+++ b/tests/managers/test_manager_simple.py
@@ -9,7 +9,7 @@ from edgy.core.db.querysets import QuerySet
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_managers.py
+++ b/tests/managers/test_managers.py
@@ -8,7 +8,7 @@ from edgy.core.db.querysets import QuerySet
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_managers.py
+++ b/tests/managers/test_managers.py
@@ -5,10 +5,10 @@ import pytest
 import edgy
 from edgy import Manager
 from edgy.core.db.querysets import QuerySet
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_managers_abstract.py
+++ b/tests/managers/test_managers_abstract.py
@@ -8,7 +8,7 @@ from edgy.core.db.querysets import QuerySet
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_managers_abstract.py
+++ b/tests/managers/test_managers_abstract.py
@@ -5,10 +5,10 @@ import pytest
 import edgy
 from edgy import Manager
 from edgy.core.db.querysets import QuerySet
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_managers_inherited.py
+++ b/tests/managers/test_managers_inherited.py
@@ -8,7 +8,7 @@ from edgy.core.db.querysets import QuerySet
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_managers_inherited.py
+++ b/tests/managers/test_managers_inherited.py
@@ -5,10 +5,10 @@ import pytest
 import edgy
 from edgy import Manager
 from edgy.core.db.querysets import QuerySet
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_managers_related.py
+++ b/tests/managers/test_managers_related.py
@@ -8,7 +8,7 @@ from edgy.core.db.querysets import QuerySet
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_managers_related.py
+++ b/tests/managers/test_managers_related.py
@@ -5,10 +5,10 @@ import pytest
 import edgy
 from edgy import Manager
 from edgy.core.db.querysets import QuerySet
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_queryset.py
+++ b/tests/managers/test_queryset.py
@@ -8,7 +8,7 @@ from edgy.core.db.querysets import QuerySet
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/managers/test_queryset.py
+++ b/tests/managers/test_queryset.py
@@ -5,10 +5,10 @@ import pytest
 import edgy
 from edgy import Manager
 from edgy.core.db.querysets import QuerySet
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_all.py
+++ b/tests/marshalls/save/test_marshall_all.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_all.py
+++ b/tests/marshalls/save/test_marshall_all.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_all_with_custom.py
+++ b/tests/marshalls/save/test_marshall_all_with_custom.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_all_with_custom.py
+++ b/tests/marshalls/save/test_marshall_all_with_custom.py
@@ -9,10 +9,10 @@ from pydantic import BaseModel, __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_exclude.py
+++ b/tests/marshalls/save/test_marshall_exclude.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_exclude.py
+++ b/tests/marshalls/save/test_marshall_exclude.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_import_string.py
+++ b/tests/marshalls/save/test_marshall_import_string.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_import_string.py
+++ b/tests/marshalls/save/test_marshall_import_string.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_method_field.py
+++ b/tests/marshalls/save/test_marshall_method_field.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_method_field.py
+++ b/tests/marshalls/save/test_marshall_method_field.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_source.py
+++ b/tests/marshalls/save/test_marshall_source.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_source.py
+++ b/tests/marshalls/save/test_marshall_source.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_source_from_property.py
+++ b/tests/marshalls/save/test_marshall_source_from_property.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_marshall_source_from_property.py
+++ b/tests/marshalls/save/test_marshall_source_from_property.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_simple_marshall.py
+++ b/tests/marshalls/save/test_simple_marshall.py
@@ -8,10 +8,10 @@ from pydantic import __version__
 
 import edgy
 from edgy.core.marshalls import ConfigMarshall, Marshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/save/test_simple_marshall.py
+++ b/tests/marshalls/save/test_simple_marshall.py
@@ -11,7 +11,7 @@ from edgy.core.marshalls import ConfigMarshall, Marshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_all.py
+++ b/tests/marshalls/test_marshall_all.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_all.py
+++ b/tests/marshalls/test_marshall_all.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_all_with_custom.py
+++ b/tests/marshalls/test_marshall_all_with_custom.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_all_with_custom.py
+++ b/tests/marshalls/test_marshall_all_with_custom.py
@@ -9,10 +9,10 @@ from pydantic import BaseModel, __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_config_errors.py
+++ b/tests/marshalls/test_marshall_config_errors.py
@@ -9,7 +9,7 @@ from edgy.exceptions import MarshallFieldDefinitionError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_config_errors.py
+++ b/tests/marshalls/test_marshall_config_errors.py
@@ -6,10 +6,10 @@ import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
 from edgy.exceptions import MarshallFieldDefinitionError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_exclude.py
+++ b/tests/marshalls/test_marshall_exclude.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_exclude.py
+++ b/tests/marshalls/test_marshall_exclude.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_import_string.py
+++ b/tests/marshalls/test_marshall_import_string.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_import_string.py
+++ b/tests/marshalls/test_marshall_import_string.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_method_field.py
+++ b/tests/marshalls/test_marshall_method_field.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_method_field.py
+++ b/tests/marshalls/test_marshall_method_field.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_source.py
+++ b/tests/marshalls/test_marshall_source.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_source.py
+++ b/tests/marshalls/test_marshall_source.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_source_from_property.py
+++ b/tests/marshalls/test_marshall_source_from_property.py
@@ -9,10 +9,10 @@ from pydantic import __version__
 import edgy
 from edgy.core.marshalls import Marshall, fields
 from edgy.core.marshalls.config import ConfigMarshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_marshall_source_from_property.py
+++ b/tests/marshalls/test_marshall_source_from_property.py
@@ -12,7 +12,7 @@ from edgy.core.marshalls.config import ConfigMarshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_simple_marshall.py
+++ b/tests/marshalls/test_simple_marshall.py
@@ -8,10 +8,10 @@ from pydantic import __version__
 
 import edgy
 from edgy.core.marshalls import ConfigMarshall, Marshall
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/marshalls/test_simple_marshall.py
+++ b/tests/marshalls/test_simple_marshall.py
@@ -11,7 +11,7 @@ from edgy.core.marshalls import ConfigMarshall, Marshall
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/metaclass/test_meta.py
+++ b/tests/metaclass/test_meta.py
@@ -1,12 +1,12 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/metaclass/test_meta.py
+++ b/tests/metaclass/test_meta.py
@@ -6,7 +6,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/metaclass/test_meta_errors.py
+++ b/tests/metaclass/test_meta_errors.py
@@ -10,7 +10,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/metaclass/test_meta_errors.py
+++ b/tests/metaclass/test_meta_errors.py
@@ -5,12 +5,12 @@ import pytest
 import edgy
 from edgy import Manager, QuerySet
 from edgy.exceptions import ForeignKeyBadConfigured, ImproperlyConfigured
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/run_sync/test_bulk_create.py
+++ b/tests/models/run_sync/test_bulk_create.py
@@ -14,7 +14,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/run_sync/test_bulk_create.py
+++ b/tests/models/run_sync/test_bulk_create.py
@@ -9,12 +9,12 @@ import pytest
 import edgy
 from edgy import run_sync
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/run_sync/test_bulk_update.py
+++ b/tests/models/run_sync/test_bulk_update.py
@@ -5,12 +5,12 @@ import pytest
 
 import edgy
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/run_sync/test_bulk_update.py
+++ b/tests/models/run_sync/test_bulk_update.py
@@ -10,7 +10,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/run_sync/test_decimal_field.py
+++ b/tests/models/run_sync/test_decimal_field.py
@@ -6,12 +6,12 @@ import pytest
 import edgy
 from edgy.core.db import fields
 from edgy.exceptions import FieldDefinitionError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/run_sync/test_decimal_field.py
+++ b/tests/models/run_sync/test_decimal_field.py
@@ -11,7 +11,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/run_sync/test_model_abstract.py
+++ b/tests/models/run_sync/test_model_abstract.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_abstract.py
+++ b/tests/models/run_sync/test_model_abstract.py
@@ -5,7 +5,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_class.py
+++ b/tests/models/run_sync/test_model_class.py
@@ -3,10 +3,10 @@ import pytest
 import edgy
 from edgy.core.db.fields.core import Field
 from edgy.exceptions import MultipleObjectsReturned, ObjectNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_class.py
+++ b/tests/models/run_sync/test_model_class.py
@@ -6,7 +6,7 @@ from edgy.exceptions import MultipleObjectsReturned, ObjectNotFound
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_count.py
+++ b/tests/models/run_sync/test_model_count.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_count.py
+++ b/tests/models/run_sync/test_model_count.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_defer.py
+++ b/tests/models/run_sync/test_model_defer.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_defer.py
+++ b/tests/models/run_sync/test_model_defer.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_distinct.py
+++ b/tests/models/run_sync/test_model_distinct.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_distinct.py
+++ b/tests/models/run_sync/test_model_distinct.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_exists.py
+++ b/tests/models/run_sync/test_model_exists.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_exists.py
+++ b/tests/models/run_sync/test_model_exists.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_first.py
+++ b/tests/models/run_sync/test_model_first.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_first.py
+++ b/tests/models/run_sync/test_model_first.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_get_or_create.py
+++ b/tests/models/run_sync/test_model_get_or_create.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_get_or_create.py
+++ b/tests/models/run_sync/test_model_get_or_create.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_get_or_none.py
+++ b/tests/models/run_sync/test_model_get_or_none.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_get_or_none.py
+++ b/tests/models/run_sync/test_model_get_or_none.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_group_by.py
+++ b/tests/models/run_sync/test_model_group_by.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_group_by.py
+++ b/tests/models/run_sync/test_model_group_by.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_inheritance.py
+++ b/tests/models/run_sync/test_model_inheritance.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_inheritance.py
+++ b/tests/models/run_sync/test_model_inheritance.py
@@ -5,7 +5,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_last.py
+++ b/tests/models/run_sync/test_model_last.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_last.py
+++ b/tests/models/run_sync/test_model_last.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_limit.py
+++ b/tests/models/run_sync/test_model_limit.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_limit.py
+++ b/tests/models/run_sync/test_model_limit.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_multiple_inheritance.py
+++ b/tests/models/run_sync/test_model_multiple_inheritance.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_multiple_inheritance.py
+++ b/tests/models/run_sync/test_model_multiple_inheritance.py
@@ -5,7 +5,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_offset.py
+++ b/tests/models/run_sync/test_model_offset.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_offset.py
+++ b/tests/models/run_sync/test_model_offset.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_only.py
+++ b/tests/models/run_sync/test_model_only.py
@@ -5,7 +5,7 @@ from edgy.exceptions import QuerySetError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_only.py
+++ b/tests/models/run_sync/test_model_only.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.exceptions import QuerySetError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_order_by.py
+++ b/tests/models/run_sync/test_model_order_by.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_order_by.py
+++ b/tests/models/run_sync/test_model_order_by.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_primary_key.py
+++ b/tests/models/run_sync/test_model_primary_key.py
@@ -4,10 +4,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_primary_key.py
+++ b/tests/models/run_sync/test_model_primary_key.py
@@ -7,7 +7,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_proxy.py
+++ b/tests/models/run_sync/test_model_proxy.py
@@ -6,7 +6,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_proxy.py
+++ b/tests/models/run_sync/test_model_proxy.py
@@ -3,10 +3,10 @@ from typing import Any
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_queryset_delete.py
+++ b/tests/models/run_sync/test_model_queryset_delete.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_queryset_delete.py
+++ b/tests/models/run_sync/test_model_queryset_delete.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_queryset_update.py
+++ b/tests/models/run_sync/test_model_queryset_update.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_queryset_update.py
+++ b/tests/models/run_sync/test_model_queryset_update.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_registry.py
+++ b/tests/models/run_sync/test_model_registry.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_registry.py
+++ b/tests/models/run_sync/test_model_registry.py
@@ -5,7 +5,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/run_sync/test_model_search.py
+++ b/tests/models/run_sync/test_model_search.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_search.py
+++ b/tests/models/run_sync/test_model_search.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_sqlalchemy.py
+++ b/tests/models/run_sync/test_model_sqlalchemy.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_sqlalchemy.py
+++ b/tests/models/run_sync/test_model_sqlalchemy.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_sync.py
+++ b/tests/models/run_sync/test_model_sync.py
@@ -5,7 +5,7 @@ from edgy import run_sync
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_sync.py
+++ b/tests/models/run_sync/test_model_sync.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import run_sync
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_update_or_create.py
+++ b/tests/models/run_sync/test_model_update_or_create.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_update_or_create.py
+++ b/tests/models/run_sync/test_model_update_or_create.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_values.py
+++ b/tests/models/run_sync/test_model_values.py
@@ -5,7 +5,7 @@ from edgy.exceptions import QuerySetError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_values.py
+++ b/tests/models/run_sync/test_model_values.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.exceptions import QuerySetError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_values_list.py
+++ b/tests/models/run_sync/test_model_values_list.py
@@ -5,7 +5,7 @@ from edgy.exceptions import QuerySetError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_values_list.py
+++ b/tests/models/run_sync/test_model_values_list.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.exceptions import QuerySetError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_models_filter.py
+++ b/tests/models/run_sync/test_models_filter.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.exceptions import ObjectNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_models_filter.py
+++ b/tests/models/run_sync/test_models_filter.py
@@ -5,7 +5,7 @@ from edgy.exceptions import ObjectNotFound
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_save.py
+++ b/tests/models/run_sync/test_save.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_save.py
+++ b/tests/models/run_sync/test_save.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_bulk_create.py
+++ b/tests/models/test_bulk_create.py
@@ -13,7 +13,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_bulk_create.py
+++ b/tests/models/test_bulk_create.py
@@ -8,12 +8,12 @@ import pytest
 
 import edgy
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_bulk_update.py
+++ b/tests/models/test_bulk_update.py
@@ -5,12 +5,12 @@ import pytest
 
 import edgy
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_bulk_update.py
+++ b/tests/models/test_bulk_update.py
@@ -10,7 +10,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_datetime.py
+++ b/tests/models/test_datetime.py
@@ -7,7 +7,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_datetime.py
+++ b/tests/models/test_datetime.py
@@ -4,10 +4,10 @@ import time
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_decimal_field.py
+++ b/tests/models/test_decimal_field.py
@@ -6,12 +6,12 @@ import pytest
 import edgy
 from edgy.core.db import fields
 from edgy.exceptions import FieldDefinitionError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_decimal_field.py
+++ b/tests/models/test_decimal_field.py
@@ -11,7 +11,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_embeddables.py
+++ b/tests/models/test_embeddables.py
@@ -5,11 +5,11 @@ import pytest
 import edgy
 from edgy.core.db.fields.base import BaseField
 from edgy.core.db.models.managers import BaseManager
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_embeddables.py
+++ b/tests/models/test_embeddables.py
@@ -9,7 +9,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_inner_select.py
+++ b/tests/models/test_inner_select.py
@@ -8,7 +8,7 @@ from edgy.contrib.multi_tenancy import TenantRegistry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/models/test_inner_select.py
+++ b/tests/models/test_inner_select.py
@@ -5,10 +5,10 @@ from pydantic import __version__
 
 import edgy
 from edgy.contrib.multi_tenancy import TenantRegistry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/models/test_lazyness.py
+++ b/tests/models/test_lazyness.py
@@ -2,7 +2,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_lazyness.py
+++ b/tests/models/test_lazyness.py
@@ -1,8 +1,8 @@
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/models/test_model_abstract.py
+++ b/tests/models/test_model_abstract.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_abstract.py
+++ b/tests/models/test_model_abstract.py
@@ -5,7 +5,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_class.py
+++ b/tests/models/test_model_class.py
@@ -3,10 +3,10 @@ import pytest
 import edgy
 from edgy.core.db.fields.base import Field
 from edgy.exceptions import MultipleObjectsReturned, ObjectNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_class.py
+++ b/tests/models/test_model_class.py
@@ -6,7 +6,7 @@ from edgy.exceptions import MultipleObjectsReturned, ObjectNotFound
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_count.py
+++ b/tests/models/test_model_count.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_count.py
+++ b/tests/models/test_model_count.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_defer.py
+++ b/tests/models/test_model_defer.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_defer.py
+++ b/tests/models/test_model_defer.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_distinct.py
+++ b/tests/models/test_model_distinct.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_distinct.py
+++ b/tests/models/test_model_distinct.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_exists.py
+++ b/tests/models/test_model_exists.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_exists.py
+++ b/tests/models/test_model_exists.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_first.py
+++ b/tests/models/test_model_first.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_first.py
+++ b/tests/models/test_model_first.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_get_or_create.py
+++ b/tests/models/test_model_get_or_create.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_get_or_create.py
+++ b/tests/models/test_model_get_or_create.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_get_or_none.py
+++ b/tests/models/test_model_get_or_none.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_get_or_none.py
+++ b/tests/models/test_model_get_or_none.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_group_by.py
+++ b/tests/models/test_model_group_by.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_group_by.py
+++ b/tests/models/test_model_group_by.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_inheritance.py
+++ b/tests/models/test_model_inheritance.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_inheritance.py
+++ b/tests/models/test_model_inheritance.py
@@ -5,7 +5,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_last.py
+++ b/tests/models/test_model_last.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_last.py
+++ b/tests/models/test_model_last.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_limit.py
+++ b/tests/models/test_model_limit.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_limit.py
+++ b/tests/models/test_model_limit.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_multiple_inheritance.py
+++ b/tests/models/test_model_multiple_inheritance.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_multiple_inheritance.py
+++ b/tests/models/test_model_multiple_inheritance.py
@@ -5,7 +5,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_multiple_primary_keys.py
+++ b/tests/models/test_model_multiple_primary_keys.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_multiple_primary_keys.py
+++ b/tests/models/test_model_multiple_primary_keys.py
@@ -5,7 +5,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_offset.py
+++ b/tests/models/test_model_offset.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_offset.py
+++ b/tests/models/test_model_offset.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_only.py
+++ b/tests/models/test_model_only.py
@@ -5,7 +5,7 @@ from edgy.exceptions import QuerySetError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_only.py
+++ b/tests/models/test_model_only.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.exceptions import QuerySetError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_order_by.py
+++ b/tests/models/test_model_order_by.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_order_by.py
+++ b/tests/models/test_model_order_by.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_primary_key.py
+++ b/tests/models/test_model_primary_key.py
@@ -4,10 +4,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_primary_key.py
+++ b/tests/models/test_model_primary_key.py
@@ -7,7 +7,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_proxy.py
+++ b/tests/models/test_model_proxy.py
@@ -6,7 +6,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_proxy.py
+++ b/tests/models/test_model_proxy.py
@@ -3,10 +3,10 @@ from typing import Any
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_queryset_delete.py
+++ b/tests/models/test_model_queryset_delete.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_queryset_delete.py
+++ b/tests/models/test_model_queryset_delete.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_queryset_update.py
+++ b/tests/models/test_model_queryset_update.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_queryset_update.py
+++ b/tests/models/test_model_queryset_update.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_registry.py
+++ b/tests/models/test_model_registry.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy import Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_registry.py
+++ b/tests/models/test_model_registry.py
@@ -5,7 +5,7 @@ from edgy import Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/models/test_model_search.py
+++ b/tests/models/test_model_search.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_search.py
+++ b/tests/models/test_model_search.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_sqlalchemy.py
+++ b/tests/models/test_model_sqlalchemy.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_sqlalchemy.py
+++ b/tests/models/test_model_sqlalchemy.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_update_or_create.py
+++ b/tests/models/test_model_update_or_create.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_update_or_create.py
+++ b/tests/models/test_model_update_or_create.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_values.py
+++ b/tests/models/test_model_values.py
@@ -5,7 +5,7 @@ from edgy.exceptions import QuerySetError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_values.py
+++ b/tests/models/test_model_values.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.exceptions import QuerySetError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_values_list.py
+++ b/tests/models/test_model_values_list.py
@@ -5,7 +5,7 @@ from edgy.exceptions import QuerySetError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_model_values_list.py
+++ b/tests/models/test_model_values_list.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.exceptions import QuerySetError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_models_filter.py
+++ b/tests/models/test_models_filter.py
@@ -2,10 +2,10 @@ import pytest
 
 import edgy
 from edgy.exceptions import ObjectNotFound
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_models_filter.py
+++ b/tests/models/test_models_filter.py
@@ -5,7 +5,7 @@ from edgy.exceptions import ObjectNotFound
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_save.py
+++ b/tests/models/test_save.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_save.py
+++ b/tests/models/test_save.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_select_related_mul.py
+++ b/tests/models/test_select_related_mul.py
@@ -8,7 +8,7 @@ from edgy.contrib.multi_tenancy import TenantRegistry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/models/test_select_related_mul.py
+++ b/tests/models/test_select_related_mul.py
@@ -5,10 +5,10 @@ from pydantic import __version__
 
 import edgy
 from edgy.contrib.multi_tenancy import TenantRegistry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/models/test_select_related_single.py
+++ b/tests/models/test_select_related_single.py
@@ -8,7 +8,7 @@ from edgy.contrib.multi_tenancy import TenantRegistry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/models/test_select_related_single.py
+++ b/tests/models/test_select_related_single.py
@@ -5,10 +5,10 @@ from pydantic import __version__
 
 import edgy
 from edgy.contrib.multi_tenancy import TenantRegistry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_error.py
+++ b/tests/prefetch/test_prefetch_error.py
@@ -8,7 +8,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_error.py
+++ b/tests/prefetch/test_prefetch_error.py
@@ -3,12 +3,12 @@ import pytest
 import edgy
 from edgy.core.db.querysets import Prefetch
 from edgy.exceptions import QuerySetError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_multiple.py
+++ b/tests/prefetch/test_prefetch_multiple.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.core.db.querysets import Prefetch
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_multiple.py
+++ b/tests/prefetch/test_prefetch_multiple.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_object.py
+++ b/tests/prefetch/test_prefetch_object.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.exceptions import QuerySetError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_object.py
+++ b/tests/prefetch/test_prefetch_object.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_related_nested.py
+++ b/tests/prefetch/test_prefetch_related_nested.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.core.db.querysets import Prefetch
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_related_nested.py
+++ b/tests/prefetch/test_prefetch_related_nested.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_related_with_select_related.py
+++ b/tests/prefetch/test_prefetch_related_with_select_related.py
@@ -2,12 +2,12 @@ import pytest
 
 import edgy
 from edgy.core.db.querysets import Prefetch
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/prefetch/test_prefetch_related_with_select_related.py
+++ b/tests/prefetch/test_prefetch_related_with_select_related.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/pydantic_tests/test_fields.py
+++ b/tests/pydantic_tests/test_fields.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/pydantic_tests/test_fields.py
+++ b/tests/pydantic_tests/test_fields.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/reflection/test_table_reflection.py
+++ b/tests/reflection/test_table_reflection.py
@@ -12,7 +12,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/reflection/test_table_reflection.py
+++ b/tests/reflection/test_table_reflection.py
@@ -12,7 +12,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/registry/test_different_registry_default.py
+++ b/tests/registry/test_different_registry_default.py
@@ -10,7 +10,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database, schema="another")
 
 

--- a/tests/registry/test_different_registry_default.py
+++ b/tests/registry/test_different_registry_default.py
@@ -5,12 +5,12 @@ import pytest
 
 import edgy
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database, schema="another")
 
 

--- a/tests/registry/test_registries.py
+++ b/tests/registry/test_registries.py
@@ -1,11 +1,11 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_ALTERNATIVE_URL, DATABASE_URL
 
-database = Database(url=DATABASE_URL)
-another_db = Database(url=DATABASE_ALTERNATIVE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+another_db = DatabaseTestClient(DATABASE_ALTERNATIVE_URL, test_prefix="")
 
 registry = edgy.Registry(database=database, extra={"alternative": another_db})
 pytestmark = pytest.mark.anyio

--- a/tests/registry/test_registries.py
+++ b/tests/registry/test_registries.py
@@ -4,8 +4,8 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_ALTERNATIVE_URL, DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
-another_db = DatabaseTestClient(DATABASE_ALTERNATIVE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
+another_db = DatabaseTestClient(DATABASE_ALTERNATIVE_URL)
 
 registry = edgy.Registry(database=database, extra={"alternative": another_db})
 pytestmark = pytest.mark.anyio

--- a/tests/registry/test_registry.py
+++ b/tests/registry/test_registry.py
@@ -4,7 +4,7 @@ import pytest
 
 import edgy
 from edgy.exceptions import SchemaError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 
@@ -20,7 +20,7 @@ def get_random_string(
     return "".join(random.choice(allowed_chars) for _ in range(length))
 
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 registry = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/registry/test_registry.py
+++ b/tests/registry/test_registry.py
@@ -20,7 +20,7 @@ def get_random_string(
     return "".join(random.choice(allowed_chars) for _ in range(length))
 
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 registry = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/signals/test_signals.py
+++ b/tests/signals/test_signals.py
@@ -12,10 +12,10 @@ from edgy.core.signals import (
     pre_update,
 )
 from edgy.exceptions import SignalError
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/signals/test_signals.py
+++ b/tests/signals/test_signals.py
@@ -15,7 +15,7 @@ from edgy.exceptions import SignalError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/tenancy/test_activate_tenant.py
+++ b/tests/tenancy/test_activate_tenant.py
@@ -10,7 +10,7 @@ from edgy.core.db.querysets.mixins import activate_schema, deactivate_schema
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_activate_tenant.py
+++ b/tests/tenancy/test_activate_tenant.py
@@ -7,10 +7,10 @@ import edgy
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db.querysets.mixins import activate_schema, deactivate_schema
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_activate_tenant_precedent.py
+++ b/tests/tenancy/test_activate_tenant_precedent.py
@@ -10,7 +10,7 @@ from edgy.core.db.querysets.mixins import activate_schema, deactivate_schema
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_activate_tenant_precedent.py
+++ b/tests/tenancy/test_activate_tenant_precedent.py
@@ -7,10 +7,10 @@ import edgy
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db.querysets.mixins import activate_schema, deactivate_schema
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_load.py
+++ b/tests/tenancy/test_load.py
@@ -9,7 +9,7 @@ from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_load.py
+++ b/tests/tenancy/test_load.py
@@ -6,10 +6,10 @@ from pydantic import __version__
 import edgy
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_mt_bulk_create.py
+++ b/tests/tenancy/test_mt_bulk_create.py
@@ -14,7 +14,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/tenancy/test_mt_bulk_create.py
+++ b/tests/tenancy/test_mt_bulk_create.py
@@ -9,12 +9,12 @@ from sqlalchemy.exc import ProgrammingError
 
 import edgy
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/tenancy/test_mt_bulk_create_different_db.py
+++ b/tests/tenancy/test_mt_bulk_create_different_db.py
@@ -14,8 +14,8 @@ from tests.settings import DATABASE_ALTERNATIVE_URL, DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
-another_db = DatabaseTestClient(DATABASE_ALTERNATIVE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
+another_db = DatabaseTestClient(DATABASE_ALTERNATIVE_URL)
 models = edgy.Registry(database=database, extra={"another": another_db})
 registry = copy.copy(models)
 registry.database = another_db

--- a/tests/tenancy/test_mt_bulk_create_different_db.py
+++ b/tests/tenancy/test_mt_bulk_create_different_db.py
@@ -9,13 +9,13 @@ import pytest
 
 import edgy
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_ALTERNATIVE_URL, DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
-another_db = Database(DATABASE_ALTERNATIVE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+another_db = DatabaseTestClient(DATABASE_ALTERNATIVE_URL, test_prefix="")
 models = edgy.Registry(database=database, extra={"another": another_db})
 registry = copy.copy(models)
 registry.database = another_db

--- a/tests/tenancy/test_normal_tenancy.py
+++ b/tests/tenancy/test_normal_tenancy.py
@@ -8,7 +8,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = edgy.Database(DATABASE_URL, test_prefix="")
+database = edgy.Database(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/tenancy/test_normal_tenancy.py
+++ b/tests/tenancy/test_normal_tenancy.py
@@ -3,13 +3,12 @@ from uuid import uuid4
 import pytest
 
 import edgy
-from edgy import Database
 from edgy.core.tenancy.utils import create_schema
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = edgy.Database(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/tenancy/test_raise_assertation_error.py
+++ b/tests/tenancy/test_raise_assertation_error.py
@@ -14,8 +14,8 @@ from tests.settings import DATABASE_ALTERNATIVE_URL, DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
-another_db = DatabaseTestClient(DATABASE_ALTERNATIVE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
+another_db = DatabaseTestClient(DATABASE_ALTERNATIVE_URL)
 models = edgy.Registry(database=database, extra={"another": another_db})
 registry = copy.copy(models)
 registry.database = another_db

--- a/tests/tenancy/test_raise_assertation_error.py
+++ b/tests/tenancy/test_raise_assertation_error.py
@@ -9,13 +9,13 @@ import pytest
 
 import edgy
 from edgy.core.db import fields
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_ALTERNATIVE_URL, DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
-another_db = Database(DATABASE_ALTERNATIVE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+another_db = DatabaseTestClient(DATABASE_ALTERNATIVE_URL, test_prefix="")
 models = edgy.Registry(database=database, extra={"another": another_db})
 registry = copy.copy(models)
 registry.database = another_db

--- a/tests/tenancy/test_select_related.py
+++ b/tests/tenancy/test_select_related.py
@@ -7,7 +7,7 @@ from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_select_related.py
+++ b/tests/tenancy/test_select_related.py
@@ -4,10 +4,10 @@ from pydantic import __version__
 from edgy import fields
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_select_related_multiple.py
+++ b/tests/tenancy/test_select_related_multiple.py
@@ -9,7 +9,7 @@ from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_select_related_multiple.py
+++ b/tests/tenancy/test_select_related_multiple.py
@@ -6,10 +6,10 @@ from pydantic import __version__
 import edgy
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_select_related_two.py
+++ b/tests/tenancy/test_select_related_two.py
@@ -9,7 +9,7 @@ from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_select_related_two.py
+++ b/tests/tenancy/test_select_related_two.py
@@ -6,10 +6,10 @@ from pydantic import __version__
 import edgy
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_tenancy_queries.py
+++ b/tests/tenancy/test_tenancy_queries.py
@@ -7,7 +7,7 @@ from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = TenantRegistry(database=database)
 
 

--- a/tests/tenancy/test_tenancy_queries.py
+++ b/tests/tenancy/test_tenancy_queries.py
@@ -4,10 +4,10 @@ from pydantic import __version__
 from edgy import fields
 from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = TenantRegistry(database=database)
 
 

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -14,7 +14,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -14,7 +14,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/test_declarative_models.py
+++ b/tests/test_declarative_models.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/test_declarative_models.py
+++ b/tests/test_declarative_models.py
@@ -1,10 +1,10 @@
 import pytest
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -6,7 +6,7 @@ from edgy import Migrate, Registry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(url=DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(url=DATABASE_URL)
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -3,10 +3,10 @@ from esmerald import Esmerald
 
 import edgy
 from edgy import Migrate, Registry
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = Database(url=DATABASE_URL)
+database = DatabaseTestClient(url=DATABASE_URL, test_prefix="")
 models = Registry(database=database)
 nother = Registry(database=database)
 

--- a/tests/uniques/test_unique.py
+++ b/tests/uniques/test_unique.py
@@ -5,12 +5,12 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/uniques/test_unique.py
+++ b/tests/uniques/test_unique.py
@@ -10,7 +10,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/uniques/test_unique_constraint.py
+++ b/tests/uniques/test_unique_constraint.py
@@ -6,12 +6,12 @@ from sqlalchemy.exc import IntegrityError
 
 import edgy
 from edgy.core.db.datastructures import UniqueConstraint
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/uniques/test_unique_constraint.py
+++ b/tests/uniques/test_unique_constraint.py
@@ -11,7 +11,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 

--- a/tests/uniques/test_unique_together.py
+++ b/tests/uniques/test_unique_together.py
@@ -5,12 +5,12 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 import edgy
-from edgy.testclient import DatabaseTestClient as Database
+from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = Database(DATABASE_URL)
+database = DatabaseTestClient(DATABASE_URL, test_prefix="")
 models = edgy.Registry(database=database)
 
 

--- a/tests/uniques/test_unique_together.py
+++ b/tests/uniques/test_unique_together.py
@@ -10,7 +10,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 


### PR DESCRIPTION
Changes:
- Fix compatibility with databasez >= 0.9.
- Allow configuring the DatabaseTestClient with environment variables,
- update ruff in pre-commit