### PR TITLE
contenttypes

### DIFF
--- a/docs/contenttypes/intro.md
+++ b/docs/contenttypes/intro.md
@@ -1,0 +1,44 @@
+# Contenttypes
+
+## Intro
+
+Relational database systems work with the concept of tables. Tables are independent of each other except
+for foreign keys which works nice in most cases but this design has a little drawback.
+
+Querying, iterating generically across tables and domains is hard, this is where ContentTypes come in play.
+ContentTypes abstract all the tables in one table, which is quite powerful. By having
+only one table with back links to all the other tables, it is possible to have generic tables which logic applies
+to all other tables.
+Normally you can only enforce uniqueness per table, now it this possible via the ContentType table for data
+in different tables (you just have to compress them usefully e.g. by a hash).
+
+```python
+{!> ../docs_src/contenttypes/basic.py !}
+```
+
+!!! Implementation Note
+    Because we allow all sorts of primary keys we have to inject an unique field in every model to traverse back.
+
+### Example: The art of comparing apples with pears
+
+Let's imagine we have to compare apples with pears via weight. We want only fruits with different weights.
+Because weight is a small number we just can put it in the
+collision_key field of ContentType.
+
+```python
+{!> ../docs_src/contenttypes/collision.py !}
+```
+
+If we know we compare over all domains just weight, we can
+even replace the collision_key field via an IntegerField.
+
+```python
+{!> ../docs_src/contenttypes/customized_collision.py !}
+```
+
+Or now we allow fruits with the same weight. Let's just remove the uniqueness from the collision_key field.
+
+
+```python
+{!> ../docs_src/contenttypes/customized_nocollision.py !}
+```

--- a/docs/contenttypes/intro.md
+++ b/docs/contenttypes/intro.md
@@ -42,3 +42,19 @@ Or now we allow fruits with the same weight. Let's just remove the uniqueness fr
 ```python
 {!> ../docs_src/contenttypes/customized_nocollision.py !}
 ```
+
+## Tricks
+
+### Using in libraries
+
+ContentType is always available under the name `ContentType` if activated and as a `content_type` attribute on registry.
+
+If the attribute `content_type` on registry is not None, you can be assured ContentType is available.
+
+
+### Opting out
+
+Some models may should not be referencable by ContentType.
+
+You can opt out by overwriting `content_type` on the model to opt out with any Field.
+Use `ExcludeField` to remove the field entirely.

--- a/docs/contenttypes/replace_elasticsearch.md
+++ b/docs/contenttypes/replace_elasticsearch.md
@@ -1,5 +1,6 @@
 # Building a tagged index (or replace elasticsearch)
 
+## Introduction
 Elasticsearch is a commonly used software for comparing data across domains.
 It comes at a hefty price:
 It is resource hungry and you have to leave the relational sql world for TCP which introduces round-trips on a by magnitudes
@@ -7,6 +8,8 @@ slower lane.
 
 In short: it is only useful for very big shared high performance setups. Not for yours, most probably.
 Here I explain how to do it much simpler and with way less resources in a relational db (this saves you hardware costs and shorts your electricity bill).
+
+## Setup
 
 First we need a generic table which maps to all other tables. We have ContentType. Check
 
@@ -22,7 +25,7 @@ The entries are now hashed (each entry) and afterwards a hash is build from all 
 
 
 ```python
-{!> ../docs_src/contenttypes/customized_nocollision.py !}
+{!> ../docs_src/contenttypes/contenttype_tags.py !}
 ```
 
 
@@ -33,5 +36,24 @@ collisions.
 !!! Note
     The seperator is up to you. I just `=` because I used this in the secretgraph project, but all chars are elligable. More logic you can lookup there.
 
+
+## Alternative implementations
+
+If you don't like the shared field for key value operations you may want seperate fields for both.
+Also it would be possible (for postgres and other more powerful dbs) to make the tag field unique.
+
+## Operations
+
+Searching for a key:
+
+use `registry.content_type.query.filter(tags__tag__startswith='key=')`
+
+Searching for a key and a value starting with:
+
+use `registry.content_type.query.filter(tags__tag__startswith='key=value_start')`
+
+
+
+## References
 
 [secretgraph](https://github.com/secretgraph/secretgraph)

--- a/docs/contenttypes/replace_elasticsearch.md
+++ b/docs/contenttypes/replace_elasticsearch.md
@@ -1,0 +1,37 @@
+# Building a tagged index (or replace elasticsearch)
+
+Elasticsearch is a commonly used software for comparing data across domains.
+It comes at a hefty price:
+It is resource hungry and you have to leave the relational sql world for TCP which introduces round-trips on a by magnitudes
+slower lane.
+
+In short: it is only useful for very big shared high performance setups. Not for yours, most probably.
+Here I explain how to do it much simpler and with way less resources in a relational db (this saves you hardware costs and shorts your electricity bill).
+
+First we need a generic table which maps to all other tables. We have ContentType. Check
+
+Secondly we need tags, that are text fields with a key value syntax.
+We can use TextFields for this. In my projects I use a syntax: `key=value`. Stupidly simple but you have to check that you only seperate on the first
+`=` which is a bit hard in some programming languages (use regex, e.g. `/^([^=]+)=(.*)/` for seperating in js).
+
+Third (optionally): It would be nice to detect collisions among data of different tables --> collision_key.
+For building a hash for a collision key we can leverage an hash method adapted from the rdf guys.
+
+First merge the keys with values with a seperator like `=` (or just use the tags) into an array. Sort the array.
+The entries are now hashed (each entry) and afterwards a hash is build from all the hashes as if they would be a long bytestring.
+
+
+```python
+{!> ../docs_src/contenttypes/customized_nocollision.py !}
+```
+
+
+!!! Note
+    It is crucial that each entry is mangled (either by hash or an other mangling method) because otherwise malicious users could inject `=` in the value data and provoke
+collisions.
+
+!!! Note
+    The seperator is up to you. I just `=` because I used this in the secretgraph project, but all chars are elligable. More logic you can lookup there.
+
+
+[secretgraph](https://github.com/secretgraph/secretgraph)

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -698,8 +698,9 @@ Fields have to inherit from `edgy.db.fields.base.BaseField` and to provide follo
 - `get_columns(self, field_name)` - returns the sqlalchemy columns which should be created by this field.
 - `clean(self, field_name, value, to_query=False)` - returns the cleaned column values. to_query specifies if clean is used by the query sanitizer and must be more strict (no partial values).
 
-Additional they can provide following methods:
+Additional they can provide/overwrite following methods:
 
+* `operator_to_clause` - Generates clauses for db from the result of clean. Implies clean is called with `for_query=True`.
 * `__get__(self, instance, owner=None)` - Descriptor protocol like get access customization. Second parameter contains the class where the field was specified.
   To prevent unwanted loads operate on the instance `__dict__`. You can throw an AttributeError to trigger a load.
 * `__set__(self, instance, value)` - Descriptor protocol like set access customization. Dangerous to use. Better use to_model.
@@ -729,6 +730,10 @@ You should also provide an init method which sets following attributes:
 
 `clean` is required to clean the values for the db. It has an extra parameter `for_query` which is set
 in a querying context (searching something in the db).
+
+When using a multi-column field, you can overwrite `operator_to_clause`. You may want to adjust clean called with
+`for_query=True` so it returns are suitable holder object (e.g. dict) for the fieldname.
+See `tests/fields/test_multi_column_fields.py` for an example.
 
 #### Using phases
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -367,7 +367,7 @@ See [FileField](file_handling.md#filefield).
 
 #### ImageField
 
-See [ImageField](file_handling.md#ImageField).
+See [ImageField](file_handling.md#imagefield).
 
 #### FloatField
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -703,7 +703,7 @@ Additional they can provide following methods:
 * `__get__(self, instance, owner=None)` - Descriptor protocol like get access customization. Second parameter contains the class where the field was specified.
   To prevent unwanted loads operate on the instance `__dict__`. You can throw an AttributeError to trigger a load.
 * `__set__(self, instance, value)` - Descriptor protocol like set access customization. Dangerous to use. Better use to_model.
-* `to_model(self, field_name, phase="", instance=None)` - like clean, just for setting attributes or initializing a model. It is also used when setting attributes or in initialization (phase contains the phase where it is called). This way it is much more powerful than `__set__`.
+* `to_model(self, field_name, phase="")` - like clean, just for setting attributes or initializing a model. It is also used when setting attributes or in initialization (phase contains the phase where it is called). This way it is much more powerful than `__set__`.
 * `get_embedded_fields(self, field_name, fields)` - Define internal fields.
 * `get_default_values(self, field_name, cleaned_data, is_update=False)` - returns the default values for the field. Can provide default values for embedded fields. If your field spans only one column you can also use the simplified get_default_value instead. This way you don't have to check for collisions. By default get_default_value is used internally.
 * `get_default_value(self)` - return default value for one column fields.
@@ -756,7 +756,7 @@ For getting an immutable object attached to a Model instance, there are two ways
 
 The last way is a bit more complicated than managers. You need to consider 3 ways the field is affected:
 
-1. `__init__` and `load`: Some values are passed to the field. Use `to_model` for providing an initial object with instance.
+1. `__init__` and `load`: Some values are passed to the field. Use `to_model` for providing an initial object with the CURRENT_INSTANCE context var.
     Note: this doesn't gurantee the initialization. We still need the  `__get__`-
 2. `__getattr__` here the object can get an instance it can attach to. Use `__get__` for this.
 3. Set access. Either use `__set__` or `to_model` so it uses the old value.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -26,6 +26,7 @@ hide:
 - `modify_input` receives now an argument phase.
 - `foreign_key_fields` is now a frozenset.
 - Switch away from nest_asyncio.
+- All sqlalchemy operators are now accessable. The setting for them is gone.
 
 ### Fixed
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ hide:
 - ImageField stub (more is comming soon)
 - `stage` method in relations.
 - ModelRefs passed as normal positional arguments are automatically staged.
+- ContentType was added.
 
 ### Changed
 
@@ -22,7 +23,9 @@ hide:
 - `model_references` are superseeded by `post_save_fields` in meta.
 - ModelParser mixin is gone. Use the classmethod `extract_column_values` instead.
 - edgy_settr is not used internally anymore (circular imports).
-- `modify_input` receives now an argument phase
+- `modify_input` receives now an argument phase.
+- `foreign_key_fields` is now a frozenset.
+- Switch away from nest_asyncio.
 
 ### Fixed
 

--- a/docs/tenancy/contrib.md
+++ b/docs/tenancy/contrib.md
@@ -57,7 +57,8 @@ More on this in the [example](#example) provided.
 All the needed imports are located inside the `multi_tenancy` module in `contrib`:
 
 ```python
-from edgy.contrib.multi_tenancy import TenantModel. TenantRegistry, TenancySettings
+from edgy import Registry
+from edgy.contrib.multi_tenancy import TenantModel, TenancySettings
 from edgy.contrib.multi_tenancy.models import TenantMixin, DomainMixin, TenantUserMixin
 ```
 
@@ -74,21 +75,6 @@ core functionalities but introduces a new internam `metaclass` required for the 
 
 This is how you **must** declare a model that you want it to be in your multi-tenant schemas using
 this particular module. **This is mandatory**.
-
-Did you notice that a `TenantRegistry` was used? Nothing to worry about, it is nothing completely
-new to you, it is just an inherited [registry](../registry.md) with extra properties specifically
-created for this purpose 😁.
-
-## TenantRegistry
-
-The `TenantRegistry` as mentioned above, it is just an inherited [registry](../registry.md) with extra properties specifically
-created for the purpose of useing the Edgy contrib module where it adds some extras to make this
-integration easier, such as the `tenant_models` object which is internally used to understand
-which models should be generated upon the creation of a `Tenant` automatically.
-
-```python hl_lines="2 5 8 19"
-{!> ../docs_src/tenancy/contrib/tenant_registry.py !}
-```
 
 ## TenancySettings
 

--- a/docs_src/contenttypes/basic.py
+++ b/docs_src/contenttypes/basic.py
@@ -1,0 +1,40 @@
+import edgy
+
+database = edgy.Database("sqlite:///db.sqlite")
+models = edgy.Registry(database=database, with_content_type=True)
+
+
+class Person(edgy.Model):
+    first_name = edgy.fields.CharField(max_length=100)
+    last_name = edgy.fields.CharField(max_length=100)
+
+    class Meta:
+        registry = models
+        unique_together = [("first_name", "last_name")]
+
+
+class Organisation(edgy.Model):
+    name = edgy.fields.CharField(max_length=100, unique=True)
+
+    class Meta:
+        registry = models
+
+
+class Company(edgy.Model):
+    name = edgy.fields.CharField(max_length=100, unique=True)
+
+    class Meta:
+        registry = models
+
+
+async def main():
+    async with database:
+        await models.create_all()
+        person = await Person.query.create(first_name="John", last_name="Doe")
+        org = await Organisation.query.create(name="Edgy org")
+        comp = await Company.query.create(name="Edgy inc")
+        # we all have the content_type attribute and are queryable
+        assert await models.content_type.query.count() == 3
+
+
+edgy.run_sync(main())

--- a/docs_src/contenttypes/collision.py
+++ b/docs_src/contenttypes/collision.py
@@ -1,0 +1,47 @@
+import asyncio
+
+from sqlalchemy.exc import IntegrityError
+import edgy
+
+database = edgy.Database("sqlite:///db.sqlite")
+models = edgy.Registry(database=database, with_content_type=True)
+
+
+class Apple(edgy.Model):
+    g = edgy.fields.SmallIntegerField()
+
+    class Meta:
+        registry = models
+
+
+class Pear(edgy.Model):
+    g = edgy.fields.SmallIntegerField()
+
+    class Meta:
+        registry = models
+
+
+async def main():
+    async with database:
+        await models.create_all()
+        await Apple.query.bulk_create(
+            [{"g": i, "content_type": {"collision_key": str(i)}} for i in range(1, 100, 10)]
+        )
+        apples = [
+            await asyncio.create_task(content_type.get_instance())
+            async for content_type in models.content_type.query.filter(name="Apple")
+        ]
+        try:
+            await Pear.query.bulk_create(
+                [{"g": i, "content_type": {"collision_key": str(i)}} for i in range(1, 100, 10)]
+            )
+        except IntegrityError:
+            pass
+        pears = [
+            await asyncio.create_task(content_type.get_instance())
+            async for content_type in models.content_type.query.filter(name="Pear")
+        ]
+        assert len(pears) == 0
+
+
+edgy.run_sync(main())

--- a/docs_src/contenttypes/contenttype_tags.py
+++ b/docs_src/contenttypes/contenttype_tags.py
@@ -1,0 +1,55 @@
+import edgy
+
+database = edgy.Database("sqlite:///db.sqlite")
+models = edgy.Registry(database=database, with_content_type=True)
+
+
+class ContentTypeTag(edgy.Model):
+    # this prevents the normally set ContentTypeField and replaces it with a common ForeignKey
+    content_type = edgy.fields.ForeignKey("ContentType", related_name="tags")
+    tag = edgy.fields.TextField()
+
+    class Meta:
+        registry = models
+
+
+class Person(edgy.Model):
+    first_name = edgy.fields.CharField(max_length=100)
+    last_name = edgy.fields.CharField(max_length=100)
+
+    class Meta:
+        registry = models
+        unique_together = [("first_name", "last_name")]
+
+
+class Organisation(edgy.Model):
+    name = edgy.fields.CharField(max_length=100, unique=True)
+
+    class Meta:
+        registry = models
+
+
+class Company(edgy.Model):
+    name = edgy.fields.CharField(max_length=100, unique=True)
+
+    class Meta:
+        registry = models
+
+
+async def main():
+    async with database:
+        await models.create_all()
+        person = await Person.query.create(first_name="John", last_name="Doe")
+        await person.content_type.tags.add({"tag": "name=John Doe"})
+        await person.content_type.tags.add({"tag": "type=natural_person"})
+        org = await Organisation.query.create(name="Edgy org")
+        await org.content_type.tags.add({"tag": "name=Edgy org"})
+        await org.content_type.tags.add({"tag": "type=organisation"})
+        comp = await Company.query.create(name="Edgy inc")
+        await comp.content_type.tags.add({"tag": "name=Edgy inc"})
+        await comp.content_type.tags.add({"tag": "type=organisation"})
+        # now we can query via content_type
+        assert await models.content_type.query.filter(tags__tag="type=organisation").count() == 2
+
+
+edgy.run_sync(main())

--- a/docs_src/contenttypes/customized_collision.py
+++ b/docs_src/contenttypes/customized_collision.py
@@ -1,0 +1,58 @@
+import asyncio
+
+from sqlalchemy.exc import IntegrityError
+import edgy
+from edgy import Database, Registry, run_sync
+from edgy.contrib.contenttypes import ContentType as _ContentType
+
+database = Database("sqlite:///db.sqlite")
+
+
+class ContentType(_ContentType):
+    collision_key = edgy.IntegerField(null=True, unique=True)
+
+    class Meta:
+        abstract = True
+
+
+models = Registry(database=database, with_content_type=ContentType)
+
+
+class Apple(edgy.Model):
+    g = edgy.fields.SmallIntegerField()
+
+    class Meta:
+        registry = models
+
+
+class Pear(edgy.Model):
+    g = edgy.fields.SmallIntegerField()
+
+    class Meta:
+        registry = models
+
+
+async def main():
+    async with database:
+        await models.create_all()
+        await Apple.query.bulk_create(
+            [{"g": i, "content_type": {"collision_key": i}} for i in range(1, 100, 10)]
+        )
+        apples = [
+            await asyncio.create_task(content_type.get_instance())
+            async for content_type in models.content_type.query.filter(name="Apple")
+        ]
+        try:
+            await Pear.query.bulk_create(
+                [{"g": i, "content_type": {"collision_key": i}} for i in range(1, 100, 10)]
+            )
+        except IntegrityError:
+            pass
+        pears = [
+            await asyncio.create_task(content_type.get_instance())
+            async for content_type in models.content_type.query.filter(name="Pear")
+        ]
+        assert len(pears) == 0
+
+
+run_sync(main())

--- a/docs_src/contenttypes/customized_nocollision.py
+++ b/docs_src/contenttypes/customized_nocollision.py
@@ -1,0 +1,54 @@
+import asyncio
+
+from sqlalchemy.exc import IntegrityError
+import edgy
+from edgy import Database, Registry, run_sync
+from edgy.contrib.contenttypes import ContentType as _ContentType
+
+database = Database("sqlite:///db.sqlite")
+
+
+class ContentType(_ContentType):
+    collision_key = edgy.IntegerField(null=True, unique=False)
+
+    class Meta:
+        abstract = True
+
+
+models = Registry(database=database, with_content_type=ContentType)
+
+
+class Apple(edgy.Model):
+    g = edgy.fields.SmallIntegerField()
+
+    class Meta:
+        registry = models
+
+
+class Pear(edgy.Model):
+    g = edgy.fields.SmallIntegerField()
+
+    class Meta:
+        registry = models
+
+
+async def main():
+    async with database:
+        await models.create_all()
+        await Apple.query.bulk_create(
+            [{"g": i, "content_type": {"collision_key": i}} for i in range(1, 100, 10)]
+        )
+        apples = [
+            await asyncio.create_task(content_type.get_instance())
+            async for content_type in models.content_type.query.filter(name="Apple")
+        ]
+        await Pear.query.bulk_create(
+            [{"g": i, "content_type": {"collision_key": i}} for i in range(1, 100, 10)]
+        )
+        pears = [
+            await asyncio.create_task(content_type.get_instance())
+            async for content_type in models.content_type.query.filter(name="Pear")
+        ]
+
+
+run_sync(main())

--- a/docs_src/tenancy/contrib/domain_mixin.py
+++ b/docs_src/tenancy/contrib/domain_mixin.py
@@ -1,9 +1,8 @@
 import edgy
-from edgy.contrib.multi_tenancy import TenantRegistry
 from edgy.contrib.multi_tenancy.models import DomainMixin, TenantMixin
 
 database = edgy.Database("<YOUR-CONNECTION-STRING>")
-registry = TenantRegistry(database=database)
+registry = edgy.Registry(database=database)
 
 
 class Tenant(TenantMixin):

--- a/docs_src/tenancy/contrib/example/models.py
+++ b/docs_src/tenancy/contrib/example/models.py
@@ -1,9 +1,9 @@
 import edgy
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import DomainMixin, TenantMixin, TenantUserMixin
 
 database = edgy.Database("<YOUR-CONNECTION-STRING>")
-registry = TenantRegistry(database=database)
+registry = edgy.Registry(database=database)
 
 
 class Tenant(TenantMixin):

--- a/docs_src/tenancy/contrib/tenant_mixin.py
+++ b/docs_src/tenancy/contrib/tenant_mixin.py
@@ -1,9 +1,8 @@
 import edgy
-from edgy.contrib.multi_tenancy import TenantRegistry
 from edgy.contrib.multi_tenancy.models import TenantMixin
 
 database = edgy.Database("<YOUR-CONNECTION-STRING>")
-registry = TenantRegistry(database=database)
+registry = edgy.Registry(database=database)
 
 
 class Tenant(TenantMixin):

--- a/docs_src/tenancy/contrib/tenant_model.py
+++ b/docs_src/tenancy/contrib/tenant_model.py
@@ -1,8 +1,8 @@
 import edgy
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy.contrib.multi_tenancy import TenantModel
 
 database = edgy.Database("<YOUR-CONNECTION-STRING>")
-registry = TenantRegistry(database=database)
+registry = edgy.Registry(database=database)
 
 
 class User(TenantModel):

--- a/docs_src/tenancy/contrib/tenant_registry.py
+++ b/docs_src/tenancy/contrib/tenant_registry.py
@@ -1,5 +1,0 @@
-import edgy
-from edgy.contrib.multi_tenancy import TenantRegistry
-
-database = edgy.Database("<YOUR-CONNECTION-STRING>")
-registry = TenantRegistry(database=database)

--- a/docs_src/tenancy/contrib/tenant_user_mixin.py
+++ b/docs_src/tenancy/contrib/tenant_user_mixin.py
@@ -1,9 +1,8 @@
 import edgy
-from edgy.contrib.multi_tenancy import TenantRegistry
 from edgy.contrib.multi_tenancy.models import DomainMixin, TenantMixin, TenantUserMixin
 
 database = edgy.Database("<YOUR-CONNECTION-STRING>")
-registry = TenantRegistry(database=database)
+registry = edgy.Registry(database=database)
 
 
 class Tenant(TenantMixin):

--- a/edgy/conf/global_settings.py
+++ b/edgy/conf/global_settings.py
@@ -35,16 +35,4 @@ class EdgySettings(MediaSettings):
     ptpython_config_file: str = "~/.config/ptpython/config.py"
 
     # General settings
-    filter_operators: Dict[str, str] = {
-        "exact": "__eq__",
-        "iexact": "ilike",
-        "contains": "like",
-        "icontains": "ilike",
-        "in": "in_",
-        "gt": "__gt__",
-        "gte": "__ge__",
-        "lt": "__lt__",
-        "lte": "__le__",
-    }
-    many_to_many_relation: str = "relation_{key}"
     dialects: Dict[str, str] = {"postgres": "postgres", "postgresql": "postgresql"}

--- a/edgy/contrib/contenttypes/__init__.py
+++ b/edgy/contrib/contenttypes/__init__.py
@@ -1,0 +1,4 @@
+from .fields import ContentTypeField
+from .models import ContentType
+
+__all__ = ["ContentTypeField", "ContentType"]

--- a/edgy/contrib/contenttypes/fields.py
+++ b/edgy/contrib/contenttypes/fields.py
@@ -1,0 +1,49 @@
+from functools import cached_property
+from typing import Any, Dict
+
+from edgy.core.db.fields.foreign_keys import BaseForeignKeyField, ForeignKey
+from edgy.core.terminal import Print
+
+terminal = Print()
+
+
+class BaseGenericForeignKeyField(BaseForeignKeyField):
+    pass
+
+
+class GenericForeignKey(ForeignKey):
+    field_bases = (BaseGenericForeignKeyField,)
+
+    @classmethod
+    def validate(cls, kwargs: Dict[str, Any]) -> None:
+        super().validate(kwargs)
+        for argument in ["related_name", "reverse_name", "unique", "null"]:
+            if kwargs.get(argument):
+                terminal.write_warning(
+                    f"Declaring `{argument}` on a GenericForeignKey has no effect."
+                )
+        kwargs.pop("related_name", None)
+        kwargs.pop("reverse_name", None)
+        kwargs["unique"] = True
+        kwargs["null"] = False
+        kwargs.setdefault(
+            "default", lambda owner: owner.registry["ContentType"](model_name=owner.__name__)
+        )
+
+    @cached_property
+    def reverse_name(self) -> str:
+        return f"reverse_{self.owner.__name__.lower()}"
+
+    @cached_property
+    def related_name(self) -> str:
+        return f"reverse_{self.owner.__name__.lower()}"
+
+    def has_default(self) -> bool:
+        return True
+
+    def get_default_value(self) -> Any:
+        default = getattr(self, "default", None)
+        if callable(default):
+            # WARNING: here defaults are called with the owner
+            return default(self.owner)
+        return default

--- a/edgy/contrib/contenttypes/fields.py
+++ b/edgy/contrib/contenttypes/fields.py
@@ -12,6 +12,17 @@ terminal = Print()
 
 
 class BaseContentTypeFieldField(BaseForeignKeyField):
+    async def pre_save_callback(
+        self, value: Any, original_value: Any, instance: "BaseModelType"
+    ) -> Any:
+        target = self.target
+        if value is None or (isinstance(value, dict) and not value):
+            value = original_value
+        # e.g. default was a Model
+        if isinstance(value, (target, target.proxy_model)):
+            value.name = self.owner.__name__
+        return await super().pre_save_callback(value, original_value, instance=instance)
+
     def get_default_value(self) -> Any:
         default = getattr(self, "default", None)
         if callable(default):

--- a/edgy/contrib/contenttypes/fields.py
+++ b/edgy/contrib/contenttypes/fields.py
@@ -13,7 +13,7 @@ terminal = Print()
 
 class BaseContentTypeFieldField(BaseForeignKeyField):
     async def pre_save_callback(
-        self, value: Any, original_value: Any, instance: "BaseModelType"
+        self, value: Any, original_value: Any, force_insert: bool, instance: "BaseModelType"
     ) -> Any:
         target = self.target
         if value is None or (isinstance(value, dict) and not value):
@@ -21,7 +21,9 @@ class BaseContentTypeFieldField(BaseForeignKeyField):
         # e.g. default was a Model
         if isinstance(value, (target, target.proxy_model)):
             value.name = self.owner.__name__
-        return await super().pre_save_callback(value, original_value, instance=instance)
+        return await super().pre_save_callback(
+            value, original_value, force_insert=force_insert, instance=instance
+        )
 
     def get_default_value(self) -> Any:
         default = getattr(self, "default", None)

--- a/edgy/contrib/contenttypes/models.py
+++ b/edgy/contrib/contenttypes/models.py
@@ -7,11 +7,12 @@ class ContentType(edgy.Model):
     class Meta:
         abstract = True
 
+    # NOTE: model_ is a private namespace of pydantic
     # model names shouldn't be so long, maybe a check would be appropriate
-    model_name: str = edgy.fields.CharField(max_length=100)
+    name: str = edgy.fields.CharField(max_length=100)
     hash_key: str = edgy.fields.CharField(max_length=255, null=True, unique=True)
 
     def get_models(self) -> Any:
         # FIXME: the return type should be MultiRelation/Queryset
-        reverse_name = f"reverse_{self.model_name.lower()}"
+        reverse_name = f"reverse_{self.name.lower()}"
         return getattr(self, reverse_name)

--- a/edgy/contrib/contenttypes/models.py
+++ b/edgy/contrib/contenttypes/models.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+import edgy
+
+
+class ContentType(edgy.Model):
+    class Meta:
+        abstract = True
+
+    # model names shouldn't be so long, maybe a check would be appropriate
+    model_name: str = edgy.fields.CharField(max_length=100)
+    hash_key: str = edgy.fields.CharField(max_length=255, null=True, unique=True)
+
+    def get_models(self) -> Any:
+        # FIXME: the return type should be MultiRelation/Queryset
+        reverse_name = f"reverse_{self.model_name.lower()}"
+        return getattr(self, reverse_name)

--- a/edgy/contrib/contenttypes/models.py
+++ b/edgy/contrib/contenttypes/models.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import edgy
 
 
@@ -10,9 +8,9 @@ class ContentType(edgy.Model):
     # NOTE: model_ is a private namespace of pydantic
     # model names shouldn't be so long, maybe a check would be appropriate
     name: str = edgy.fields.CharField(max_length=100)
-    hash_key: str = edgy.fields.CharField(max_length=255, null=True, unique=True)
+    # can be a hash or similar. For checking collisions cross domain
+    collision_key: str = edgy.fields.CharField(max_length=255, null=True, unique=True)
 
-    def get_models(self) -> Any:
-        # FIXME: the return type should be MultiRelation/Queryset
+    async def get_instance(self) -> edgy.Model:
         reverse_name = f"reverse_{self.name.lower()}"
-        return getattr(self, reverse_name)
+        return await getattr(self, reverse_name).get()

--- a/edgy/contrib/contenttypes/models.py
+++ b/edgy/contrib/contenttypes/models.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING, cast
+
 import edgy
+
+if TYPE_CHECKING:
+    from edgy.core.db.querysets.base import QuerySet
 
 
 class ContentType(edgy.Model):
@@ -13,4 +18,4 @@ class ContentType(edgy.Model):
 
     async def get_instance(self) -> edgy.Model:
         reverse_name = f"reverse_{self.name.lower()}"
-        return await getattr(self, reverse_name).get()
+        return await cast("QuerySet", getattr(self, reverse_name)).get()

--- a/edgy/contrib/contenttypes/models.py
+++ b/edgy/contrib/contenttypes/models.py
@@ -12,7 +12,7 @@ class ContentType(edgy.Model):
 
     # NOTE: model_ is a private namespace of pydantic
     # model names shouldn't be so long, maybe a check would be appropriate
-    name: str = edgy.fields.CharField(max_length=100)
+    name: str = edgy.fields.CharField(max_length=100, default="")
     # can be a hash or similar. For checking collisions cross domain
     collision_key: str = edgy.fields.CharField(max_length=255, null=True, unique=True)
 

--- a/edgy/contrib/multi_tenancy/models.py
+++ b/edgy/contrib/multi_tenancy/models.py
@@ -10,6 +10,7 @@ from edgy import settings
 from edgy.contrib.multi_tenancy.utils import create_tables
 from edgy.core.db.models.model import Model
 from edgy.core.db.models.utils import get_model
+from edgy.core.utils.db import check_db_connection
 from edgy.exceptions import ModelSchemaError, ObjectNotFound
 
 
@@ -120,7 +121,8 @@ class DomainMixin(edgy.Model):
         values: Dict[str, Any] = None,
         **kwargs: Any,
     ) -> Model:
-        async with self.meta.registry.database.transaction():
+        check_db_connection(self.database)
+        async with self.database as database, database.transaction():
             domains = self.__class__.query.filter(tenant=self.tenant, is_primary=True).exclude(
                 pk=self.pk
             )

--- a/edgy/contrib/multi_tenancy/registry.py
+++ b/edgy/contrib/multi_tenancy/registry.py
@@ -1,10 +1,3 @@
-from typing import Any, Dict
+from edgy.core.connection.registry import Registry as TenantRegistry
 
-from edgy.core.connection.database import Database
-from edgy.core.connection.registry import Registry
-
-
-class TenantRegistry(Registry):
-    def __init__(self, database: Database, **kwargs: Any) -> None:
-        super().__init__(database, **kwargs)
-        self.tenant_models: Dict[str, Any] = {}
+__all__ = ["TenantRegistry"]

--- a/edgy/core/connection/registry.py
+++ b/edgy/core/connection/registry.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Any, Dict, List, Mapping, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Mapping, Type, Union, cast
 
 import sqlalchemy
 from sqlalchemy import Engine
@@ -8,6 +8,11 @@ from sqlalchemy.orm import declarative_base as sa_declarative_base
 
 from edgy.core.connection.database import Database, DatabaseURL
 from edgy.core.connection.schemas import Schema
+from edgy.core.utils.models import create_edgy_model
+
+if TYPE_CHECKING:
+    from edgy.core.db.fields.types import BaseFieldType
+    from edgy.core.db.models.types import BaseModelType
 
 
 class Registry:
@@ -16,29 +21,104 @@ class Registry:
     """
 
     db_schema: Union[str, None] = None
+    content_type: Union[Type["BaseModelType"], None]
 
-    def __init__(self, database: Union[Database, str, DatabaseURL], **kwargs: Any) -> None:
+    def __init__(
+        self,
+        database: Union[Database, str, DatabaseURL],
+        *,
+        with_content_type: Union[bool, Type["BaseModelType"]] = False,
+        **kwargs: Any,
+    ) -> None:
         self.db_schema = kwargs.pop("schema", None)
         extra = kwargs.pop("extra", {})
         self.database: Database = (
             database if isinstance(database, Database) else Database(database, **kwargs)
         )
-        self.models: Dict[str, Any] = {}
-        self.reflected: Dict[str, Any] = {}
+        self.models: Dict[str, Type[BaseModelType]] = {}
+        self.reflected: Dict[str, Type[BaseModelType]] = {}
+        self.tenant_models: Dict[str, Type[BaseModelType]] = {}
+        # when setting a Model or Reflected Model execute the callbacks
+        # Note: they are only executed if the Model is not in Registry yet
+        self._onetime_callbacks: Dict[
+            Union[str, None], List[Callable[[Type[BaseModelType]], None]]
+        ] = {}
+        self._callbacks: Dict[Union[str, None], List[Callable[[Type[BaseModelType]], None]]] = {}
+
         self.extra: Mapping[str, Database] = {
             k: v if isinstance(v, Database) else Database(v) for k, v in extra.items()
         }
-        # when setting a Model or Reflected Model execute the callbacks
-        self._callbacks: Dict[str, List[Any]] = {}
 
         self.schema = Schema(registry=self)
-        self.tenant_models: Dict[str, Any] = {}
 
         self._metadata: sqlalchemy.MetaData = (
             sqlalchemy.MetaData(schema=self.db_schema)
             if self.db_schema is not None
             else sqlalchemy.MetaData()
         )
+        if with_content_type is not False:
+            self._set_content_type(with_content_type)
+
+    def _set_content_type(
+        self, with_content_type: Union[Literal[True], Type["BaseModelType"]]
+    ) -> None:
+        from edgy.contrib.contenttypes.fields import BaseGenericForeignKeyField, GenericForeignKey
+        from edgy.contrib.contenttypes.models import ContentType
+        from edgy.core.db.models.metaclasses import MetaInfo
+        from edgy.core.db.relationships.related_field import RelatedField
+
+        if with_content_type is True:
+            with_content_type = ContentType
+
+        real_content_type: Type[BaseModelType] = with_content_type
+
+        if real_content_type.meta.abstract:
+            meta_args = {
+                "tablename": "contenttypes",
+                "registry": self,
+            }
+
+            new_meta: MetaInfo = MetaInfo(None, **meta_args)
+            real_content_type = create_edgy_model(
+                "ContentType",
+                with_content_type.__module__,
+                __metadata__=new_meta,
+                __bases__=(with_content_type,),
+            )
+            self.models["ContentType"] = real_content_type
+        self.content_type = real_content_type
+
+        def callback(model_class: Type["BaseModelType"]) -> None:
+            # they are not updated, despite this shouldn't happen anyway
+            if issubclass(model_class, ContentType):
+                return
+            # skip if is explicit set
+            for field in model_class.meta.fields.values():
+                if isinstance(field, BaseGenericForeignKeyField):
+                    return
+            # e.g. exclude field
+            if "content_type" not in model_class.meta.fields:
+                related_name = f"reverse_{model_class.__name__.lower()}"
+                assert (
+                    related_name not in real_content_type.meta.fields
+                ), f"duplicate model name: {model_class.__name__}"
+                model_class.meta.fields["content_type"] = cast(
+                    "BaseFieldType",
+                    GenericForeignKey(
+                        name="content_type", owner=model_class, to=real_content_type, registry=self
+                    ),
+                )
+                real_content_type.fields[related_name] = RelatedField(
+                    name=related_name,
+                    foreign_key_name="content_type",
+                    related_from=model_class,
+                    owner=real_content_type,
+                    registry=real_content_type.meta.registry,
+                )
+                if real_content_type.meta._is_init:
+                    real_content_type.meta.post_save_fields.add(related_name)
+
+        self.register_callback(None, callback, one_time=False)
 
     @property
     def metadata(self) -> Any:
@@ -49,6 +129,56 @@ class Registry:
     @metadata.setter
     def metadata(self, value: sqlalchemy.MetaData) -> None:
         self._metadata = value
+
+    def register_callback(
+        self,
+        name_or_class: Union[Type["BaseModelType"], str, None],
+        callback: Callable[[Type["BaseModelType"]], None],
+        one_time: bool,
+    ) -> None:
+        if name_or_class is not None and not isinstance(name_or_class, str):
+            name_or_class = name_or_class.__name__
+        called: bool = False
+        if name_or_class is None:
+            for model in self.models.values():
+                callback(model)
+                called = True
+            for model in self.reflected.values():
+                callback(model)
+                called = True
+        else:
+            if name_or_class in self.models:
+                callback(self.models[name_or_class])
+                called = True
+            elif name_or_class in self.reflected:
+                callback(self.reflected[name_or_class])
+                called = True
+        if called and one_time:
+            return
+        if one_time:
+            self._onetime_callbacks.setdefault(name_or_class, []).append(callback)
+        else:
+            self._callbacks.setdefault(name_or_class, []).append(callback)
+
+    def execute_model_callbacks(self, model_class: Type["BaseModelType"]) -> None:
+        name = model_class.__name__
+        callbacks = self._onetime_callbacks.get(name)
+        while callbacks:
+            callbacks.pop()(model_class)
+
+        callbacks = self._onetime_callbacks.get(None)
+        while callbacks:
+            callbacks.pop()(model_class)
+
+        callbacks = self._callbacks.get(name)
+        if callbacks:
+            for callback in callbacks:
+                callback(model_class)
+
+        callbacks = self._callbacks.get(None)
+        if callbacks:
+            for callback in callbacks:
+                callback(model_class)
 
     @cached_property
     def declarative_base(self) -> Any:

--- a/edgy/core/connection/registry.py
+++ b/edgy/core/connection/registry.py
@@ -32,6 +32,7 @@ class Registry:
         self._callbacks: Dict[str, List[Any]] = {}
 
         self.schema = Schema(registry=self)
+        self.tenant_models: Dict[str, Any] = {}
 
         self._metadata: sqlalchemy.MetaData = (
             sqlalchemy.MetaData(schema=self.db_schema)

--- a/edgy/core/connection/schemas.py
+++ b/edgy/core/connection/schemas.py
@@ -54,6 +54,7 @@ class Schema:
             except ProgrammingError as e:
                 raise SchemaError(detail=e.orig.args[0]) from e  # type: ignore
 
+        # don't check inperformance here
         async with self.database as database:
             with database.force_rollback(False):
                 await database.run_sync(execute_create)

--- a/edgy/core/db/context_vars.py
+++ b/edgy/core/db/context_vars.py
@@ -1,6 +1,12 @@
 from contextvars import ContextVar
-from typing import Literal, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
+if TYPE_CHECKING:
+    from edgy.core.db.models.types import BaseModelType
+
+CURRENT_INSTANCE: ContextVar[Optional["BaseModelType"]] = ContextVar(
+    "CURRENT_INSTANCE", default=None
+)
 MODEL_GETATTR_BEHAVIOR: ContextVar[Literal["passdown", "load", "coro"]] = ContextVar(
     "MODEL_GETATTR_BEHAVIOR", default="load"
 )

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -402,19 +402,10 @@ class PKField(BaseCompositeField):
 
 class BaseForeignKey(RelationshipField):
     is_m2m: bool = False
-
-    def __init__(
-        self,
-        *,
-        related_name: Union[str, Literal[False]] = "",
-        reverse_name: str = "",
-        **kwargs: Any,
-    ) -> None:
-        self.related_name = related_name
-        # name used for backward relations
-        # only useful if related_name = False because otherwise it gets overwritten
-        self.reverse_name = reverse_name
-        super().__init__(**kwargs)
+    related_name: Union[str, Literal[False]] = ""
+    # name used for backward relations
+    # only useful if related_name = False because otherwise it gets overwritten
+    reverse_name: str = ""
 
     @property
     def target(self) -> Any:

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -103,7 +103,7 @@ class BaseField(BaseFieldType, FieldInfo):
                 value = f"%{value}%"
             clause_fn = column.ilike if operator[0] == "i" else column.like
             clause = clause_fn(value)
-            clause.modifiers["escape"] = "\\" if has_escaped_character else None
+            clause.modifiers["escape"] = "\\" if has_escaped_character else None  # type: ignore
             return clause
         return getattr(column, operator)(value)
 

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -221,7 +221,6 @@ class BaseCompositeField(BaseField):
         field_name: str,
         value: Any,
         phase: str = "",
-        instance: Optional["BaseModelType"] = None,
     ) -> Dict[str, Any]:
         """
         Runs the checks for the fields being validated.
@@ -239,11 +238,7 @@ class BaseCompositeField(BaseField):
                 if phase == "init" or phase == "init_db":
                     continue
                 raise ErrorType(f"Missing sub-field: {sub_name} for {field_name}")
-            result.update(
-                field.to_model(
-                    sub_name, value.get(translated_name, None), phase=phase, instance=instance
-                )
-            )
+            result.update(field.to_model(sub_name, value.get(translated_name, None), phase=phase))
         return result
 
     def get_default_values(
@@ -380,8 +375,8 @@ class PKField(BaseCompositeField):
             and not isinstance(value, (dict, BaseModel))
         ):
             field = self.owner.meta.fields[pknames[0]]
-            return field.to_model(pknames[0], value, phase=phase, instance=instance)
-        return super().to_model(field_name, value, phase=phase, instance=instance)
+            return field.to_model(pknames[0], value, phase=phase)
+        return super().to_model(field_name, value, phase=phase)
 
     def get_composite_fields(self) -> Dict[str, BaseFieldType]:
         return {
@@ -460,6 +455,5 @@ class BaseForeignKey(RelationshipField):
         field_name: str,
         value: Any,
         phase: str = "",
-        instance: Optional["BaseModelType"] = None,
     ) -> Dict[str, Any]:
         return {field_name: self.expand_relationship(value)}

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -446,7 +446,8 @@ class BaseForeignKey(RelationshipField):
             delattr(self, "_target")
 
     def is_cross_db(self) -> bool:
-        return self.owner.meta.registry is not self.target.meta.registry
+        # self.registry should be self.owner.meta.registry
+        return self.registry is not self.target.meta.registry
 
     def expand_relationship(self, value: Any) -> Any:
         """

--- a/edgy/core/db/fields/composite_field.py
+++ b/edgy/core/db/fields/composite_field.py
@@ -188,7 +188,6 @@ class ConcreteCompositeField(BaseCompositeField):
         field_name: str,
         value: Any,
         phase: str = "",
-        instance: Optional["BaseModelType"] = None,
     ) -> Dict[str, Any]:
         assert len(self.inner_field_names) >= 1
         if (
@@ -198,7 +197,7 @@ class ConcreteCompositeField(BaseCompositeField):
             and not isinstance(value, (dict, BaseModel))
         ):
             field = self.owner.meta.fields[self.inner_field_names[0]]
-            return field.to_model(self.inner_field_names[0], value, phase=phase, instance=instance)
+            return field.to_model(self.inner_field_names[0], value, phase=phase)
         return super().to_model(field_name, value, phase=phase)
 
     def get_embedded_fields(

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -18,8 +18,6 @@ from edgy.core.db.fields.types import BaseFieldType
 from edgy.exceptions import FieldDefinitionError
 
 if TYPE_CHECKING:
-    from edgy.core.db.models.types import BaseModelType
-
     try:
         import zoneinfo  # type: ignore[import-not-found, unused-ignore]
     except ImportError:
@@ -282,7 +280,6 @@ class TimezonedField:
         field_name: str,
         value: Any,
         phase: str = "",
-        instance: Optional["BaseModelType"] = None,
     ) -> Dict[str, Optional[Union[datetime.datetime, datetime.date]]]:
         """
         Convert input object to datetime

--- a/edgy/core/db/fields/exclude_field.py
+++ b/edgy/core/db/fields/exclude_field.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, Dict, Type
 
 from edgy.core.db.fields.factories import FieldFactory
 
@@ -42,7 +42,6 @@ class ExcludeField(FieldFactory, Type[None]):
         name: str,
         value: Any,
         phase: str = "",
-        instance: Optional["BaseModelType"] = None,
         original_fn: Any = None,
     ) -> Dict[str, Any]:
         """remove any value from input and raise when setting an attribute."""

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -159,13 +159,10 @@ class ForeignKeyFieldFactory(FieldFactory):
         cls,
         *,
         to: Any = None,
-        null: bool = False,
         on_update: str = CASCADE,
         on_delete: str = RESTRICT,
         related_name: Union[str, Literal[False]] = "",
         server_onupdate: Any = None,
-        default: Any = None,
-        server_default: Any = None,
         **kwargs: Dict[str, Any],
     ) -> BaseFieldType:
         kwargs = {
@@ -181,7 +178,8 @@ class ForeignKeyFieldFactory(FieldFactory):
         """default validation useful for one_to_one and foreign_key"""
         on_delete = kwargs.get("on_delete", CASCADE)
         on_update = kwargs.get("on_update", RESTRICT)
-        null = kwargs.get("null", False)
+        kwargs.setdefault("null", False)
+        null = kwargs["null"]
 
         if on_delete is None:
             raise FieldDefinitionError("on_delete must not be null.")
@@ -199,3 +197,4 @@ class ForeignKeyFieldFactory(FieldFactory):
 
         if related_name:
             kwargs["related_name"] = related_name.lower()
+        kwargs.setdefault("default", None)

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -70,7 +70,6 @@ class FieldFactory(metaclass=FieldFactoryMeta):
         pydantic_type = cls.get_pydantic_type(**kwargs)
         constraints = cls.get_constraints(**kwargs)
         default: None = kwargs.pop("default", None)
-        server_default: None = kwargs.pop("server_default", None)
 
         new_field = cls._get_field_cls(cls)
 
@@ -79,7 +78,6 @@ class FieldFactory(metaclass=FieldFactoryMeta):
             annotation=pydantic_type,
             column_type=column_type,
             default=default,
-            server_default=server_default,
             constraints=constraints,
             factory=cls,
             **kwargs,

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -18,6 +18,7 @@ from typing import (
 import orjson
 import sqlalchemy
 
+from edgy.core.db.context_vars import CURRENT_INSTANCE
 from edgy.core.db.fields.base import BaseCompositeField
 from edgy.core.db.fields.core import BigIntegerField, BooleanField, JSONField
 from edgy.core.db.fields.factories import FieldFactory
@@ -73,7 +74,6 @@ class ConcreteFileField(BaseCompositeField):
         field_name: str,
         value: Any,
         phase: str = "",
-        instance: Optional["BaseModelType"] = None,
     ) -> Dict[str, Any]:
         """
         Inverse of clean. Transforms column(s) to a field for a pydantic model (EdgyBaseModel).
@@ -86,6 +86,7 @@ class ConcreteFileField(BaseCompositeField):
             phase: the phase (set, creation, ...)
 
         """
+        instance = CURRENT_INSTANCE.get()
         if (
             phase in {"post_update", "post_insert"}
             and instance is not None

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -59,7 +59,7 @@ class BaseForeignKeyField(BaseForeignKey):
             await value.save()
             return self.clean(self.name, value, for_query=False)
         elif isinstance(value, dict):
-            return await self.pre_save_callback(target(**value))
+            return await self.pre_save_callback(target(**value), None, instance=instance)
         return {self.name: value}
 
     def get_relation(self, **kwargs: Any) -> ManyRelationProtocol:

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 from edgy.core.db.constants import CASCADE
+from edgy.core.db.context_vars import CURRENT_INSTANCE
 from edgy.core.db.fields.base import BaseForeignKey
 from edgy.core.db.fields.factories import ForeignKeyFieldFactory
 from edgy.core.db.fields.foreign_keys import ForeignKey
@@ -171,7 +172,8 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
                     self.from_foreign_key = candidate
                 if not self.to_foreign_key:
                     candidate = None
-                    for field_name, field in through.meta.foreign_key_fields.items():
+                    for field_name in through.meta.foreign_key_fields:
+                        field = through.meta.fields[field_name]
                         if field.target == self.to:
                             if candidate:
                                 raise ValueError("multiple foreign keys to target")
@@ -261,11 +263,11 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         field_name: str,
         value: Any,
         phase: str = "",
-        instance: Optional["BaseModelType"] = None,
     ) -> Dict[str, Any]:
         """
         Meta field
         """
+        instance = CURRENT_INSTANCE.get()
         if isinstance(value, ManyRelationProtocol):
             return {field_name: value}
         if instance:

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -152,14 +152,15 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         if self.through:
             if isinstance(self.through, str):
                 self.through = self.registry.models[self.through]
-            through = cast(Type["BaseModelType"], self.through)
+            through = self.through
             if through.meta.abstract:
                 pknames = set(cast(Sequence[str], through.pknames))
                 __bases__ = (through,)
             else:
                 if not self.from_foreign_key:
                     candidate = None
-                    for field_name, field in through.meta.foreign_key_fields.items():
+                    for field_name in through.meta.foreign_key_fields:
+                        field = through.meta.fields[field_name]
                         if field.target == self.owner:
                             if candidate:
                                 raise ValueError("multiple foreign keys to owner")

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -103,7 +103,6 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         field_name: str,
         value: Any,
         phase: str = "",
-        instance: Optional[BaseModelType] = None,
     ) -> Dict[str, Any]:
         """
         Inverse of clean. Transforms column(s) to a field for a pydantic model (EdgyBaseModel).

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -10,6 +10,7 @@ from edgy.core.connection.registry import Registry
 from edgy.types import Undefined
 
 if TYPE_CHECKING:
+    from edgy.core.db.fields.factories import FieldFactory
     from edgy.core.db.models.metaclasses import MetaInfo
     from edgy.core.db.models.types import BaseModelType
 
@@ -50,13 +51,15 @@ class BaseFieldDefinitions:
     skip_absorption_check: bool = False
     registry: Optional[Registry] = None
     field_type: Any = Any
-    factory: Any = None
+    factory: Optional[FieldFactory] = None
+
     __original_type__: Any = None
     name: str = ""
     secret: bool = False
     exclude: bool = False
     owner: Any = None
     default: Any = Undefined
+    server_default: Any = None
 
     # column specific
     primary_key: bool = False

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -88,6 +88,15 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         Returns the columns of the field being declared.
         """
 
+    def operator_to_clause(
+        self, field_name: str, operator: str, table: sqlalchemy.Table, value: Any
+    ) -> Any:
+        """
+        Analyzes the operator and build a clause from it.
+        Needs to be able to handle "exact".
+        """
+        raise NotImplementedError()
+
     def clean(self, field_name: str, value: Any, for_query: bool = False) -> Dict[str, Any]:
         """
         Validates a value and transform it into columns which can be used for querying and saving.

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -23,7 +23,7 @@ import sqlalchemy
 from pydantic import BaseModel, ConfigDict
 from pydantic_core._pydantic_core import SchemaValidator as SchemaValidator
 
-from edgy.core.db.context_vars import MODEL_GETATTR_BEHAVIOR
+from edgy.core.db.context_vars import CURRENT_INSTANCE, MODEL_GETATTR_BEHAVIOR
 from edgy.core.db.datastructures import Index, UniqueConstraint
 from edgy.core.db.models.managers import Manager, RedirectManager
 from edgy.core.db.models.metaclasses import BaseModelMeta, MetaInfo
@@ -111,17 +111,21 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
         new_kwargs: Dict[str, Any] = {}
 
         fields = cls.meta.fields
-        # phase 1: transform
-        # Note: this is order dependend. There should be no overlap.
-        for field_name in cls.meta.input_modifying_fields:
-            fields[field_name].modify_input(field_name, kwargs, phase=phase)
-        # phase 2: apply to_model
-        for key, value in kwargs.items():
-            field = fields.get(key, None)
-            if field is not None:
-                new_kwargs.update(**field.to_model(key, value, phase=phase, instance=instance))
-            else:
-                new_kwargs[key] = value
+        token = CURRENT_INSTANCE.set(instance)
+        try:
+            # phase 1: transform
+            # Note: this is order dependend. There should be no overlap.
+            for field_name in cls.meta.input_modifying_fields:
+                fields[field_name].modify_input(field_name, kwargs, phase=phase)
+            # phase 2: apply to_model
+            for key, value in kwargs.items():
+                field = fields.get(key, None)
+                if field is not None:
+                    new_kwargs.update(**field.to_model(key, value, phase=phase))
+                else:
+                    new_kwargs[key] = value
+        finally:
+            CURRENT_INSTANCE.reset(token)
         return new_kwargs
 
     def setup_model_from_kwargs(self, kwargs: Any) -> Any:
@@ -136,8 +140,12 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
 
     def __str__(self) -> str:
         pkl = []
-        for pkname in self.pknames:
-            pkl.append(f"{pkname}={getattr(self, pkname, None)}")
+        token = MODEL_GETATTR_BEHAVIOR.set("passdown")
+        try:
+            for pkname in self.pknames:
+                pkl.append(f"{pkname}={getattr(self, pkname, None)}")
+        finally:
+            MODEL_GETATTR_BEHAVIOR.reset(token)
         return f"{self.__class__.__name__}({', '.join(pkl)})"
 
     @cached_property
@@ -259,9 +267,6 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
         Generates a proxy model for each model. This proxy model is a simple
         shallow copy of the original model being generated.
         """
-        if cls.__proxy_model__:
-            return cls.__proxy_model__
-
         fields = {key: copy.copy(field) for key, field in cls.meta.fields.items()}
         proxy_model = ProxyModel(
             name=cls.__name__,
@@ -429,11 +434,28 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
         """
         return sqlalchemy.Index(index.name, *index.fields)  # type: ignore
 
+    async def execute_pre_save_hooks(self, values: Dict[str, Any]) -> None:
+        affected_fields = self.meta.pre_save_fields.intersection(values.keys())
+        if affected_fields:
+            # don't trigger loads
+            token = MODEL_GETATTR_BEHAVIOR.set("passdown")
+            token2 = CURRENT_INSTANCE.set(self)
+            try:
+                for field_name in affected_fields:
+                    if field_name not in values:
+                        continue
+                    field = self.meta.fields[field_name]
+                    values.update(await field.pre_save_callback(values[field_name], instance=self))
+            finally:
+                MODEL_GETATTR_BEHAVIOR.reset(token)
+                CURRENT_INSTANCE.reset(token2)
+
     async def execute_post_save_hooks(self, fields: Sequence[str]) -> None:
         affected_fields = self.meta.post_save_fields.intersection(fields)
         if affected_fields:
             # don't trigger loads, AttributeErrors are used for skipping fields
             token = MODEL_GETATTR_BEHAVIOR.set("passdown")
+            token2 = CURRENT_INSTANCE.set(self)
             try:
                 for field_name in affected_fields:
                     field = self.meta.fields[field_name]
@@ -444,6 +466,7 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
                     await field.post_save_callback(value, instance=self)
             finally:
                 MODEL_GETATTR_BEHAVIOR.reset(token)
+                CURRENT_INSTANCE.reset(token2)
 
     @classmethod
     def extract_column_values(
@@ -487,6 +510,7 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
         if need_second_pass:
             for field in need_second_pass:
                 # check if field appeared e.g. by composite
+                # Note: default values are directly passed without validation
                 if field.name not in validated:
                     validated.update(
                         field.get_default_values(field.name, validated, is_update=is_update)
@@ -496,18 +520,22 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
     def __setattr__(self, key: str, value: Any) -> None:
         fields = self.meta.fields
         field = fields.get(key, None)
-        if field is not None:
-            if hasattr(field, "__set__"):
-                # not recommended, better to use to_model instead except for kept objects
-                # used in related_fields to mask and not to implement to_model
-                field.__set__(self, value)
+        token = CURRENT_INSTANCE.set(self)
+        try:
+            if field is not None:
+                if hasattr(field, "__set__"):
+                    # not recommended, better to use to_model instead except for kept objects
+                    # used in related_fields to mask and not to implement to_model
+                    field.__set__(self, value)
+                else:
+                    for k, v in field.to_model(key, value, phase="set").items():
+                        # bypass __setattr__ method
+                        object.__setattr__(self, k, v)
             else:
-                for k, v in field.to_model(key, value, phase="set", instance=self).items():
-                    # bypass __setattr__ method
-                    object.__setattr__(self, k, v)
-        else:
-            # bypass __setattr__ method
-            object.__setattr__(self, key, value)
+                # bypass __setattr__ method
+                object.__setattr__(self, key, value)
+        finally:
+            CURRENT_INSTANCE.reset(token)
 
     async def _agetattr_helper(self, name: str, getter: Any) -> Any:
         await self.load()

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -285,7 +285,7 @@ class MetaInfo:
             for attr in ("_table", "_pknames", "_pkcolumns", "_db_schemas"):
                 with contextlib.suppress(AttributeError):
                     delattr(self.model, attr)
-
+            # FIXME: clumsy and imperformant, make proxy_model lazy
             proxy_model = self.model.generate_proxy_model()
             self.model.__proxy_model__ = proxy_model
             self.model.__proxy_model__.__parent__ = self.model
@@ -668,11 +668,6 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
 
         # Ensure the initialization is only performed for subclasses of EdgyBaseModel
         attrs["__init_annotations__"] = annotations
-
-        # Ensure initialization is only performed for subclasses of EdgyBaseModel
-        # (excluding the EdgyBaseModel class itself).
-        if not parents:
-            return model_class(cls, name, bases, attrs, **kwargs)
 
         new_class = cast(Type["Model"], model_class(cls, name, bases, attrs, **kwargs))
         meta.model = new_class

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -614,6 +614,11 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
                         raise ImproperlyConfigured(
                             f"Cannot create model {name}. No primary key found and reflected."
                         )
+                    elif registry.database.url.scheme.startswith("sqlite"):
+                        # sqlite special we cannot have a big IntegerField as PK
+                        fields["id"] = edgy_fields.IntegerField(
+                            primary_key=True, autoincrement=True, inherit=False, name="id"
+                        )  # type: ignore
                     else:
                         fields["id"] = edgy_fields.BigIntegerField(
                             primary_key=True, autoincrement=True, inherit=False, name="id"
@@ -868,7 +873,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
         return cast("sqlalchemy.Table", schema_obj)
 
     @property
-    def proxy_model(cls) -> Any:
+    def proxy_model(cls: Type["Model"]) -> Any:
         """
         Returns the proxy_model from the Model when called using the cache.
         """

--- a/edgy/core/db/models/mixins/row.py
+++ b/edgy/core/db/models/mixins/row.py
@@ -92,7 +92,8 @@ class ModelRowMixin:
         # Populate the related names
         # Making sure if the model being queried is not inside a select related
         # This way it is not overritten by any value
-        for related, foreign_key in cls.meta.foreign_key_fields.items():
+        for related in cls.meta.foreign_key_fields:
+            foreign_key = cls.meta.fields[related]
             ignore_related: bool = cls.__should_ignore_related_name(related, select_related)
             if ignore_related or related in cls.meta.secret_fields:
                 continue

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -92,7 +92,9 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
             check_db_connection(self.database)
             async with self.database as database, database.transaction():
                 # can update column_values
-                column_values.update(await self.execute_pre_save_hooks(column_values, kwargs))
+                column_values.update(
+                    await self.execute_pre_save_hooks(column_values, kwargs, force_insert=False)
+                )
                 expression = (
                     self.table.update().values(**column_values).where(*self.identifying_clauses())
                 )
@@ -173,7 +175,9 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         check_db_connection(self.database)
         async with self.database as database, database.transaction():
             # can update column_values
-            column_values.update(await self.execute_pre_save_hooks(column_values, kwargs))
+            column_values.update(
+                await self.execute_pre_save_hooks(column_values, kwargs, force_insert=True)
+            )
             expression = self.table.insert().values(**column_values)
             autoincrement_value = await database.execute(expression)
         # sqlalchemy supports only one autoincrement column

--- a/edgy/core/db/models/model_proxy.py
+++ b/edgy/core/db/models/model_proxy.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING, Any, Dict, Tuple, Type, Union, cast
 from pydantic import ConfigDict
 
 if TYPE_CHECKING:
-    from edgy import Model
     from edgy.core.db.models.metaclasses import MetaInfo
+    from edgy.core.db.models.types import BaseModelType
 
 
 class ProxyModel:
@@ -18,7 +18,7 @@ class ProxyModel:
         name: str,
         module: str,
         *,
-        bases: Union[Tuple[Type["Model"]], None] = None,
+        bases: Union[Tuple[Type["BaseModelType"]], None] = None,
         definitions: Union[Dict[Any, Any], None] = None,
         metadata: Union[Type["MetaInfo"], None] = None,
         qualname: Union[str, None] = None,
@@ -28,7 +28,7 @@ class ProxyModel:
     ) -> None:
         self.__name__: str = name
         self.__module__: str = module
-        self.__bases__: Union[Tuple[Type[Model]], None] = bases
+        self.__bases__: Union[Tuple[Type[BaseModelType]], None] = bases
         self.__definitions__: Union[Dict[Any, Any], None] = definitions
         self.__metadata__: Union[Type[MetaInfo], None] = metadata
         self.__qualname__: Union[str, None] = qualname
@@ -43,7 +43,7 @@ class ProxyModel:
         """
         from edgy.core.utils.models import create_edgy_model
 
-        model: Type[Model] = create_edgy_model(
+        model: Type[BaseModelType] = create_edgy_model(
             __name__=self.__name__,
             __module__=self.__module__,
             __bases__=self.__bases__,
@@ -58,11 +58,11 @@ class ProxyModel:
         return self
 
     @property
-    def model(self) -> Type["Model"]:
-        return cast(Type["Model"], self.__model__)
+    def model(self) -> Type["BaseModelType"]:
+        return cast(Type["BaseModelType"], self.__model__)
 
     @model.setter
-    def model(self, value: Type["Model"]) -> None:
+    def model(self, value: Type["BaseModelType"]) -> None:
         self.__model__ = value  # type: ignore
 
     def __repr__(self) -> str:

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -155,7 +155,16 @@ class BaseModelType(ABC):
     async def execute_post_save_hooks(self, fields: Sequence[str]) -> None: ...
 
     @abstractmethod
-    async def execute_pre_save_hooks(self, values: Dict[str, Any]) -> Dict[str, Any]: ...
+    async def execute_pre_save_hooks(
+        self, values: Dict[str, Any], original: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        For async operations after clean. Can be used to reintroduce stripped values for save.
+        The async operations run in a transaction with save or update. This allows to intervene with the operation.
+        Has also access to the defaults and can transform them.
+
+        Returns: column values for saving.
+        """
 
     @classmethod
     @abstractmethod

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -152,7 +152,10 @@ class BaseModelType(ABC):
         """
 
     @abstractmethod
-    async def execute_post_save_hooks(self) -> None: ...
+    async def execute_post_save_hooks(self, fields: Sequence[str]) -> None: ...
+
+    @abstractmethod
+    async def execute_pre_save_hooks(self, values: Dict[str, Any]) -> Dict[str, Any]: ...
 
     @classmethod
     @abstractmethod

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -156,7 +156,7 @@ class BaseModelType(ABC):
 
     @abstractmethod
     async def execute_pre_save_hooks(
-        self, values: Dict[str, Any], original: Dict[str, Any]
+        self, values: Dict[str, Any], original: Dict[str, Any], force_insert: bool
     ) -> Dict[str, Any]:
         """
         For async operations after clean. Can be used to reintroduce stripped values for save.

--- a/edgy/core/db/models/utils.py
+++ b/edgy/core/db/models/utils.py
@@ -15,10 +15,7 @@ def get_model(registry: "Registry", model_name: str) -> "Model":
 
     Raise lookup error if no model is found.
     """
-    try:
-        return cast("Model", registry.models[model_name])
-    except KeyError:
-        raise LookupError(f"Registry doesn't have a {model_name} model.") from None
+    return cast("Model", registry.get_model(model_name))
 
 
 def build_pknames(model_class: Any) -> None:

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -1138,7 +1138,7 @@ class QuerySet(BaseQuerySet):
                 if self.model_class.meta.post_save_fields:
                     new_objs.append(obj)
             original = obj.extract_db_fields()
-            col_values = obj.extract_column_values(original)
+            col_values: Dict[str, Any] = obj.extract_column_values(original)
             col_values.update(await obj.execute_pre_save_hooks(col_values, original))
             return col_values
 

--- a/edgy/core/db/relationships/related_field.py
+++ b/edgy/core/db/relationships/related_field.py
@@ -1,7 +1,8 @@
 import functools
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, Tuple, Type, cast
 
+from edgy.core.db.context_vars import CURRENT_INSTANCE
 from edgy.core.db.fields.base import RelationshipField
 from edgy.core.db.fields.foreign_keys import BaseForeignKeyField
 from edgy.protocols.many_relationship import ManyRelationProtocol
@@ -49,11 +50,11 @@ class RelatedField(RelationshipField):
         field_name: str,
         value: Any,
         phase: str = "",
-        instance: Optional["BaseModelType"] = None,
     ) -> Dict[str, Any]:
         """
         Meta field
         """
+        instance = CURRENT_INSTANCE.get()
         if isinstance(value, ManyRelationProtocol):
             return {field_name: value}
         if instance:

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -137,8 +137,7 @@ class ManyRelation(ManyRelationProtocol):
         child = self.expand_relationship(child)
         # try saving intermediate model. If it fails another instance already exists and return None
         try:
-            async with child.database.transaction():
-                return await child.save(force_save=True)
+            return await child.save(force_save=True)
         except IntegrityError:
             pass
         return None
@@ -247,14 +246,6 @@ class SingleRelation(ManyRelationProtocol):
         related_columns = self.to.meta.fields[self.to_foreign_key].related_columns.keys()
         if len(related_columns) == 1 and not isinstance(value, (dict, BaseModel)):
             value = {next(iter(related_columns)): value}
-        if isinstance(value, dict):
-            for key in related_columns:
-                if value.get(key) is None:
-                    return None
-        else:
-            for key in related_columns:
-                if getattr(value, key, None) is None:
-                    return None
         instance = target.proxy_model(**value)
         instance.identifying_db_fields = related_columns
         return instance

--- a/edgy/core/db/relationships/utils.py
+++ b/edgy/core/db/relationships/utils.py
@@ -7,7 +7,6 @@ from typing import (
     Union,
 )
 
-from edgy.conf import settings
 from edgy.core.db.fields.base import BaseForeignKey, RelationshipField
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -58,7 +57,7 @@ def crawl_relationship(
             else:
                 forward_prefix_path = field_name
         elif len(splitted) == 2:
-            if "__" not in splitted[1] and splitted[1] in settings.filter_operators:
+            if "__" not in splitted[1]:
                 operator = splitted[1]
                 break
             else:

--- a/edgy/core/files/base.py
+++ b/edgy/core/files/base.py
@@ -182,8 +182,6 @@ class File:
 
         Args:
             mode (str, optional): The mode in which to open the file. If not provided, uses the existing mode.
-            *args: Positional arguments to be passed to the `open` function.
-            **kwargs: Keyword arguments to be passed to the `open` function.
 
         Returns:
             File: The opened file.

--- a/edgy/core/marshalls/fields.py
+++ b/edgy/core/marshalls/fields.py
@@ -22,10 +22,10 @@ class BaseMarshallField(FieldInfo, _repr.Representation):
         self.field_type = field_type
         super().__init__(**kwargs)
 
-        if self.null and default is Undefined:
-            self.default = None
         if default is not Undefined:
             self.default = default
+        elif self.null:
+            self.default = None
 
     def is_required(self) -> bool:
         """Check if the argument is required.

--- a/edgy/core/utils/db.py
+++ b/edgy/core/utils/db.py
@@ -1,0 +1,18 @@
+import warnings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from edgy.core.connection.database import Database
+
+
+def check_db_connection(db: "Database") -> None:
+    if not db.is_connected:
+        # with force_rollback the effects are even worse, so fail
+        if db.force_rollback:
+            raise RuntimeError("db is not connected.")
+        # db engine will be created and destroyed afterwards
+        warnings.warn(
+            "Database not connected. Executing operation is inperformant.",
+            UserWarning,
+            stacklevel=2,
+        )

--- a/edgy/core/utils/models.py
+++ b/edgy/core/utils/models.py
@@ -24,7 +24,7 @@ def create_edgy_model(
     Generates an `edgy.Model` with all the required definitions to generate the pydantic
     like model.
     """
-    from edgy.core.db.models import Model
+    from edgy.core.db.models.model import Model
 
     if not __bases__:
         __bases__ = (Model,)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,9 @@ nav:
       - Reference ForeignKey: "reference-foreignkey.md"
       - Marshalls: "marshalls.md"
       - Connection: "connection.md"
+      - ContentTypes:
+          - Introduction: "contenttypes/intro.md"
+          - ContentTags - or how to replace elastic search: "contenttypes/replace_elasticsearch.md"
       - Tenancy:
           - Edgy: "tenancy/edgy.md"
           - Contrib: "tenancy/contrib.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "orjson",
     "alembic>=1.11.3,<2.0.0",
     "click>=8.1.3,<9.0.0",
-    "databasez>=0.10.2",
+    "databasez>=0.10.3",
     "loguru>=0.7.0,<0.10.0",
     "pydantic>=2.5.3,<3.0.0",
     "pydantic-settings>=2.0.0,<3.0.0",
@@ -100,7 +100,7 @@ jdbc = ["databasez[jdbc]"]
 all = ["edgy[test,mime,image,postgres,mysql,sqlite,mssql,jdbc]", "ipython", "ptpython"]
 
 [tool.hatch.envs.default]
-dependencies = ["pre-commit>=2.17.0,<4.0.0"]
+dependencies = ["pre-commit>=2.17.0,<4.0.0", "edgy[sqlite]"]
 
 [tool.hatch.envs.default.scripts]
 clean_pyc = "find . -type f -name \"*.pyc\" -delete"

--- a/tests/cli/utils.py
+++ b/tests/cli/utils.py
@@ -4,6 +4,7 @@ import subprocess
 
 def run_cmd(app, cmd, is_app=True):
     env = dict(os.environ)
+    env.setdefault("PYTHONPATH", env["PWD"])
     if is_app:
         env["EDGY_DEFAULT_APP"] = app
     cmd = f"hatch --env test run {cmd}"

--- a/tests/contrib/contenttypes/test_contenttypes.py
+++ b/tests/contrib/contenttypes/test_contenttypes.py
@@ -1,0 +1,89 @@
+import pytest
+
+import edgy
+from edgy.contrib.contenttypes.fields import ContentTypeField
+from edgy.testclient import DatabaseTestClient
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+
+database = DatabaseTestClient(DATABASE_URL, use_existing=False)
+models = edgy.Registry(database=edgy.Database(database), with_content_type=True)
+
+
+class ContentTypeTag(edgy.Model):
+    ctype = edgy.fields.ForeignKey(to="ContentType", related_name="tags")
+    tag = edgy.fields.CharField(max_length=50)
+
+    content_type = edgy.fields.ExcludeField()
+
+    class Meta:
+        registry = models
+
+
+class Organisation(edgy.Model):
+    name = edgy.fields.CharField(max_length=100, unique=True)
+
+    class Meta:
+        registry = models
+
+
+class Company(edgy.Model):
+    name = edgy.fields.CharField(max_length=100, unique=True)
+
+    class Meta:
+        registry = models
+
+
+class Person(edgy.Model):
+    first_name = edgy.fields.CharField(max_length=100)
+    last_name = edgy.fields.CharField(max_length=100)
+    # to defaults to ContentType
+    c = ContentTypeField()
+
+    class Meta:
+        registry = models
+        unique_together = [("first_name", "last_name")]
+
+
+class Profile(edgy.Model):
+    id = edgy.IntegerField(primary_key=True)
+    website = edgy.CharField(max_length=100)
+    person = edgy.OneToOneField(
+        Person,
+        on_delete=edgy.CASCADE,
+    )
+
+    class Meta:
+        registry = models
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def create_test_database():
+    async with database:
+        await models.create_all()
+        yield
+        if not database.drop:
+            await models.drop_all()
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def rollback_transactions():
+    async with models.database:
+        yield
+
+
+async def test_auto_created_contenttypes():
+    model1 = await Company.query.create(name="edgy inc")
+    model2 = await Organisation.query.create(name="edgy inc")
+    assert model1.content_type.id is not None
+    assert model1.content_type.name == "Company"
+    assert model2.content_type.id is not None
+    assert model2.content_type.name == "Organisation"
+    tag = await model2.content_type.tags.add({"tag": "foo"})
+    with pytest.raises(ValueError):
+        tag.content_type  # noqa
+
+
+async def test_collision():
+    pass

--- a/tests/contrib/contenttypes/test_contenttypes.py
+++ b/tests/contrib/contenttypes/test_contenttypes.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from sqlalchemy.exc import IntegrityError
 
@@ -81,6 +83,14 @@ async def test_default_contenttypes():
     assert await model_after_load.content_type.get_instance() == model1
     # count
     assert await models.content_type.query.count() == 2
+    # fetch_all
+    [await content_type.get_instance() for content_type in await models.content_type.query.all()]
+    # iterate
+    with pytest.warns(UserWarning):
+        ops = [
+            content_type.get_instance() async for content_type in models.content_type.query.all()
+        ]
+    await asyncio.gather(*ops)
 
 
 async def test_different_named_contenttypes():

--- a/tests/contrib/contenttypes/test_contenttypes.py
+++ b/tests/contrib/contenttypes/test_contenttypes.py
@@ -90,8 +90,7 @@ async def test_default_contenttypes():
     assert model_after_load.content_type.id is not None
     # defer
     assert model_after_load.content_type.name == "Company"
-    # FIXME: get_instance is missing in proxy_type
-    # assert await model_after_load.content_type.get_instance() == model1
+    assert await model_after_load.content_type.get_instance() == model1
 
 
 async def test_explicit_contenttypes():
@@ -109,8 +108,7 @@ async def test_explicit_contenttypes():
     assert model_after_load.content_type.id is not None
     # defer
     assert model_after_load.content_type.name == "Company"
-    # FIXME: get_instance is missing in proxy_type
-    # assert await model_after_load.content_type.get_instance() == model1
+    assert await model_after_load.content_type.get_instance() == model1
 
 
 async def test_collision():

--- a/tests/contrib/contenttypes/test_contenttypes_custom.py
+++ b/tests/contrib/contenttypes/test_contenttypes_custom.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from sqlalchemy.exc import IntegrityError
 
@@ -92,6 +94,14 @@ async def test_default_contenttypes():
     # defer
     assert model_after_load.content_type.name == "Company"
     assert await model_after_load.content_type.get_instance() == model1
+    # fetch_all
+    [await content_type.get_instance() for content_type in await models.content_type.query.all()]
+    # iterate
+    with pytest.warns(UserWarning):
+        ops = [
+            content_type.get_instance() async for content_type in models.content_type.query.all()
+        ]
+    await asyncio.gather(*ops)
 
 
 async def test_explicit_contenttypes():

--- a/tests/contrib/contenttypes/test_contenttypes_custom.py
+++ b/tests/contrib/contenttypes/test_contenttypes_custom.py
@@ -98,8 +98,7 @@ async def test_default_contenttypes():
     assert model_after_load.content_type.id is not None
     # defer
     assert model_after_load.content_type.name == "Company"
-    # FIXME: get_instance is missing in proxy_type
-    # assert await model_after_load.content_type.get_instance() == model1
+    assert await model_after_load.content_type.get_instance() == model1
 
 
 async def test_explicit_contenttypes():
@@ -117,5 +116,4 @@ async def test_explicit_contenttypes():
     assert model_after_load.content_type.id is not None
     # defer
     assert model_after_load.content_type.name == "Company"
-    # FIXME: get_instance is missing in proxy_type
-    # assert await model_after_load.content_type.get_instance() == model1
+    assert await model_after_load.content_type.get_instance() == model1

--- a/tests/contrib/contenttypes/test_contenttypes_iterate.py
+++ b/tests/contrib/contenttypes/test_contenttypes_iterate.py
@@ -1,0 +1,84 @@
+import asyncio
+
+import pytest
+
+import edgy
+from edgy.contrib.contenttypes.fields import ContentTypeField
+from edgy.testclient import DatabaseTestClient
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+
+database = DatabaseTestClient(DATABASE_URL, force_rollback=False, full_isolation=False)
+models = edgy.Registry(database=database, with_content_type=True)
+
+
+class ContentTypeTag(edgy.Model):
+    ctype = edgy.fields.ForeignKey(to="ContentType", related_name="tags")
+    tag = edgy.fields.CharField(max_length=50)
+
+    content_type = edgy.fields.ExcludeField()
+
+    class Meta:
+        registry = models
+
+
+class Organisation(edgy.Model):
+    name = edgy.fields.CharField(max_length=100, unique=True)
+
+    class Meta:
+        registry = models
+
+
+class Company(edgy.Model):
+    name = edgy.fields.CharField(max_length=100, unique=True)
+
+    class Meta:
+        registry = models
+
+
+class Person(edgy.Model):
+    first_name = edgy.fields.CharField(max_length=100)
+    last_name = edgy.fields.CharField(max_length=100)
+    # to defaults to ContentType
+    c = ContentTypeField()
+
+    class Meta:
+        registry = models
+        unique_together = [("first_name", "last_name")]
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def create_test_database():
+    async with database:
+        await models.create_all()
+        yield
+        if not database.drop:
+            await models.drop_all()
+
+
+async def test_iterate():
+    model1 = await Company.query.create(name="edgy inc")
+    model2 = await Organisation.query.create(name="edgy inc")
+    assert model1.content_type.id is not None
+    assert model1.content_type.name == "Company"
+    assert model2.content_type.id is not None
+    assert model2.content_type.name == "Organisation"
+    tag = await model2.content_type.tags.add({"tag": "foo"})
+    with pytest.raises(ValueError):
+        tag.content_type  # noqa
+    model_after_load = await Company.query.get(id=model1.id)
+    assert model_after_load.content_type.id is not None
+    # defer
+    assert model_after_load.content_type.name == "Company"
+    assert await model_after_load.content_type.get_instance() == model1
+    # count
+    assert await models.content_type.query.count() == 2
+    # iterate
+    # we need create_task otherwise the connection is reused
+    [
+        await asyncio.create_task(content_type.get_instance())
+        async for content_type in models.content_type.query.all()
+    ]
+
+    # we cannot iterate without deadlocking because of force_rollback

--- a/tests/contrib/multi_tenancy/test_mt_models.py
+++ b/tests/contrib/multi_tenancy/test_mt_models.py
@@ -6,7 +6,8 @@ from uuid import UUID
 
 import pytest
 
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy import Registry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields
 from edgy.exceptions import ModelSchemaError
@@ -14,7 +15,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = Registry(database=database)
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/contrib/multi_tenancy/test_tenant_models_using.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_using.py
@@ -2,14 +2,15 @@ from datetime import datetime
 
 import pytest
 
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy import Registry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = Registry(database=database)
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/contrib/multi_tenancy/test_tenant_models_using_operations.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_using_operations.py
@@ -2,7 +2,8 @@ from datetime import datetime
 
 import pytest
 
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy import Registry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields
 from edgy.exceptions import ObjectNotFound
@@ -10,7 +11,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = Registry(database=database)
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/contrib/multi_tenancy/test_tenant_models_working.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_working.py
@@ -2,14 +2,15 @@ from datetime import datetime
 
 import pytest
 
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy import Registry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = Registry(database=database)
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/fields/test_defaults.py
+++ b/tests/fields/test_defaults.py
@@ -1,0 +1,41 @@
+import pytest
+
+import edgy
+from edgy.testclient import DatabaseTestClient
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+database = DatabaseTestClient(DATABASE_URL)
+models = edgy.Registry(database=edgy.Database(database, force_rollback=True))
+
+
+class MyModel(edgy.Model):
+    name: str = edgy.CharField(max_length=150)
+    weight: float = edgy.FloatField(default=0.0)
+
+    class Meta:
+        registry = models
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def create_test_database():
+    async with database:
+        await models.create_all()
+        yield
+        if not database.drop:
+            await models.drop_all()
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def rollback_transactions():
+    async with models.database:
+        yield
+
+
+async def test_defaults():
+    model = (await MyModel.query.get_or_create(name="01", defaults={"weight": 30}))[0]
+    assert model.weight == 30
+    assert model.name == "01"
+    await MyModel.query.filter(name="01").update(name="02")
+    model2 = await MyModel.query.get(name="02")
+    assert model2.weight == 30

--- a/tests/fields/test_multi_column_fields.py
+++ b/tests/fields/test_multi_column_fields.py
@@ -53,9 +53,7 @@ class MultiColumnFieldInner(BaseField):
                 "inner": kwargs.pop(field_name + "_inner", normal),
             }
 
-    def to_model(
-        self, field_name: str, value: Any, phase: str = "", instance=None
-    ) -> Dict[str, Any]:
+    def to_model(self, field_name: str, value: Any, phase: str = "") -> Dict[str, Any]:
         if isinstance(value, str):
             return {field_name: {"normal": value, "inner": value}}
         return {field_name: value}

--- a/tests/fields/test_multi_column_fields.py
+++ b/tests/fields/test_multi_column_fields.py
@@ -7,6 +7,7 @@ import edgy
 from edgy.core.db.fields.base import BaseField
 from edgy.core.db.fields.core import FieldFactory
 from edgy.core.db.fields.types import ColumnDefinitionModel
+from edgy.core.db.querysets.clauses import and_
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
@@ -16,6 +17,15 @@ models = edgy.Registry(database=database)
 
 
 class MultiColumnFieldInner(BaseField):
+    def operator_to_clause(
+        self, field_name: str, operator: str, table: sqlalchemy.Table, value: Any
+    ) -> Any:
+        # after clean
+        return and_(
+            super().operator_to_clause(field_name, operator, table, value["normal"]),
+            super().operator_to_clause(field_name + "_inner", operator, table, value["inner"]),
+        )
+
     def get_columns(self, field_name: str) -> Sequence[sqlalchemy.Column]:
         model = ColumnDefinitionModel.model_validate(self, from_attributes=True)
         return [
@@ -33,13 +43,19 @@ class MultiColumnFieldInner(BaseField):
             ),
         ]
 
-    def clean(self, field_name: str, value: Any, for_query: bool = False) -> Dict[str, Any]:
-        """
-        Runs the checks for the fields being validated.
-        """
+    def _clean(self, field_name: str, value: Any) -> Dict[str, Any]:
         if isinstance(value, str):
             return {field_name: value, field_name + "_inner": value}
         return {field_name: value["normal"], field_name + "_inner": value["inner"]}
+
+    def clean(self, field_name: str, value: Any, for_query: bool = False) -> Dict[str, Any]:
+        if for_query:
+            # we need to wrap for operators
+            result = self._clean("normal", value)
+            result["inner"] = result.pop("normal_inner")
+            return {field_name: result}
+        else:
+            return self._clean(field_name, value)
 
     def modify_input(self, field_name: str, kwargs: Any, phase: str = "") -> None:
         if field_name not in kwargs and field_name + "_inner" not in kwargs:
@@ -94,11 +110,14 @@ async def test_create_and_assign(create_test_database):
     assert obj.multi["normal"] == "edgy"
     assert obj.multi["inner"] == "edgytoo"
     assert hasattr(MyModel.table.columns, "multi_inner")
+    assert await MyModel.query.filter(multi__exact={"normal": "edgy", "inner": "edgytoo"}).exists()
+    assert await MyModel.query.filter(multi__startswith="edgy").exists()
     obj.multi = "test"
     assert obj.multi["normal"] == "test"
     assert obj.multi["inner"] == "test"
     await obj.save()
     assert await MyModel.query.filter(MyModel.table.columns.multi_inner == "test").exists()
+    assert await MyModel.query.filter(multi="test").exists()
     assert obj.multi["inner"] == "test"
 
     obj.multi = {"normal": "edgy", "inner": "foo"}

--- a/tests/integration/test_esmerald_tenant.py
+++ b/tests/integration/test_esmerald_tenant.py
@@ -8,7 +8,8 @@ from httpx import ASGITransport, AsyncClient
 from lilya.types import ASGIApp, Receive, Scope, Send
 from pydantic import __version__
 
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy import Registry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin, TenantUserMixin
 from edgy.core.db import fields, set_tenant
 from edgy.exceptions import ObjectNotFound
@@ -16,7 +17,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/integration/test_esmerald_tenant_user.py
+++ b/tests/integration/test_esmerald_tenant_user.py
@@ -8,7 +8,8 @@ from httpx import ASGITransport, AsyncClient
 from lilya.types import ASGIApp, Receive, Scope, Send
 from pydantic import __version__
 
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy import Registry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin, TenantUserMixin
 from edgy.core.db import fields, set_tenant
 from edgy.exceptions import ObjectNotFound
@@ -16,7 +17,7 @@ from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_datetime.py
+++ b/tests/models/test_datetime.py
@@ -1,5 +1,5 @@
+import asyncio
 import datetime
-import time
 
 import pytest
 
@@ -43,7 +43,7 @@ async def test_creates_and_updates_only_updated_at():
     last_created_datetime = user.created_at
     last_updated_datetime = user.updated_at
 
-    time.sleep(2)
+    await asyncio.sleep(0.5)
 
     await user.update(name="Test 2")
 
@@ -57,7 +57,7 @@ async def test_creates_and_updates_only_updated_at_on_save():
     last_created_datetime = user.created_at
     last_updated_datetime = user.updated_at
 
-    time.sleep(2)
+    await asyncio.sleep(0.5)
 
     user.name = "Test 2"
     await user.save()

--- a/tests/models/test_inner_select.py
+++ b/tests/models/test_inner_select.py
@@ -4,18 +4,18 @@ import pytest
 from pydantic import __version__
 
 import edgy
-from edgy.contrib.multi_tenancy import TenantRegistry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL, full_isolation=True)
-models = TenantRegistry(database=database)
+models = edgy.Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio
 pydantic_version = __version__[:3]
 
 # TODO: disallow loading and check the crashes
+
 
 class EdgyTenantBaseModel(edgy.Model):
     id: int = edgy.IntegerField(primary_key=True)

--- a/tests/models/test_lazyness.py
+++ b/tests/models/test_lazyness.py
@@ -32,6 +32,8 @@ class Product(edgy.Model):
 
 
 def test_control_lazyness():
+    # test basics
+    assert User.meta is models.get_model("User").meta
     # initial
     assert not BaseUser.meta._is_init
     assert User.meta._is_init
@@ -46,6 +48,7 @@ def test_control_lazyness():
 
     # invalidate
     models.invalidate_models()
+    assert User.meta is models.get_model("User").meta
     assert not User.meta._is_init
     assert "name" not in User.meta.columns_to_field.data
     assert not Product.meta._is_init

--- a/tests/models/test_model_defer.py
+++ b/tests/models/test_model_defer.py
@@ -9,6 +9,7 @@ models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio
 
+
 class User(edgy.Model):
     id = edgy.IntegerField(primary_key=True)
     name = edgy.CharField(max_length=100)

--- a/tests/models/test_model_defer.py
+++ b/tests/models/test_model_defer.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, full_isolation=True)
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio
@@ -39,8 +39,6 @@ async def test_model_defer():
 
     assert "description" not in users[0].model_dump()
     assert "description" not in users[1].model_dump()
-
-    # FIXME: hangs without full_isolation but shouldn't
 
     users[0].description  # noqa
     users[1].description  # noqa

--- a/tests/models/test_select_related_mul.py
+++ b/tests/models/test_select_related_mul.py
@@ -4,12 +4,11 @@ import pytest
 from pydantic import __version__
 
 import edgy
-from edgy.contrib.multi_tenancy import TenantRegistry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = edgy.Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/test_select_related_single.py
+++ b/tests/models/test_select_related_single.py
@@ -4,12 +4,11 @@ import pytest
 from pydantic import __version__
 
 import edgy
-from edgy.contrib.multi_tenancy import TenantRegistry
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = edgy.Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/tenancy/test_activate_tenant.py
+++ b/tests/tenancy/test_activate_tenant.py
@@ -4,14 +4,14 @@ import pytest
 from pydantic import __version__
 
 import edgy
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db.querysets.mixins import activate_schema, deactivate_schema
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = edgy.Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/tenancy/test_activate_tenant_precedent.py
+++ b/tests/tenancy/test_activate_tenant_precedent.py
@@ -4,14 +4,14 @@ import pytest
 from pydantic import __version__
 
 import edgy
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db.querysets.mixins import activate_schema, deactivate_schema
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = edgy.Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/tenancy/test_load.py
+++ b/tests/tenancy/test_load.py
@@ -4,13 +4,13 @@ import pytest
 from pydantic import __version__
 
 import edgy
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = edgy.Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/tenancy/test_select_related.py
+++ b/tests/tenancy/test_select_related.py
@@ -1,14 +1,14 @@
 import pytest
 from pydantic import __version__
 
-from edgy import fields
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy import Registry, fields
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/tenancy/test_select_related_multiple.py
+++ b/tests/tenancy/test_select_related_multiple.py
@@ -4,13 +4,13 @@ import pytest
 from pydantic import __version__
 
 import edgy
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = edgy.Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/tenancy/test_select_related_two.py
+++ b/tests/tenancy/test_select_related_two.py
@@ -4,13 +4,13 @@ import pytest
 from pydantic import __version__
 
 import edgy
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = edgy.Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio

--- a/tests/tenancy/test_tenancy_queries.py
+++ b/tests/tenancy/test_tenancy_queries.py
@@ -1,14 +1,14 @@
 import pytest
 from pydantic import __version__
 
-from edgy import fields
-from edgy.contrib.multi_tenancy import TenantModel, TenantRegistry
+from edgy import Registry, fields
+from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
 database = DatabaseTestClient(DATABASE_URL)
-models = TenantRegistry(database=database)
+models = Registry(database=database)
 
 
 pytestmark = pytest.mark.anyio


### PR DESCRIPTION
Changes:
- add ContentType
- replace instance parameter by CURRENT_INSTANCE contextvar (backward compatible, the instance parameter was only main)
- foreign_key_fields is now a frozenset
- TenantRegistry is now just an old alias to Registry
- Prevent proxy models ever touching model registry.
- add pre_save_callback and wrap saves and updates in transactions
- foreign keys can be initialized on the fly. No need to save them first.

TODO:

docs