### PR TITLE
Revision field and rework parameters

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -761,6 +761,9 @@ This implements a copy on save. We have now revision safe models. This is very s
 It even works with FileFields or ImageFields.
 
 
+!!! Warning
+    When using FileField or ImageField and want to be able to delete single revisions make sure you save a copy per revision with `to_file()`.
+
 #### Revisioning with unsafe updates
 
 Sometimes you want to be able to modify old revisions. There is a second revisioning pattern allowing this:
@@ -778,7 +781,8 @@ class MyModel(edgy.Model):
 async def main():
     obj = await MyModel.query.create(name="foo")
     # obj.rev == 0
-    await obj.save()
+    # cloak FileField so a new filename is generated
+    await obj.save(document=obj.document.to_file())
     # obj.rev == 1
     assert len(await MyModel.query.all()) == 2
     # rev must be in update otherwise it fails (what is good)
@@ -786,7 +790,7 @@ async def main():
 ```
 
 !!! Warning
-    When using FileField or ImageField make sure you save revisi
+    When using FileField or ImageField make sure you save per revision with to_file().
 
 ### Countdown Field
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -758,6 +758,7 @@ async def main():
 ```
 
 This implements a copy on save. We have now revision safe models. This is very strictly checked.
+It even works with FileFields or ImageFields.
 
 
 #### Revisioning with unsafe updates
@@ -769,6 +770,7 @@ import edgy
 
 class MyModel(edgy.Model):
     id: int = edgy.IntegerField(primary_key=True, autoincrement=True)
+    document = edgy.fields.FileField(null=True)
     rev: int = edgy.SmallIntegerField(default=0, increment_on_save=1, primary_key=True, read_only=False)
     name = edgy.CharField(max_length=50)
     ...
@@ -782,6 +784,9 @@ async def main():
     # rev must be in update otherwise it fails (what is good)
     await obj.update(name="bar", rev=obj.rev)
 ```
+
+!!! Warning
+    When using FileField or ImageField make sure you save revisi
 
 ### Countdown Field
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -92,7 +92,7 @@ This field is used as a default field for the `id` of a model.
 * `minimum` - An integer indicating the minimum.
 * `maximum` - An integer indicating the maximum.
 * `multiple_of` - An integer indicating the multiple of.
-* `increment_on_save` - An integery which is applied on every save.
+* `increment_on_save` - An integer which is applied on every save.
 
 #### IntegerField
 
@@ -112,7 +112,7 @@ class MyModel(edgy.Model):
 * `minimum` - An integer indicating the minimum.
 * `maximum` - An integer indicating the maximum.
 * `multiple_of` - An integer indicating the multiple of.
-* `increment_on_save` - An integery which is applied on every save.
+* `increment_on_save` - An integer which is applied on every save.
 
 
 #### SmallIntegerField
@@ -133,7 +133,7 @@ class MyModel(edgy.Model):
 * `minimum` - An integer indicating the minimum.
 * `maximum` - An integer indicating the maximum.
 * `multiple_of` - An integer indicating the multiple of.
-* `increment_on_save` - An integery which is applied on every save.
+* `increment_on_save` - An integer which is applied on every save.
 
 #### BooleanField
 

--- a/docs/queries/queries.md
+++ b/docs/queries/queries.md
@@ -339,7 +339,10 @@ user = await User.query.get(email="foo@bar.com")
 user.email = "bar@foo.com"
 
 await user.save()
+# or as explicit parameter
+await user.save(values={"email": "sky@example.com"})
 ```
+
 
 Now a more unique, yet possible scenario with a save. Imagine you need to create an exact copy
 of an object and store it in the database. These cases are more common than you think but this is
@@ -355,6 +358,29 @@ user = await User.query.get(email="foo@bar.com")
 user.id = None
 new_user = await user.save()
 # User(id=2)
+```
+
+#### Parameters
+
+`save` has following signature:
+
+`save(force_insert=False,values=None)`
+
+What they do is:
+
+- `force_insert` (former `force_save`): Instead of conditionally updating, force an insert.
+- `values`: Overwrite values explicitly. Values specified here are marked as explicit set parameters.
+
+### Update
+
+Models have an `update` method too. It enforces updates:
+
+```python
+await User.query.create(is_active=True, email="foo@bar.com")
+
+user = await User.query.get(email="foo@bar.com")
+
+await user.update(email="bar@example.com")
 ```
 
 ### Create

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,9 @@ hide:
 - Support for querying across multiple databases.
 - Support for passing functions as clauses or keyword parameters.
 - Support for autocreated reflection objects by pattern matching.
+- Added some context variables for `extract_column_values` and `transform_input`:
+  - `CURRENT_PHASE`: allows retrieving the current context in which it was executed.
+  - `EXPLICIT_SPECIFIED_VALUES`: when set, it returns a set of the keys from the explicitly specified values.
 
 ### Changed
 
@@ -27,6 +30,7 @@ hide:
 - `phase` argument is shifted to `CURRENT_PHASE` context_var. If you rely on the correct phase you need to use it instead.
 - `extract_column_values` provides now also a `CURRENT_PHASE` environment.
 - `is_update` argument of `get_defaults` is now replaced by `CURRENT_PHASE` too. It is way more accurate.
+- Deprecate `force_save` kwarg of save in favor of `force_insert`. This is way more precise.
 
 ### Fixed
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -31,6 +31,7 @@ hide:
 - `extract_column_values` provides now also a `CURRENT_PHASE` environment.
 - `is_update` argument of `get_defaults` is now replaced by `CURRENT_PHASE` too. It is way more accurate.
 - Deprecate `force_save` kwarg of save in favor of `force_insert`. This is way more precise.
+- `post_save_callback` receives now also the `force_insert` parameter.
 
 ### Fixed
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,6 +24,9 @@ hide:
 - We use more metaclass kwarg arguments.
 - Switch to python >= 3.9.
 - Rename internal `_is_init` of MetaInfo to `_fields_are_initialized`.
+- `phase` argument is shifted to `CURRENT_PHASE` context_var. If you rely on the correct phase you need to use it instead.
+- `extract_column_values` provides now also a `CURRENT_PHASE` environment.
+- `is_update` argument of `get_defaults` is now replaced by `CURRENT_PHASE` too. It is way more accurate.
 
 ### Fixed
 

--- a/docs_src/tenancy/example/models.py
+++ b/docs_src/tenancy/example/models.py
@@ -51,12 +51,11 @@ class Tenant(edgy.Model):
         await registry.schema.create_schema(self.schema_name)
 
     async def save(
-        self: Any,
-        force_save: bool = False,
-        values: Dict[str, Any] = None,
-        **kwargs: Any,
+        self,
+        force_insert: bool = False,
+        values: Union[dict[str, Any], set[str], None] = None,
     ) -> Type[Model]:
-        tenant = await super().save(force_save, values, **kwargs)
+        tenant = await super().save(force_insert, values)
         try:
             await self.create_schema(schema=tenant.schema_name, if_not_exists=True)
             await self.create_tables(

--- a/edgy/contrib/contenttypes/fields.py
+++ b/edgy/contrib/contenttypes/fields.py
@@ -19,7 +19,7 @@ terminal = Print()
 class BaseContentTypeFieldField(BaseForeignKeyField):
     async def pre_save_callback(
         self, value: Any, original_value: Any, force_insert: bool, instance: "BaseModelType"
-    ) -> Any:
+    ) -> dict[str, Any]:
         target = self.target
         if value is None or (isinstance(value, dict) and not value):
             value = original_value

--- a/edgy/core/db/context_vars.py
+++ b/edgy/core/db/context_vars.py
@@ -3,9 +3,14 @@ from typing import TYPE_CHECKING, Literal, Optional, Union
 
 if TYPE_CHECKING:
     from edgy.core.db.models.types import BaseModelType
+    from edgy.core.db.querysets.base import QuerySet
 
-CURRENT_INSTANCE: ContextVar[Optional["BaseModelType"]] = ContextVar(
+CURRENT_INSTANCE: ContextVar[Optional[Union["BaseModelType", "QuerySet"]]] = ContextVar(
     "CURRENT_INSTANCE", default=None
+)
+CURRENT_PHASE: ContextVar[str] = ContextVar("CURRENT_PHASE", default="")
+EXPLICIT_SPECIFIED_VALUES: ContextVar[Optional[set[str]]] = ContextVar(
+    "EXPLICIT_SPECIFIED_VALUES", default=None
 )
 MODEL_GETATTR_BEHAVIOR: ContextVar[Literal["passdown", "load", "coro"]] = ContextVar(
     "MODEL_GETATTR_BEHAVIOR", default="load"

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -164,7 +164,7 @@ class BaseField(BaseFieldType, FieldInfo):
             return default()
         return default
 
-    def get_default_values(self, field_name: str, cleaned_data: dict[str, Any]) -> Any:
+    def get_default_values(self, field_name: str, cleaned_data: dict[str, Any]) -> dict[str, Any]:
         # for multidefaults overwrite in subclasses get_default_values to
         # parse default values differently
         # NOTE: multi value fields should always check here if defaults were already applied

--- a/edgy/core/db/fields/composite_field.py
+++ b/edgy/core/db/fields/composite_field.py
@@ -22,14 +22,6 @@ if TYPE_CHECKING:
     from edgy.core.db.models.types import BaseModelType
 
 
-def _removeprefix(text: str, prefix: str) -> str:
-    # TODO: replace with removeprefix when python3.9 is minimum
-    if text.startswith(prefix):
-        return text[len(prefix) :]
-    else:
-        return text
-
-
 class ConcreteCompositeField(BaseCompositeField):
     """
     Conrete, internal implementation of the CompositeField
@@ -91,7 +83,7 @@ class ConcreteCompositeField(BaseCompositeField):
     def translate_name(self, name: str) -> str:
         if self.prefix_embedded and name in self.embedded_field_defs:
             # PYTHON 3.8 compatibility
-            return _removeprefix(name, self.prefix_embedded)
+            return name.removeprefix(self.prefix_embedded)
         return name
 
     def embed_field(

--- a/edgy/core/db/fields/composite_field.py
+++ b/edgy/core/db/fields/composite_field.py
@@ -184,7 +184,6 @@ class ConcreteCompositeField(BaseCompositeField):
         self,
         field_name: str,
         value: Any,
-        phase: str = "",
     ) -> dict[str, Any]:
         assert len(self.inner_field_names) >= 1
         if (
@@ -194,8 +193,8 @@ class ConcreteCompositeField(BaseCompositeField):
             and not isinstance(value, (dict, BaseModel))
         ):
             field = self.owner.meta.fields[self.inner_field_names[0]]
-            return field.to_model(self.inner_field_names[0], value, phase=phase)
-        return super().to_model(field_name, value, phase=phase)
+            return field.to_model(self.inner_field_names[0], value)
+        return super().to_model(field_name, value)
 
     def get_embedded_fields(
         self, name: str, fields: dict[str, "BaseFieldType"]

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -114,7 +114,7 @@ class IncrementOnSaveBaseField(Field):
 
     async def _notset_pre_save_callback(
         self, value: Any, original_value: Any, force_insert: bool, instance: "BaseModelType"
-    ) -> dict[str:Any]:
+    ) -> dict[str, Any]:
         explicit_values = EXPLICIT_SPECIFIED_VALUES.get()
         if explicit_values is not None and self.name in explicit_values:
             return {}

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -12,6 +12,7 @@ import pydantic
 import sqlalchemy
 from pydantic import EmailStr
 
+from edgy.core.db.context_vars import CURRENT_INSTANCE, CURRENT_PHASE, EXPLICIT_SPECIFIED_VALUES
 from edgy.core.db.fields._internal import IPAddress
 from edgy.core.db.fields._validators import IPV4_REGEX, IPV6_REGEX
 from edgy.core.db.fields.base import Field
@@ -20,10 +21,9 @@ from edgy.core.db.fields.types import BaseFieldType
 from edgy.exceptions import FieldDefinitionError
 
 if TYPE_CHECKING:
-    try:
-        import zoneinfo  # type: ignore[import-not-found, unused-ignore]
-    except ImportError:
-        zoneinfo = Any  # type: ignore[unused-ignore, no-redef, assignment]
+    import zoneinfo
+
+    from edgy.core.db.models.types import BaseModelType
 
 
 CLASS_DEFAULTS = ["cls", "__class__", "kwargs"]
@@ -101,12 +101,69 @@ class TextField(FieldFactory, str):
         return sqlalchemy.Text(collation=kwargs.get("collation"))
 
 
+class IncrementOnSaveBaseField(Field):
+    increment_on_update: int = 0
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(
+            **kwargs,
+        )
+        if self.increment_on_update != 0:
+            self.pre_save_callback = self._notset_pre_save_callback
+
+    async def _notset_pre_save_callback(
+        self, value: Any, original_value: Any, force_insert: bool, instance: "BaseModelType"
+    ) -> dict[str:Any]:
+        explicit_values = EXPLICIT_SPECIFIED_VALUES.get()
+        if explicit_values is not None and self.name in explicit_values:
+            return {}
+        model_or_query = CURRENT_INSTANCE.get()
+
+        if force_insert:
+            if original_value is None:
+                return {self.name: self.get_default_value()}
+            else:
+                return {self.name: value + self.increment_on_update}
+        else:
+            return {
+                self.name: (
+                    model_or_query if model_or_query is not None else instance
+                ).table.columns[self.name]
+                + self.increment_on_update
+            }
+
+    def get_default_values(
+        self,
+        field_name: str,
+        cleaned_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        if self.increment_on_update != 0:
+            phase = CURRENT_PHASE.get()
+            if phase in "prepare_update":
+                return {field_name: None}
+        return super().get_default_values(field_name, cleaned_data)
+
+    def to_model(
+        self,
+        field_name: str,
+        value: Any,
+    ) -> dict[str, Any]:
+        phase = CURRENT_PHASE.get()
+        instance = CURRENT_INSTANCE.get()
+        if self.increment_on_update != 0 and phase == "post_update":
+            # a bit dirty but works
+            instance.__dict__.pop(field_name, None)
+            return {}
+        return super().to_model(field_name, value)
+
+
 class IntegerField(FieldFactory, int):
     """
     Integer field factory that construct Field classes and populated their values.
     """
 
     field_type = int
+    field_bases = (IncrementOnSaveBaseField,)
 
     def __new__(  # type: ignore
         cls,
@@ -116,10 +173,9 @@ class IntegerField(FieldFactory, int):
         le: Union[int, float, decimal.Decimal, None] = None,
         lt: Union[int, float, decimal.Decimal, None] = None,
         multiple_of: Optional[int] = None,
+        increment_on_update: int = 0,
         **kwargs: Any,
     ) -> BaseFieldType:
-        if kwargs.get("primary_key", False):
-            kwargs.setdefault("autoincrement", True)
         kwargs = {
             **kwargs,
             **{k: v for k, v in locals().items() if k not in ["cls", "__class__", "kwargs"]},
@@ -129,6 +185,19 @@ class IntegerField(FieldFactory, int):
     @classmethod
     def get_column_type(cls, **kwargs: Any) -> Any:
         return sqlalchemy.Integer()
+
+    @classmethod
+    def validate(cls, kwargs: dict[str, Any]) -> None:
+        increment_on_update = kwargs.get("increment_on_update", 0)
+        if increment_on_update == 0 and kwargs.get("primary_key", False):
+            kwargs.setdefault("autoincrement", True)
+        if increment_on_update != 0:
+            if kwargs.get("autoincrement"):
+                raise FieldDefinitionError(
+                    detail="'autoincrement' is incompatible with 'increment_on_update'"
+                )
+            kwargs.setdefault("read_only", True)
+            kwargs["inject_default_on_partial_update"] = True
 
 
 class FloatField(FieldFactory, float):
@@ -287,7 +356,6 @@ class TimezonedField:
         self,
         field_name: str,
         value: Any,
-        phase: str = "",
     ) -> dict[str, Optional[Union[datetime.datetime, datetime.date]]]:
         """
         Convert input object to datetime
@@ -355,12 +423,12 @@ class DateTimeField(AutoNowMixin, datetime.datetime):
         field_obj: Field,
         field_name: str,
         cleaned_data: dict[str, Any],
-        is_update: bool = False,
         original_fn: Any = None,
     ) -> Any:
-        if field_obj.auto_now_add and is_update:
+        phase = CURRENT_PHASE.get()
+        if field_obj.auto_now_add and phase == "prepare_update":
             return {}
-        return original_fn(field_name, cleaned_data, is_update=is_update)
+        return original_fn(field_name, cleaned_data)
 
 
 class DateField(AutoNowMixin, datetime.date):

--- a/edgy/core/db/fields/exclude_field.py
+++ b/edgy/core/db/fields/exclude_field.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
+from edgy.core.db.context_vars import CURRENT_PHASE
 from edgy.core.db.fields.factories import FieldFactory
 
 if TYPE_CHECKING:
@@ -41,10 +42,10 @@ class ExcludeField(FieldFactory, type[None]):
         obj: "BaseFieldType",
         name: str,
         value: Any,
-        phase: str = "",
         original_fn: Any = None,
     ) -> dict[str, Any]:
         """remove any value from input and raise when setting an attribute."""
+        phase = CURRENT_PHASE.get()
         if phase == "set":
             raise ValueError("field is excluded")
         return {}

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -15,7 +15,7 @@ from typing import (
 import orjson
 import sqlalchemy
 
-from edgy.core.db.context_vars import CURRENT_INSTANCE
+from edgy.core.db.context_vars import CURRENT_INSTANCE, CURRENT_PHASE
 from edgy.core.db.fields.base import BaseCompositeField
 from edgy.core.db.fields.core import BigIntegerField, BooleanField, JSONField
 from edgy.core.db.fields.factories import FieldFactory
@@ -39,7 +39,7 @@ class ConcreteFileField(BaseCompositeField):
         Callable[[Optional["BaseModelType"], Union[File, BinaryIO], str, bool], str]
     ] = None
 
-    def modify_input(self, name: str, kwargs: dict[str, Any], phase: str = "") -> None:
+    def modify_input(self, name: str, kwargs: dict[str, Any]) -> None:
         # we are empty
         if name not in kwargs:
             return
@@ -71,7 +71,6 @@ class ConcreteFileField(BaseCompositeField):
         self,
         field_name: str,
         value: Any,
-        phase: str = "",
     ) -> dict[str, Any]:
         """
         Inverse of clean. Transforms column(s) to a field for a pydantic model (EdgyBaseModel).
@@ -84,6 +83,7 @@ class ConcreteFileField(BaseCompositeField):
             phase: the phase (set, creation, ...)
 
         """
+        phase = CURRENT_PHASE.get()
         instance = CURRENT_INSTANCE.get()
         if (
             phase in {"post_update", "post_insert"}
@@ -272,7 +272,7 @@ class FileField(FieldFactory):
     @classmethod
     def get_column_type(cls, **kwargs: Any) -> Any:
         return sqlalchemy.String(
-            length=kwargs.get("max_length", 255), collation=kwargs.get("collation", None)
+            length=kwargs.get("max_length", 255), collation=kwargs.get("collation")
         )
 
     @classmethod

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -320,7 +320,7 @@ class FileField(FieldFactory):
             elif getattr(instance, "__db_model__", False):
                 # save was called and values passed
                 to_save = value[field_name]
-                value = getattr(instance, field_name)
+                value = cast("FieldFile", getattr(instance, field_name))
                 value.save(to_save)
         assert for_query or isinstance(value, FieldFile), f"Not a FieldFile: {value!r}"
         if for_query:

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -313,8 +313,15 @@ class FileField(FieldFactory):
         """
         assert field_obj.owner
         # unpack
-        if isinstance(value, dict) and isinstance(value.get(field_name), FieldFile):
-            value = value[field_name]
+        if isinstance(value, dict) and value.get(field_name) is not None:
+            instance = CURRENT_INSTANCE.get()
+            if isinstance(value[field_name], FieldFile):
+                value = value[field_name]
+            elif getattr(instance, "__db_model__", False):
+                # save was called and values passed
+                to_save = value[field_name]
+                value = getattr(instance, field_name)
+                value.save(to_save)
         assert for_query or isinstance(value, FieldFile), f"Not a FieldFile: {value!r}"
         if for_query:
             if isinstance(value, str):

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -317,26 +317,27 @@ class FileField(FieldFactory):
         # unpack
         if isinstance(value, dict) and field_name in value:
             instance = CURRENT_INSTANCE.get()
+            phase = CURRENT_PHASE.get()
             if isinstance(value[field_name], FieldFile) or value[field_name] is None:
                 value = value[field_name]
             elif getattr(instance, "__db_model__", False):
                 # save was called and values passed
                 to_save = value[field_name]
                 value = cast("FieldFile", getattr(instance, field_name))
-                value.save(to_save)
+                value.save(to_save, delete_old=phase == "prepare_update")
         if value is None:
-            retdict: dict[str, Any] = {
+            nulldict: dict[str, Any] = {
                 field_name: None,
             }
-            retdict[f"{field_name}_storage"] = None
+            nulldict[f"{field_name}_storage"] = None
             if not for_query:
                 if field_obj.with_approval:
-                    retdict[f"{field_name}_approved"] = False
+                    nulldict[f"{field_name}_approved"] = False
                 if field_obj.with_size:
-                    retdict[f"{field_name}_size"] = None
+                    nulldict[f"{field_name}_size"] = None
                 if field_obj.with_metadata:
-                    retdict[f"{field_name}_metadata"] = {}
-            return retdict
+                    nulldict[f"{field_name}_metadata"] = {}
+            return nulldict
 
         if for_query:
             if isinstance(value, str):

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -13,6 +13,7 @@ import sqlalchemy
 from pydantic import BaseModel
 
 from edgy.core.db.constants import CASCADE
+from edgy.core.db.context_vars import CURRENT_PHASE
 from edgy.core.db.fields.base import BaseForeignKey
 from edgy.core.db.fields.factories import ForeignKeyFieldFactory
 from edgy.core.db.fields.types import BaseFieldType
@@ -81,7 +82,7 @@ class BaseForeignKeyField(BaseForeignKey):
 
     async def pre_save_callback(
         self, value: Any, original_value: Any, force_insert: bool, instance: "BaseModelType"
-    ) -> Any:
+    ) -> dict[str, Any]:
         target = self.target
         # value is clean result, check what is provided as kwarg
         # still use value for handling defaults
@@ -192,7 +193,8 @@ class BaseForeignKeyField(BaseForeignKey):
             raise ValueError(f"cannot handle: {value} of type {type(value)}")
         return retdict
 
-    def modify_input(self, name: str, kwargs: dict[str, Any], phase: str = "") -> None:
+    def modify_input(self, name: str, kwargs: dict[str, Any]) -> None:
+        phase = CURRENT_PHASE.get()
         column_names = self.get_column_names(name)
         assert len(column_names) >= 1
         if len(column_names) == 1:

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -31,14 +31,6 @@ if TYPE_CHECKING:
 FK_CHAR_LIMIT = 63
 
 
-def _removeprefix(text: str, prefix: str) -> str:
-    # TODO: replace with removeprefix when python3.9 is minimum
-    if text.startswith(prefix):
-        return text[len(prefix) :]
-    else:
-        return text
-
-
 class BaseForeignKeyField(BaseForeignKey):
     force_cascade_deletion_relation: bool = False
     relation_has_post_delete_callback: bool = False
@@ -118,12 +110,12 @@ class BaseForeignKeyField(BaseForeignKey):
         )
 
     def traverse_field(self, path: str) -> tuple[Any, str, str]:
-        return self.target, self.reverse_name, _removeprefix(_removeprefix(path, self.name), "__")
+        return self.target, self.reverse_name, path.removeprefix(self.name).removeprefix("__")
 
     def reverse_traverse_field(self, path: str) -> tuple[Any, str, str]:
         if self.reverse_path_fn:
             return self.reverse_path_fn(path)
-        return self.owner, self.name, _removeprefix(_removeprefix(path, self.reverse_name), "__")
+        return self.owner, self.name, path.removeprefix(self.reverse_name).removeprefix("__")
 
     @cached_property
     def related_columns(self) -> dict[str, Optional[sqlalchemy.Column]]:
@@ -256,7 +248,7 @@ class BaseForeignKeyField(BaseForeignKey):
     def from_fk_field_name(self, name: str, fieldname: str) -> str:
         if len(self.related_columns) == 1:
             return next(iter(self.related_columns.keys()))
-        return _removeprefix(fieldname, f"{name}_")
+        return fieldname.removeprefix(f"{name}_")
 
     def get_columns(self, name: str) -> Sequence[sqlalchemy.Column]:
         target = self.target

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -90,7 +90,7 @@ class BaseForeignKeyField(BaseForeignKey):
             value = original_value
         # e.g. default was a Model
         if isinstance(value, (target, target.proxy_model)):
-            await value.save(force_insert=force_insert)
+            await value.save()
             return self.clean(self.name, value, for_query=False)
         elif isinstance(value, dict):
             return await self.pre_save_callback(

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -255,12 +255,11 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         self,
         field_name: str,
         value: Any,
-        phase: str = "",
     ) -> dict[str, Any]:
         """
         Meta field
         """
-        instance = CURRENT_INSTANCE.get()
+        instance = cast("BaseModelType", CURRENT_INSTANCE.get())
         if isinstance(value, ManyRelationProtocol):
             return {field_name: value}
         if instance:
@@ -276,9 +275,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         """Checks if the field has a default value set"""
         return False
 
-    def get_default_values(
-        self, field_name: str, cleaned_data: dict[str, Any], is_update: bool = False
-    ) -> Any:
+    def get_default_values(self, field_name: str, cleaned_data: dict[str, Any]) -> Any:
         """
         Meta field
         """

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -275,7 +275,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         raise ValueError("Missing instance")
 
     async def post_save_callback(
-        self, value: ManyRelationProtocol, instance: "BaseModelType"
+        self, value: ManyRelationProtocol, instance: "BaseModelType", force_insert: bool
     ) -> None:
         await value.save_related()
 

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -27,25 +27,9 @@ if TYPE_CHECKING:
 terminal = Print()
 
 
-def _removesuffix(text: str, suffix: str) -> str:
-    # TODO: replace with _removesuffix when python3.9 is minimum
-    if text.endswith(suffix):
-        return text[: -len(suffix)]
-    else:
-        return text
-
-
-def _removeprefix(text: str, prefix: str) -> str:
-    # TODO: replace with removeprefix when python3.9 is minimum
-    if text.startswith(prefix):
-        return text[len(prefix) :]
-    else:
-        return text
-
-
 def _removeprefixes(text: str, *prefixes: str) -> str:
     for prefix in prefixes:
-        text = _removeprefix(text, prefix)
+        text = text.removeprefix(prefix)
     return text
 
 
@@ -115,9 +99,9 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
             return (
                 self.through,
                 self.from_foreign_key,
-                _removeprefixes(path, self.embed_through_prefix, "__"),
+                path.removeprefix(self.embed_through_prefix).removeprefix("__"),
             )
-        return self.to, self.reverse_name, _removeprefixes(path, self.name, "__")
+        return self.to, self.reverse_name, path.removeprefix(self.name).removeprefix("__")
 
     def reverse_traverse_field_fk(self, path: str) -> tuple[Any, str, str]:
         # used for target fk
@@ -127,9 +111,9 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
             return (
                 self.through,
                 self.to_foreign_key,
-                _removeprefix(_removeprefix(path, self.reverse_embed_through_prefix), "__"),
+                path.removeprefix(self.reverse_embed_through_prefix).removeprefix("__"),
             )
-        return self.owner, self.name, _removeprefixes(path, self.reverse_name, "__")
+        return self.owner, self.name, path.removeprefix(self.reverse_name).removeprefix("__")
 
     def create_through_model(self) -> None:
         """

--- a/edgy/core/db/fields/ref_foreign_key.py
+++ b/edgy/core/db/fields/ref_foreign_key.py
@@ -73,6 +73,7 @@ class RefForeignKey(ForeignKeyFieldFactory, list):
         obj: "BaseFieldType",
         value: Optional[list],
         instance: "BaseModelType",
+        force_insert: bool,
         original_fn: Any = None,
     ) -> None:
         if not value:

--- a/edgy/core/db/fields/ref_foreign_key.py
+++ b/edgy/core/db/fields/ref_foreign_key.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 from typing_extensions import get_origin
 
 import edgy
+from edgy.core.db.context_vars import CURRENT_PHASE
 from edgy.core.db.fields.base import BaseField
 from edgy.core.db.fields.factories import ForeignKeyFieldFactory
 from edgy.exceptions import ModelReferenceError
@@ -25,9 +26,9 @@ class RefForeignKey(ForeignKeyFieldFactory, list):
         field_obj: "BaseFieldType",
         name: str,
         kwargs: dict[str, Any],
-        phase: str = "",
         original_fn: Any = None,
     ) -> None:
+        phase = CURRENT_PHASE.get()
         # we are empty
         if name not in kwargs and phase == "init_db":
             kwargs[name] = []

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -117,7 +117,6 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         self,
         field_name: str,
         value: Any,
-        phase: str = "",
     ) -> dict[str, Any]:
         """
         Inverse of clean. Transforms column(s) to a field for a pydantic model (EdgyBaseModel).
@@ -156,9 +155,7 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         return {}
 
     @abstractmethod
-    def get_default_values(
-        self, field_name: str, cleaned_data: dict[str, Any], is_update: bool = False
-    ) -> Any:
+    def get_default_values(self, field_name: str, cleaned_data: dict[str, Any]) -> Any:
         """
         Define for each field/column a default. Non-private multicolumn fields should
         always check if the default was already applied.
@@ -166,8 +163,6 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         Args:
             field_name: the field name (can be different from name)
             cleaned_data: currently validated data. Useful to check if the default was already applied.
-        Kwargs:
-            is_update: phase. Is update phase or is creation phase. For e.g. autonow_add
 
         """
 

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -18,7 +18,7 @@ import sqlalchemy
 from pydantic import BaseModel, ConfigDict
 from pydantic_core._pydantic_core import SchemaValidator as SchemaValidator
 
-from edgy.core.db.context_vars import CURRENT_INSTANCE, MODEL_GETATTR_BEHAVIOR
+from edgy.core.db.context_vars import CURRENT_INSTANCE, CURRENT_PHASE, MODEL_GETATTR_BEHAVIOR
 from edgy.core.db.datastructures import Index, UniqueConstraint
 from edgy.core.db.models.managers import Manager, RedirectManager
 from edgy.core.db.models.metaclasses import BaseModelMeta, MetaInfo
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from edgy.core.connection.registry import Registry
     from edgy.core.db.fields.types import BaseFieldType
     from edgy.core.db.models.metaclasses import MetaInfo
+    from edgy.core.db.querysets.base import QuerySet
     from edgy.core.signals import Broadcaster
 
 _empty = cast(set[str], frozenset())
@@ -99,7 +100,7 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
 
     @classmethod
     def transform_input(
-        cls, kwargs: Any, phase: str, instance: Optional["BaseModelType"] = None
+        cls, kwargs: Any, phase: str = "", instance: Optional["BaseModelType"] = None
     ) -> Any:
         """
         Expand to_models and apply input modifications.
@@ -110,19 +111,21 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
 
         fields = cls.meta.fields
         token = CURRENT_INSTANCE.set(instance)
+        token2 = CURRENT_PHASE.set(phase)
         try:
             # phase 1: transform
             # Note: this is order dependend. There should be no overlap.
             for field_name in cls.meta.input_modifying_fields:
-                fields[field_name].modify_input(field_name, kwargs, phase=phase)
+                fields[field_name].modify_input(field_name, kwargs)
             # phase 2: apply to_model
             for key, value in kwargs.items():
                 field = fields.get(key, None)
                 if field is not None:
-                    new_kwargs.update(**field.to_model(key, value, phase=phase))
+                    new_kwargs.update(**field.to_model(key, value))
                 else:
                     new_kwargs[key] = value
         finally:
+            CURRENT_PHASE.reset(token2)
             CURRENT_INSTANCE.reset(token)
         return new_kwargs
 
@@ -506,54 +509,59 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
         extracted_values: dict[str, Any],
         is_update: bool = False,
         is_partial: bool = False,
+        phase: str = "",
+        instance: Optional[Union["BaseModelType", "QuerySet"]] = None,
     ) -> dict[str, Any]:
         validated: dict[str, Any] = {}
-        # phase 1: transform when required
-        if cls.meta.input_modifying_fields:
-            extracted_values = {**extracted_values}
-            for field_name in cls.meta.input_modifying_fields:
-                cls.meta.fields[field_name].modify_input(field_name, extracted_values)
-        # phase 2: validate fields and set defaults for readonly
-        need_second_pass: list[BaseFieldType] = []
-        for field_name, field in cls.meta.fields.items():
-            if field.read_only:
-                # if read_only, updates are not possible anymore
-                if (
+        token = CURRENT_PHASE.set(phase)
+        token2 = CURRENT_INSTANCE.set(instance)
+        try:
+            # phase 1: transform when required
+            if cls.meta.input_modifying_fields:
+                extracted_values = {**extracted_values}
+                for field_name in cls.meta.input_modifying_fields:
+                    cls.meta.fields[field_name].modify_input(field_name, extracted_values)
+            # phase 2: validate fields and set defaults for readonly
+            need_second_pass: list[BaseFieldType] = []
+            for field_name, field in cls.meta.fields.items():
+                if field.read_only:
+                    # if read_only, updates are not possible anymore
+                    if (
+                        not is_partial or (field.inject_default_on_partial_update and is_update)
+                    ) and field.has_default():
+                        validated.update(field.get_default_values(field_name, validated))
+                    continue
+                if field_name in extracted_values:
+                    item = extracted_values[field_name]
+                    assert field.owner
+                    for sub_name, value in field.clean(field_name, item).items():
+                        if sub_name in validated:
+                            raise ValueError(f"value set twice for key: {sub_name}")
+                        validated[sub_name] = value
+                elif (
                     not is_partial or (field.inject_default_on_partial_update and is_update)
                 ) and field.has_default():
-                    validated.update(
-                        field.get_default_values(field_name, validated, is_update=is_update)
-                    )
-                continue
-            if field_name in extracted_values:
-                item = extracted_values[field_name]
-                assert field.owner
-                for sub_name, value in field.clean(field_name, item).items():
-                    if sub_name in validated:
-                        raise ValueError(f"value set twice for key: {sub_name}")
-                    validated[sub_name] = value
-            elif (
-                not is_partial or (field.inject_default_on_partial_update and is_update)
-            ) and field.has_default():
-                # add field without a value to the second pass (in case no value appears)
-                # only include fields which have inject_default_on_partial_update set or if not is_partial
-                need_second_pass.append(field)
+                    # add field without a value to the second pass (in case no value appears)
+                    # only include fields which have inject_default_on_partial_update set or if not is_partial
+                    need_second_pass.append(field)
 
-        # phase 3: set defaults for the rest if not partial or inject_default_on_partial_update
-        if need_second_pass:
-            for field in need_second_pass:
-                # check if field appeared e.g. by composite
-                # Note: default values are directly passed without validation
-                if field.name not in validated:
-                    validated.update(
-                        field.get_default_values(field.name, validated, is_update=is_update)
-                    )
+            # phase 3: set defaults for the rest if not partial or inject_default_on_partial_update
+            if need_second_pass:
+                for field in need_second_pass:
+                    # check if field appeared e.g. by composite
+                    # Note: default values are directly passed without validation
+                    if field.name not in validated:
+                        validated.update(field.get_default_values(field.name, validated))
+        finally:
+            CURRENT_INSTANCE.reset(token2)
+            CURRENT_PHASE.reset(token)
         return validated
 
     def __setattr__(self, key: str, value: Any) -> None:
         fields = self.meta.fields
         field = fields.get(key, None)
         token = CURRENT_INSTANCE.set(self)
+        token2 = CURRENT_PHASE.set("set")
         try:
             if field is not None:
                 if hasattr(field, "__set__"):
@@ -561,7 +569,7 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
                     # used in related_fields to mask and not to implement to_model
                     field.__set__(self, value)
                 else:
-                    for k, v in field.to_model(key, value, phase="set").items():
+                    for k, v in field.to_model(key, value).items():
                         # bypass __setattr__ method
                         object.__setattr__(self, k, v)
             else:
@@ -569,6 +577,7 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
                 object.__setattr__(self, key, value)
         finally:
             CURRENT_INSTANCE.reset(token)
+            CURRENT_PHASE.reset(token2)
 
     async def _agetattr_helper(self, name: str, getter: Any) -> Any:
         await self.load()
@@ -642,10 +651,13 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
         if self.meta.tablename != other.meta.tablename:
             return False
         self_dict = self.extract_column_values(
-            self.extract_db_fields(self.pkcolumns), is_partial=True
+            self.extract_db_fields(self.pkcolumns), is_partial=True, phase="compare", instance=self
         )
         other_dict = other.extract_column_values(
-            other.extract_db_fields(self.pkcolumns), is_partial=True
+            other.extract_db_fields(self.pkcolumns),
+            is_partial=True,
+            phase="compare",
+            instance=other,
         )
         key_set = {*self_dict.keys(), *other_dict.keys()}
         for field_name in key_set:

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -485,7 +485,7 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
                 CURRENT_INSTANCE.reset(token2)
         return retdict
 
-    async def execute_post_save_hooks(self, fields: Sequence[str]) -> None:
+    async def execute_post_save_hooks(self, fields: Sequence[str], force_insert: bool) -> None:
         affected_fields = self.meta.post_save_fields.intersection(fields)
         if affected_fields:
             # don't trigger loads, AttributeErrors are used for skipping fields
@@ -498,7 +498,7 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
                         value = getattr(self, field_name)
                     except AttributeError:
                         continue
-                    await field.post_save_callback(value, instance=self)
+                    await field.post_save_callback(value, instance=self, force_insert=force_insert)
             finally:
                 MODEL_GETATTR_BEHAVIOR.reset(token)
                 CURRENT_INSTANCE.reset(token2)

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -113,7 +113,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
                 setattr(self, k, v)
 
         # updates aren't required to change the db, they can also just affect the meta fields
-        await self.execute_post_save_hooks(cast(Sequence[str], kwargs.keys()))
+        await self.execute_post_save_hooks(cast(Sequence[str], kwargs.keys()), force_insert=False)
         if column_values or kwargs:
             # Ensure on access refresh the results is active
             self._loaded_or_deleted = False
@@ -218,7 +218,9 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
             setattr(self, k, v)
 
         if self.meta.post_save_fields:
-            await self.execute_post_save_hooks(cast(Sequence[str], kwargs.keys()))
+            await self.execute_post_save_hooks(
+                cast(Sequence[str], kwargs.keys()), force_insert=True
+            )
         # Ensure on access refresh the results is active
         self._loaded_or_deleted = False
 

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -120,7 +120,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         await self.meta.signals.post_update.send_async(self.__class__, instance=self)
 
     async def update(self, **kwargs: Any) -> "Model":
-        token = EXPLICIT_SPECIFIED_VALUES.set(kwargs.keys())
+        token = EXPLICIT_SPECIFIED_VALUES.set(set(kwargs.keys()))
         try:
             await self._update(**kwargs)
         finally:
@@ -273,7 +273,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         finally:
             MODEL_GETATTR_BEHAVIOR.reset(token)
 
-        token = EXPLICIT_SPECIFIED_VALUES.set(explicit_values)
+        token2 = EXPLICIT_SPECIFIED_VALUES.set(explicit_values)
         try:
             if force_insert:
                 if values:
@@ -283,7 +283,7 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
             else:
                 await self._update(**(extracted_fields if values is None else values))
         finally:
-            EXPLICIT_SPECIFIED_VALUES.reset(token)
+            EXPLICIT_SPECIFIED_VALUES.reset(token2)
         await self.meta.signals.post_save.send_async(self.__class__, instance=self)
         return self
 

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -266,10 +266,11 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
                     extracted_fields.pop(pkcolumn, None)
                     force_insert = True
                 field = self.meta.fields.get(pkcolumn)
-                # this is an IntegerField
+                # this is an IntegerField with primary_key set
                 if field is not None and getattr(field, "increment_on_save", 0) != 0:
                     # we create a new revision.
                     force_insert = True
+                    # Note: we definitely want this because it is easy for forget a force_insert
         finally:
             MODEL_GETATTR_BEHAVIOR.reset(token)
 

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -120,9 +120,8 @@ class BaseModelType(ABC):
     @abstractmethod
     async def save(
         self,
-        force_save: bool = False,
-        values: dict[str, Any] = None,
-        **kwargs: Any,
+        force_insert: bool = False,
+        values: Union[dict[str, Any], set[str], list[str], None] = None,
     ) -> "BaseModelType":
         """Save model"""
 

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -158,7 +158,7 @@ class BaseModelType(ABC):
         """
 
     @abstractmethod
-    async def execute_post_save_hooks(self, fields: Sequence[str]) -> None: ...
+    async def execute_post_save_hooks(self, fields: Sequence[str], force_insert: bool) -> None: ...
 
     @abstractmethod
     async def execute_pre_save_hooks(

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -41,14 +41,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from edgy.core.db.fields.types import BaseFieldType
 
 
-def _removeprefix(text: str, prefix: str) -> str:
-    # TODO: replace with removeprefix when python3.9 is minimum
-    if text.startswith(prefix):
-        return text[len(prefix) :]
-    else:
-        return text
-
-
 generic_field = BaseField()
 
 
@@ -62,7 +54,7 @@ def clean_query_kwargs(
     for key, val in kwargs.items():
         if embed_parent:
             if embed_parent[1] and key.startswith(embed_parent[1]):
-                key = _removeprefix(_removeprefix(key, embed_parent[1]), "__")
+                key = key.removeprefix(embed_parent[1]).removeprefix("__")
             else:
                 key = f"{embed_parent[0]}__{key}"
         sub_model_class, field_name, _, _, _, cross_db_remainder = crawl_relationship(

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -1231,7 +1231,8 @@ class QuerySet(BaseQuerySet):
             table=queryset.table,
             database=queryset.database,
         )
-        instance = await instance.save(force_save=True)
+        # values=kwargs is required for ensuring all kwargs are seen as explicit kwargs
+        instance = await instance.save(force_insert=True, values=set(kwargs.keys()))
         result = await self._embed_parent_in_result(instance)
         self._clear_cache(True)
         self._cache.update([result])

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -1266,7 +1266,9 @@ class QuerySet(BaseQuerySet):
         self._clear_cache(True)
         if new_objs:
             for obj in new_objs:
-                await obj.execute_post_save_hooks(self.model_class.meta.fields.keys())
+                await obj.execute_post_save_hooks(
+                    self.model_class.meta.fields.keys(), force_insert=True
+                )
 
     async def bulk_update(self, objs: list[EdgyModel], fields: list[str]) -> None:
         """
@@ -1322,7 +1324,7 @@ class QuerySet(BaseQuerySet):
             and not self.model_class.meta.post_save_fields.isdisjoint(fields)
         ):
             for obj in objs:
-                await obj.execute_post_save_hooks(fields)
+                await obj.execute_post_save_hooks(fields, force_insert=False)
 
     async def delete(self, use_models: bool = False) -> int:
         if (

--- a/edgy/core/db/relationships/related_field.py
+++ b/edgy/core/db/relationships/related_field.py
@@ -51,12 +51,11 @@ class RelatedField(RelationshipField):
         self,
         field_name: str,
         value: Any,
-        phase: str = "",
     ) -> dict[str, Any]:
         """
         Meta field
         """
-        instance = CURRENT_INSTANCE.get()
+        instance = cast("BaseModelType", CURRENT_INSTANCE.get())
         if isinstance(value, ManyRelationProtocol):
             return {field_name: value}
         if instance:

--- a/edgy/core/db/relationships/related_field.py
+++ b/edgy/core/db/relationships/related_field.py
@@ -107,7 +107,7 @@ class RelatedField(RelationshipField):
         return f"({self.related_to.__name__}={self.related_name})"
 
     async def post_save_callback(
-        self, value: ManyRelationProtocol, instance: "BaseModelType"
+        self, value: ManyRelationProtocol, instance: "BaseModelType", force_insert: bool
     ) -> None:
         await value.save_related()
 

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -141,7 +141,7 @@ class ManyRelation(ManyRelationProtocol):
         child = self.expand_relationship(child)
         # try saving intermediate model. If it fails another instance already exists and return None
         try:
-            return await child.save(force_save=True)
+            return await child.save(force_insert=True)
         except IntegrityError:
             pass
         return None

--- a/edgy/core/files/base.py
+++ b/edgy/core/files/base.py
@@ -304,7 +304,7 @@ class FieldFile(File):
             # set value to cached_property
             self.size = size
 
-    async def execute_operation(self) -> None:
+    async def execute_operation(self, nodelete_old: bool = False) -> None:
         operation = self.operation
         self.operation = "none"
         if operation == "save" or operation == "save_delete":
@@ -317,7 +317,8 @@ class FieldFile(File):
             finally:
                 self.storage.unreserve_name(self.name)
             if (
-                operation == "save_delete"
+                not nodelete_old
+                and operation == "save_delete"
                 and self.old is not None
                 and self.old[1]
                 and self.old[1] != self.name
@@ -328,7 +329,7 @@ class FieldFile(File):
                 self.close()
             # old should not be None anyway but check that
             # if name is empty or None skip deletion
-            if self.old is not None and self.old[1]:
+            if not nodelete_old and self.old is not None and self.old[1]:
                 self.old[0].delete(self.old[1])
         # else approve operation or metadata update
         self.old = None

--- a/edgy/core/files/base.py
+++ b/edgy/core/files/base.py
@@ -298,11 +298,17 @@ class FieldFile(File):
         self.generate_name_fn = generate_name_fn
         self.metadata = metadata or {}
         self.multi_process_safe = multi_process_safe
-        self.approved = approved
         self.change_removes_approval = change_removes_approval
+        self.approved = approved
         if size is not None:
             # set value to cached_property
             self.size = size
+
+    def to_file(self) -> Optional[File]:
+        """Cloak FileField so it looks like a regular File. Required for copies."""
+        if self:
+            return File(cast(BinaryIO, self), name=self.name, storage=self.storage)
+        return None
 
     async def execute_operation(self, nodelete_old: bool = False) -> None:
         operation = self.operation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ testing = [
     "mypy==1.10",
     "httpx",
     "types-orjson==3.6.2",
-    "backports.zoneinfo;python_version<'3.9'"
 ]
 mime = ["python-magic"]
 image = ["pillow"]

--- a/tests/fields/test_date_field.py
+++ b/tests/fields/test_date_field.py
@@ -1,11 +1,7 @@
 import datetime
+import zoneinfo
 
 from edgy.core.db.fields import DateField
-
-try:
-    import zoneinfo  # type: ignore[import-not-found, unused-ignore]
-except ImportError:
-    from backports import zoneinfo  # type: ignore[import-not-found, no-redef, unused-ignore]
 
 
 def test_default_timezone():

--- a/tests/fields/test_datetime_field.py
+++ b/tests/fields/test_datetime_field.py
@@ -1,11 +1,7 @@
 import datetime
+import zoneinfo
 
 from edgy.core.db.fields import DateTimeField
-
-try:
-    import zoneinfo  # type: ignore[import-not-found, unused-ignore]
-except ImportError:
-    from backports import zoneinfo  # type: ignore[import-not-found, no-redef, unused-ignore]
 
 
 def test_default_timezone():

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -172,7 +172,7 @@ def test_can_create_datetime_field():
     field = DateTimeField(auto_now=True)
 
     assert isinstance(field, BaseField)
-    assert field.default == datetime.datetime.now
+    assert field.default.func == datetime.datetime.now
     assert field.read_only is True
 
 
@@ -185,7 +185,7 @@ def test_can_create_date_field():
     field = DateField(auto_now=True)
 
     assert isinstance(field, BaseField)
-    assert field.default == datetime.datetime.now
+    assert field.default.func == datetime.datetime.now
     assert field.read_only is True
 
 

--- a/tests/fields/test_image_fields.py
+++ b/tests/fields/test_image_fields.py
@@ -72,7 +72,7 @@ async def test_save_file_create_approved(create_test_database):
             assert "height" not in model.ifield.metadata
             assert "width" not in model.ifield.metadata
             model.ifield.set_approved(True)
-            await model.save(ifield=model.ifield)
+            await model.save(values={"ifield": model.ifield})
         else:
             assert model.ifield.metadata["mime"] == "image/jpeg"
 

--- a/tests/fields/test_multi_column_fields.py
+++ b/tests/fields/test_multi_column_fields.py
@@ -58,7 +58,7 @@ class MultiColumnFieldInner(BaseField):
         else:
             return self._clean(field_name, value)
 
-    def modify_input(self, field_name: str, kwargs: Any, phase: str = "") -> None:
+    def modify_input(self, field_name: str, kwargs: Any) -> None:
         if field_name not in kwargs and field_name + "_inner" not in kwargs:
             return
         normal = kwargs.pop(field_name, None)
@@ -70,7 +70,7 @@ class MultiColumnFieldInner(BaseField):
                 "inner": kwargs.pop(field_name + "_inner", normal),
             }
 
-    def to_model(self, field_name: str, value: Any, phase: str = "") -> dict[str, Any]:
+    def to_model(self, field_name: str, value: Any) -> dict[str, Any]:
         if isinstance(value, str):
             return {field_name: {"normal": value, "inner": value}}
         return {field_name: value}

--- a/tests/models/test_datetime.py
+++ b/tests/models/test_datetime.py
@@ -39,6 +39,8 @@ async def rollback_transactions():
 
 async def test_creates_and_updates_only_updated_at():
     user = await User.query.create(name="Test")
+    assert user.created_at.tzinfo is None
+    assert user.updated_at.tzinfo is None
 
     last_created_datetime = user.created_at
     last_updated_datetime = user.updated_at
@@ -49,6 +51,8 @@ async def test_creates_and_updates_only_updated_at():
 
     assert user.created_at == last_created_datetime
     assert user.updated_at != last_updated_datetime
+    assert user.created_at.tzinfo is None
+    assert user.updated_at.tzinfo is None
 
 
 async def test_creates_and_updates_only_updated_at_on_save():

--- a/tests/models/test_increment_onsave.py
+++ b/tests/models/test_increment_onsave.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.anyio
 
 
 class MyWebsite(edgy.Model):
-    rev: int = edgy.IntegerField(increment_on_update=1, default=0)
+    rev: int = edgy.IntegerField(increment_on_save=1, default=0)
 
     class Meta:
         registry = models
@@ -20,7 +20,7 @@ class MyWebsite(edgy.Model):
 
 class MyRevSafe(edgy.Model):
     id: int = edgy.BigIntegerField(primary_key=True, autoincrement=True)
-    rev: int = edgy.IntegerField(increment_on_update=1, primary_key=True, default=1)
+    rev: int = edgy.IntegerField(increment_on_save=1, primary_key=True, default=1)
 
     class Meta:
         registry = models
@@ -28,7 +28,7 @@ class MyRevSafe(edgy.Model):
 
 class MyCountdown(edgy.Model):
     name = edgy.CharField(max_length=5)
-    rev: int = edgy.IntegerField(increment_on_update=-1, default=10, read_only=False)
+    rev: int = edgy.IntegerField(increment_on_save=-1, default=10, read_only=False)
 
     class Meta:
         registry = models
@@ -59,7 +59,7 @@ async def test_website():
     await websites[1].load()
     assert websites[1].rev == 0
     with pytest.raises(IntegrityError):
-        await websites[0].save(force_save=True)
+        await websites[0].save(force_insert=True)
 
     await websites[0].load()
     assert websites[0].rev == 1

--- a/tests/models/test_increment_onsave.py
+++ b/tests/models/test_increment_onsave.py
@@ -1,0 +1,84 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+import edgy
+from edgy.testclient import DatabaseTestClient
+from tests.settings import DATABASE_URL
+
+database = DatabaseTestClient(DATABASE_URL)
+models = edgy.Registry(database=edgy.Database(database, force_rollback=True))
+
+pytestmark = pytest.mark.anyio
+
+
+class MyWebsite(edgy.Model):
+    rev: int = edgy.IntegerField(increment_on_update=1, default=0)
+
+    class Meta:
+        registry = models
+
+
+class MyRevSafe(edgy.Model):
+    id: int = edgy.BigIntegerField(primary_key=True, autoincrement=True)
+    rev: int = edgy.IntegerField(increment_on_update=1, primary_key=True, default=1)
+
+    class Meta:
+        registry = models
+
+
+class MyCountdown(edgy.Model):
+    name = edgy.CharField(max_length=5)
+    rev: int = edgy.IntegerField(increment_on_update=-1, default=10, read_only=False)
+
+    class Meta:
+        registry = models
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def create_test_database():
+    async with database:
+        await models.create_all()
+        yield
+        if not database.drop:
+            await models.drop_all()
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def rollback_transactions():
+    async with models.database:
+        yield
+
+
+async def test_website():
+    await MyWebsite.query.bulk_create([{"id": 1}, {"id": 2}])
+    websites = await MyWebsite.query.all()
+    assert websites[0].rev == 0
+    assert websites[1].rev == 0
+    await websites[0].save()
+    assert websites[0].rev == 1
+    await websites[1].load()
+    assert websites[1].rev == 0
+    with pytest.raises(IntegrityError):
+        await websites[0].save(force_save=True)
+
+    await websites[0].load()
+    assert websites[0].rev == 1
+
+
+async def test_rev_safe():
+    obj = await MyRevSafe.query.create()
+    assert obj.rev == 1
+    await obj.save()
+    assert obj.rev == 2
+    objs = await MyRevSafe.query.all()
+    assert len(objs) == 2
+    assert objs[0].rev == 1
+
+
+async def test_countdown():
+    obj = await MyCountdown.query.create(name="count")
+    assert obj.rev == 10
+    await obj.save()
+    assert obj.rev == 9
+    await obj.save(values={"rev": 100})
+    assert obj.rev == 100


### PR DESCRIPTION
Changes:

- add a new parameter for integer based fields `increment_on_save`
  - this is used for a number of new field patterns
- replace `is_update` and  `phase` by CURRENT_PHASE context var.
- add EXPLICIT_SPECIFIED_VALUES for distinguishing between user set and implicitly passed values.
- update docs
- deprecate `force_save` parameter in favor of `force_insert`.
- a lot of fixes