### PR TITLE
remove nest_asyncio

### DIFF
--- a/edgy/cli/operations/shell/base.py
+++ b/edgy/cli/operations/shell/base.py
@@ -3,7 +3,6 @@ import sys
 from typing import Any, Callable, Optional, Sequence
 
 import click
-import nest_asyncio
 
 from edgy import Registry
 from edgy.cli.env import MigrationEnv
@@ -58,13 +57,11 @@ async def run_shell(app: Any, lifespan: Any, registry: Registry, kernel: str) ->
             from edgy.cli.operations.shell.ipython import get_ipython
 
             ipython_shell = get_ipython(app=app, registry=registry)
-            nest_asyncio.apply()
             ipython_shell()
         else:
             from edgy.cli.operations.shell.ptpython import get_ptpython
 
             ptpython = get_ptpython(app=app, registry=registry)
-            nest_asyncio.apply()
             ptpython()
 
 

--- a/edgy/core/utils/sync.py
+++ b/edgy/core/utils/sync.py
@@ -1,10 +1,7 @@
 import asyncio
 from contextvars import copy_context
-from functools import lru_cache
 from threading import Thread
 from typing import Any, Awaitable, Optional
-
-import nest_asyncio
 
 
 async def _coro_helper(awaitable: Awaitable, timeout: Optional[float]) -> Any:
@@ -13,60 +10,32 @@ async def _coro_helper(awaitable: Awaitable, timeout: Optional[float]) -> Any:
     return await awaitable
 
 
-@lru_cache(1, False)
-def _init_nest_asyncio() -> None:
-    nest_asyncio.apply()
-
-
-def thread_run(
-    awaitable: Awaitable, future: asyncio.Future, loop: Optional[asyncio.AbstractEventLoop] = None
-) -> None:
-    close_after = False
-    if loop is None:
-        loop = asyncio.new_event_loop()
-        close_after = True
+def thread_run(awaitable: Awaitable, future: asyncio.Future) -> None:
     try:
-        assert loop is not None
-        future.set_result(loop.run_until_complete(awaitable))
+        future.set_result(asyncio.run(awaitable))
     except BaseException as exc:
         future.set_exception(exc)
-    finally:
-        if close_after:
-            loop.run_until_complete(loop.shutdown_asyncgens())
-            loop.close()
 
 
-def run_sync(
-    awaitable: Awaitable, timeout: Optional[float] = None, use_nested_loop: bool = True
-) -> Any:
+def run_sync(awaitable: Awaitable, timeout: Optional[float] = None) -> Any:
     """
     Runs the queries in sync mode
     """
-    close_after = False
     loop = None
-    if use_nested_loop:
-        _init_nest_asyncio()
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            close_after = True
-
     try:
-        if use_nested_loop:
-            assert loop is not None
-            return loop.run_until_complete(_coro_helper(awaitable, timeout))
-        else:
-            future: asyncio.Future = asyncio.Future()
-            context = copy_context()
-            thread = Thread(
-                target=context.run,
-                args=[thread_run, _coro_helper(awaitable, timeout), future, loop],
-            )
-            thread.start()
-            thread.join(timeout)
-            return future.result()
-    finally:
-        if close_after and loop is not None:
-            loop.run_until_complete(loop.shutdown_asyncgens())
-            loop.close()
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is None:
+        return asyncio.run(_coro_helper(awaitable, timeout))
+    else:
+        future: asyncio.Future = loop.create_future()
+        context = copy_context()
+        thread = Thread(
+            target=context.run,
+            args=[thread_run, _coro_helper(awaitable, timeout), future],
+        )
+        thread.start()
+        thread.join()
+        return future.result()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,10 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "nest_asyncio",
     "orjson",
     "alembic>=1.11.3,<2.0.0",
     "click>=8.1.3,<9.0.0",
-    "databasez>=0.10.0",
+    "databasez>=0.10.2",
     "loguru>=0.7.0,<0.10.0",
     "pydantic>=2.5.3,<3.0.0",
     "pydantic-settings>=2.0.0,<3.0.0",
@@ -205,7 +204,6 @@ module = [
     "sqlalchemy.*",
     "asyncpg",
     "alembic",
-    "nest_asyncio.*",
     "ptpython.*",
 ]
 ignore_missing_imports = true

--- a/tests/cli/main.py
+++ b/tests/cli/main.py
@@ -9,7 +9,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(DATABASE_URL, drop_database=True)
+database = DatabaseTestClient(DATABASE_URL, drop_database=True, test_prefix="test_")
 models = edgy.Registry(database=database)
 
 basedir = os.path.abspath(os.path.dirname(__file__))

--- a/tests/cli/main_extra.py
+++ b/tests/cli/main_extra.py
@@ -9,7 +9,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(DATABASE_URL, drop_database=True)
+database = DatabaseTestClient(DATABASE_URL, drop_database=True, test_prefix="test_")
 models = edgy.Registry(database=database)
 
 basedir = os.path.abspath(os.path.dirname(__file__))

--- a/tests/fields/test_composite_fields.py
+++ b/tests/fields/test_composite_fields.py
@@ -8,10 +8,8 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
-database = DatabaseTestClient(
-    DATABASE_URL, full_isolation=False, force_rollback=False, drop_database=True
-)
-models = edgy.Registry(database=database)
+database = DatabaseTestClient(DATABASE_URL, force_rollback=False, drop_database=True)
+models = edgy.Registry(database=edgy.Database(database))
 
 
 class PlainModel(BaseModel):
@@ -78,7 +76,8 @@ class MyModelEmbedded2(edgy.Model):
 async def create_test_database():
     async with database:
         await models.create_all()
-        yield
+        async with models.database:
+            yield
 
 
 def test_column_type():

--- a/tests/foreign_keys/test_many_to_many_field.py
+++ b/tests/foreign_keys/test_many_to_many_field.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, test_prefix="")
+database = DatabaseTestClient(DATABASE_URL)
 models = edgy.Registry(database=database)
 
 


### PR DESCRIPTION
Changes:
- remove nest_asyncio
- fixes for fixed TestClient (passes now correctly full_isolation and force_fallback through)


Note:

the tests run slightly slower. It is because of the full_isolation feature which is required for some tests with rollback.
One of the next step is to update the tests so the old performance is reached again.