### PR TITLE
Optimizations & server_defaults

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,17 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+### Changed
+
+- Server defaults don't trigger load after saving.
+- Less nested run_sync calls.
+
+### Fixed
+
+- `get_or_none` was not abidding embed_parent.
+
 ## 0.13.1
 
 ## Added

--- a/edgy/core/connection/registry.py
+++ b/edgy/core/connection/registry.py
@@ -65,6 +65,9 @@ class Registry:
     def init_models(
         self, *, init_column_mappers: bool = True, init_class_attrs: bool = True
     ) -> None:
+        """
+        Initializes lazy parts of models meta. Normally not needed to call.
+        """
         for model_class in self.models.values():
             model_class.meta.full_init(
                 init_column_mappers=init_column_mappers, init_class_attrs=init_class_attrs
@@ -76,6 +79,9 @@ class Registry:
             )
 
     def invalidate_models(self, *, clear_class_attrs: bool = True) -> None:
+        """
+        Invalidate all lazy parts of meta. They will automatically re-initialized on access.
+        """
         for model_class in self.models.values():
             model_class.meta.invalidate(clear_class_attrs=clear_class_attrs)
         for model_class in self.reflected.values():

--- a/tests/fields/test_server_defaults.py
+++ b/tests/fields/test_server_defaults.py
@@ -1,0 +1,60 @@
+import pytest
+
+import edgy
+from edgy.testclient import DatabaseTestClient
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+database = DatabaseTestClient(DATABASE_URL)
+models = edgy.Registry(database=database)
+
+
+class MyModel(edgy.Model):
+    first_name: str = edgy.CharField(max_length=255, server_default="edgy")
+    last_name: str = edgy.CharField(max_length=255, server_default="edge")
+
+    class Meta:
+        registry = models
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def create_test_database():
+    await models.create_all()
+    yield
+    await models.drop_all()
+
+
+@pytest.fixture(autouse=True)
+async def rollback_connections():
+    with database.force_rollback():
+        async with database:
+            yield
+
+
+async def test_partial_overwrite():
+    obj = await MyModel.query.create(first_name="foobar")
+    assert obj.first_name == "foobar"
+    assert "last_name" not in obj.__dict__
+    assert obj.last_name == "edge"
+    # lazy load
+    assert "last_name" in obj.__dict__
+
+
+async def test_export_without_load():
+    obj = await MyModel.query.create(first_name="foobar")
+    assert obj.model_dump() == {
+        "first_name": "foobar",
+    }
+
+
+async def test_export_with_implicit_load():
+    obj = await MyModel.query.create(first_name="foobar")
+    # triggers also implicit load
+    assert obj.last_name == "edge"
+    assert obj.model_dump() == {"first_name": "foobar", "last_name": "edge"}
+
+
+async def test_export_with_explicit_load():
+    obj = await MyModel.query.create(first_name="foobar")
+    await obj.load()
+    assert obj.model_dump() == {"first_name": "foobar", "last_name": "edge"}


### PR DESCRIPTION
Changes

- Server defaults don't trigger load after saving (it would break defer).
- No nested run_sync calls when using embed_parent.
- No load triggers for fully initialized models.
- Add tests for server defaults.

In short: afterward there are no code paths in queries or models which use run_sync.
run_sync is still used when accessing non-initialized fields but not in the hot code pathes