### PR TITLE
registry callback with default & fix for datetime field & fix for operators

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -291,6 +291,7 @@ DateTimeField supports int, float, string (isoformat), date object and of course
 * `force_timezone` - ZoneInfo containing the timezone in which all datetimes are converted.
                          For naive datetimes it behaves like `default_timezone`
 * `remove_timezone` - Boolean. Default False. Remove timezone information from datetime. Useful if the db should only contain naive datetimes and not convert.
+* `with_timezone` - Boolean. Defaults to True for remove_timezone is False. It controls if timezones are included on db side. You most probably don't need setting it except you want a naive datetime saving in a timezone aware column which makes no sense.
 
 
 !!! Note
@@ -636,6 +637,10 @@ class MyModel(edgy.Model):
     ...
 
 ```
+
+##### Parameters
+
+- * `with_timezone` - Boolean. Default `False`. Enable timezone support for time in the db.
 
 #### URLField
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -150,3 +150,17 @@ Model class attributes `class_attrs` which are cleared or set are `table`, `pkna
 `init_column_mappers` initializes the `columns_to_field` via its `init()` method. This initializes the mappers `columns_to_field`, `field_to_columns` and `field_to_column_names`.
 
 `db_schema` internally calls also `invalidate_models()` to remove table references.
+
+
+## Callbacks
+
+Sometimes you want to modify all models or a specific model but aren't sure if they are available yet.
+Here we have now the callbacks in a registry.
+You register a callback with a model name or None (for all models) and whenever a model class of the criteria is added the callback with
+the model class as parameter is executed.
+Callbacks can be registered permanent or one time (the first match triggers them). If a model is already registered it is passed to the callback too.
+The method is called `register_callback(model_or_name, callback, one_time)`.
+
+Generally you use `one_time=True` for model specific callbacks and `one_time=False` for model unspecific callbacks.
+
+If `one_time` is not provided, the logic mentioned above is applied.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ hide:
 - `stage` method in relations.
 - ModelRefs passed as normal positional arguments are automatically staged.
 - ContentType was added.
+- Proper callback support was added.
 
 ### Changed
 
@@ -33,6 +34,7 @@ hide:
 - Factory overwrites can now access owner.
 - Foreign keys to reflected models.
 - Handling to string references not in registry loaded yet.
+- Timezone aware Datetime saved in timezone unaware database columns.
 
 ## 0.14.1
 

--- a/edgy/core/connection/registry.py
+++ b/edgy/core/connection/registry.py
@@ -1,5 +1,17 @@
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Mapping, Type, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Type,
+    Union,
+    cast,
+)
 
 import sqlalchemy
 from sqlalchemy import Engine
@@ -147,8 +159,11 @@ class Registry:
         self,
         name_or_class: Union[Type["BaseModelType"], str, None],
         callback: Callable[[Type["BaseModelType"]], None],
-        one_time: bool,
+        one_time: Optional[bool] = None,
     ) -> None:
+        if one_time is None:
+            # True for model specific callbacks, False for general callbacks
+            one_time = name_or_class is not None
         called: bool = False
         if name_or_class is None:
             for model in self.models.values():

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -338,8 +338,8 @@ class DateTimeField(AutoNowMixin, datetime.datetime):
         return super().__new__(cls, **kwargs)
 
     @classmethod
-    def get_column_type(cls, **kwargs: Any) -> Any:
-        return sqlalchemy.DateTime(kwargs["with_timezone"])
+    def get_column_type(cls, with_timezone: bool = True, **kwargs: Any) -> Any:
+        return sqlalchemy.DateTime(with_timezone)
 
     @classmethod
     def get_default_values(

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -334,11 +334,12 @@ class DateTimeField(AutoNowMixin, datetime.datetime):
             **kwargs,
             **{k: v for k, v in locals().items() if k not in CLASS_DEFAULTS},
         }
+        kwargs.setdefault("with_timezone", not remove_timezone)
         return super().__new__(cls, **kwargs)
 
     @classmethod
     def get_column_type(cls, **kwargs: Any) -> Any:
-        return sqlalchemy.DateTime()
+        return sqlalchemy.DateTime(kwargs["with_timezone"])
 
     @classmethod
     def get_default_values(
@@ -397,7 +398,7 @@ class TimeField(FieldFactory, datetime.time):
 
     @classmethod
     def get_column_type(cls, **kwargs: Any) -> Any:
-        return sqlalchemy.Time()
+        return sqlalchemy.Time(kwargs.get("with_timezone") or False)
 
 
 class JSONField(FieldFactory, pydantic.Json):  # type: ignore

--- a/tests/exclude_secrets/test_exclude.py
+++ b/tests/exclude_secrets/test_exclude.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, full_isolation=False, force_rollback=False)
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_class.py
+++ b/tests/models/run_sync/test_model_class.py
@@ -6,7 +6,7 @@ from edgy.exceptions import MultipleObjectsReturned, ObjectNotFound
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, full_isolation=True, force_rollback=False)
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_defer.py
+++ b/tests/models/run_sync/test_model_defer.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, full_isolation=True, force_rollback=False)
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_get_or_none.py
+++ b/tests/models/run_sync/test_model_get_or_none.py
@@ -4,7 +4,7 @@ import edgy
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, full_isolation=True, force_rollback=False)
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_only.py
+++ b/tests/models/run_sync/test_model_only.py
@@ -5,7 +5,7 @@ from edgy.exceptions import QuerySetError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, full_isolation=True, force_rollback=False)
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_values.py
+++ b/tests/models/run_sync/test_model_values.py
@@ -5,7 +5,7 @@ from edgy.exceptions import QuerySetError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, full_isolation=True, force_rollback=False)
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/models/run_sync/test_model_values_list.py
+++ b/tests/models/run_sync/test_model_values_list.py
@@ -5,7 +5,7 @@ from edgy.exceptions import QuerySetError
 from edgy.testclient import DatabaseTestClient
 from tests.settings import DATABASE_URL
 
-database = DatabaseTestClient(DATABASE_URL, full_isolation=True, force_rollback=False)
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
 models = edgy.Registry(database=database)
 
 pytestmark = pytest.mark.anyio

--- a/tests/prefetch/test_prefetch_multiple_iterate.py
+++ b/tests/prefetch/test_prefetch_multiple_iterate.py
@@ -7,7 +7,7 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, full_isolation=True)
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
 models = edgy.Registry(database=database)
 
 


### PR DESCRIPTION
Changes:

- register_callback is now documented and has proper defaults for the one_time parameter
- DateTime fields save now the timezone (thx GladkovDO)
- field operators proper escape via autoescape where possible and escape themselves for iexact.