### PR TITLE
Cleanup model inheritance & edgy can handle now future annotations

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -484,6 +484,7 @@ The metaclass also calculates following readonly attributes:
 
 Some other interesting attributes are:
 
+- `multi_related` (set[tuple[str, str]]): Holds foreign_keys used by ManyToManyFields when being used as a through model. Is empty for non-through models.
 - `fields` (pseudo dictionary): Holds fields. When setting/deleting fields it updates the attributes.
 - `model` (model_class): This attribute is special in it's way that it is not retrieved from a meta class. It must be explicitly set.
                          This has implications for custom MetaInfo. You either replace the original one by passing meta_info_class as metaclass argument or set it in your overwrite manually.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,10 @@ hide:
 ## Unreleased
 
 
+### Removed
+
+- `parents` attribute of MetaInfo. There are no users and uses as it only saves the name not the class itself.
+
 ### Changed
 
 - Cleanup Model inheritance: Database related stuff is put into a mixin. The customized metaclass is moved from EdgyBaseModel to edgy.Model as well as some db related ClassVars.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,14 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+
+### Changed
+
+- Cleanup Model inheritance: Database related stuff is put into a mixin. The customized metaclass is moved from EdgyBaseModel to edgy.Model as well as some db related ClassVars.
+
+
 ## 0.18.0
 
 ### Added

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,7 +15,12 @@ hide:
 ### Changed
 
 - Cleanup Model inheritance: Database related stuff is put into a mixin. The customized metaclass is moved from EdgyBaseModel to edgy.Model as well as some db related ClassVars.
+- `multi_related` is now a set containing tuples (from_fk, to_fk). This can be used to identify fields used by ManyToMany fields.
+- Deprecate `is_multi`.
 
+### Fixed
+
+- Non-abstract through-models wouldn't be marked as many to many relations.
 
 ## 0.18.0
 

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -78,7 +78,7 @@ class ConcreteFileField(BaseCompositeField):
         value: Any,
     ) -> dict[str, Any]:
         """
-        Inverse of clean. Transforms column(s) to a field for a pydantic model (EdgyBaseModel).
+        Inverse of clean. Transforms column(s) to a field for edgy.Model.
         Validation happens later.
 
         Args:

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -189,6 +189,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
                     if not candidate:
                         raise ValueError("no foreign key fo target found")
                     self.to_foreign_key = candidate
+                through.meta.multi_related.add((self.from_foreign_key, self.to_foreign_key))
                 return
         owner_name = self.owner.__name__
         to_name = self.target.__name__
@@ -203,7 +204,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         meta_args = {
             "tablename": tablename,
             "registry": self.owner.meta.registry,
-            "multi_related": [to_name.lower()],
+            "multi_related": {(self.from_foreign_key, self.to_foreign_key)},
         }
         has_pknames = pknames and not pknames.issubset(
             {self.from_foreign_key, self.to_foreign_key}

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -119,7 +119,7 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         value: Any,
     ) -> dict[str, Any]:
         """
-        Inverse of clean. Transforms column(s) to a field for a pydantic model (EdgyBaseModel).
+        Inverse of clean. Transforms column(s) to a field for edgy.Model.
         Validation happens later.
 
         Args:

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -1,4 +1,3 @@
-import contextlib
 import copy
 import inspect
 import warnings
@@ -15,7 +14,6 @@ from typing import (
 )
 
 import orjson
-import sqlalchemy
 from pydantic import BaseModel, ConfigDict
 from pydantic_core._pydantic_core import SchemaValidator as SchemaValidator
 
@@ -24,23 +22,15 @@ from edgy.core.db.context_vars import (
     CURRENT_MODEL_INSTANCE,
     CURRENT_PHASE,
     MODEL_GETATTR_BEHAVIOR,
-    get_schema,
 )
-from edgy.core.db.datastructures import Index, UniqueConstraint
-from edgy.core.db.models.managers import Manager, RedirectManager
-from edgy.core.db.models.metaclasses import BaseModelMeta, MetaInfo
 from edgy.core.db.models.model_reference import ModelRef
-from edgy.core.db.models.utils import build_pkcolumns, build_pknames
 from edgy.core.utils.sync import run_sync
 from edgy.types import Undefined
 
 from .types import BaseModelType
 
 if TYPE_CHECKING:
-    from edgy.core.connection.database import Database
-    from edgy.core.connection.registry import Registry
     from edgy.core.db.fields.types import BaseFieldType
-    from edgy.core.db.models.metaclasses import MetaInfo
     from edgy.core.db.models.model import Model
     from edgy.core.db.querysets.base import QuerySet
     from edgy.core.signals import Broadcaster
@@ -48,16 +38,13 @@ if TYPE_CHECKING:
 _empty = cast(set[str], frozenset())
 
 
-class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
+class EdgyBaseModel(BaseModel, BaseModelType):
     """
     Base of all Edgy models with the core setup.
     """
 
     model_config = ConfigDict(extra="ignore", arbitrary_types_allowed=True)
 
-    query: ClassVar[Manager] = Manager()
-    query_related: ClassVar[RedirectManager] = RedirectManager(redirect_name="query")
-    meta: ClassVar[MetaInfo] = MetaInfo(None, abstract=True)
     __proxy_model__: ClassVar[Union[type["Model"], None]] = None
     # is inheriting from a registered model, so the registry is true
     __db_model__: ClassVar[bool] = False
@@ -162,40 +149,14 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
             MODEL_GETATTR_BEHAVIOR.reset(token)
         return f"{self.__class__.__name__}({', '.join(pkl)})"
 
-    @classmethod
-    def copy_edgy_model(
-        cls, registry: Optional["Registry"] = None, name: str = "", **kwargs: Any
-    ) -> type["Model"]:
-        """Copy the model class and optionally add it to another registry."""
-        # removes private pydantic stuff, except the prefixed ones
-        attrs = {
-            key: val
-            for key, val in cls.__dict__.items()
-            if key not in BaseModel.__dict__ or key.startswith("__")
-        }
-        attrs.pop("meta", None)
-        # managers and fields are gone, we have to readd them with the correct data
-        attrs.update(cls.meta.fields)
-        attrs.update(cls.meta.managers)
-        _copy = cast(
-            type["Model"],
-            type(cls.__name__, cls.__bases__, attrs, skip_registry=True, **kwargs),
-        )
-        _copy.meta.model = _copy
-        if name:
-            _copy.__name__ = name
-        if registry is not None:
-            _copy.add_to_registry(registry)
-        return _copy
-
-    @cached_property
-    def proxy_model(self) -> type["Model"]:
-        return self.__class__.proxy_model  # type: ignore
-
     @cached_property
     def identifying_db_fields(self) -> Any:
         """The columns used for loading, can be set per instance defaults to pknames"""
         return self.pkcolumns
+
+    @cached_property
+    def proxy_model(self) -> type["Model"]:
+        return self.__class__.proxy_model  # type: ignore
 
     @property
     def can_load(self) -> bool:
@@ -249,77 +210,6 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
             stacklevel=2,
         )
         return self.meta.fields
-
-    @property
-    def table(self) -> sqlalchemy.Table:
-        if getattr(self, "_table", None) is None:
-            schema = self.__using_schema__
-            if schema is Undefined:
-                schema = get_schema()
-            return cast(
-                "sqlalchemy.Table",
-                self.table_schema(schema),
-            )
-        return self._table
-
-    @table.setter
-    def table(self, value: sqlalchemy.Table) -> None:
-        with contextlib.suppress(AttributeError):
-            del self._pknames
-        with contextlib.suppress(AttributeError):
-            del self._pkcolumns
-        self._table = value
-
-    @property
-    def database(self) -> "Database":
-        if getattr(self, "_database", None) is None:
-            return cast("Database", self.__class__.database)
-        return self._database
-
-    @database.setter
-    def database(self, value: "Database") -> None:
-        self._database = value
-
-    @property
-    def pkcolumns(self) -> Sequence[str]:
-        if self.__dict__.get("_pkcolumns", None) is None:
-            if self.__dict__.get("_table", None) is None:
-                self._pkcolumns: Sequence[str] = cast(Sequence[str], self.__class__.pkcolumns)
-            else:
-                build_pkcolumns(self)
-        return self._pkcolumns
-
-    @property
-    def pknames(self) -> Sequence[str]:
-        if self.__dict__.get("_pknames", None) is None:
-            if self.__dict__.get("_table", None) is None:
-                self._pknames: Sequence[str] = cast(Sequence[str], self.__class__.pknames)
-            else:
-                build_pknames(self)
-        return self._pknames
-
-    def get_columns_for_name(self, name: str) -> Sequence["sqlalchemy.Column"]:
-        table = self.table
-        meta = self.meta
-        if name in meta.field_to_columns:
-            return meta.field_to_columns[name]
-        elif name in table.columns:
-            return (table.columns[name],)
-        else:
-            return cast(Sequence["sqlalchemy.Column"], _empty)
-
-    def identifying_clauses(self) -> list[Any]:
-        clauses: list[Any] = []
-        for field_name in self.identifying_db_fields:
-            field = self.meta.fields.get(field_name)
-            if field is not None:
-                for column, value in field.clean(field_name, self.__dict__[field_name]).items():
-                    clauses.append(getattr(self.table.columns, column) == value)
-            else:
-                clauses.append(
-                    getattr(self.table.columns, field_name) == self.__dict__[field_name]
-                )
-        return clauses
 
     def model_dump(self, show_pk: Union[bool, None] = None, **kwargs: Any) -> dict[str, Any]:
         """
@@ -414,79 +304,6 @@ class EdgyBaseModel(BaseModel, BaseModelType, metaclass=BaseModelMeta):
 
     def model_dump_json(self, **kwargs: Any) -> str:
         return orjson.dumps(self.model_dump(mode="json", **kwargs)).decode()
-
-    @classmethod
-    def build(
-        cls, schema: Optional[str] = None, metadata: Optional[sqlalchemy.MetaData] = None
-    ) -> sqlalchemy.Table:
-        """
-        Builds the SQLAlchemy table representation from the loaded fields.
-        """
-        tablename: str = cls.meta.tablename
-        registry = cls.meta.registry
-        assert registry is not None, "registry is not set"
-        if metadata is None:
-            metadata = registry.metadata
-        schemes: list[str] = []
-        if schema:
-            schemes.append(schema)
-        schemes.append(registry.db_schema or "")
-
-        unique_together = cls.meta.unique_together
-        index_constraints = cls.meta.indexes
-
-        columns: list[sqlalchemy.Column] = []
-        global_constraints: list[Any] = []
-        for name, field in cls.meta.fields.items():
-            current_columns = field.get_columns(name)
-            columns.extend(current_columns)
-            global_constraints.extend(field.get_global_constraints(name, current_columns, schemes))
-
-        # Handle the uniqueness together
-        uniques = []
-        for unique_index in unique_together or []:
-            unique_constraint = cls._get_unique_constraints(unique_index)
-            uniques.append(unique_constraint)
-
-        # Handle the indexes
-        indexes = []
-        for index_c in index_constraints or []:
-            index = cls._get_indexes(index_c)
-            indexes.append(index)
-        return sqlalchemy.Table(
-            tablename,
-            metadata,
-            *columns,
-            *uniques,
-            *indexes,
-            *global_constraints,
-            extend_existing=True,
-            schema=schema or registry.db_schema,
-        )
-
-    @classmethod
-    def _get_unique_constraints(
-        cls, columns: Union[Sequence, str, sqlalchemy.UniqueConstraint]
-    ) -> Optional[sqlalchemy.UniqueConstraint]:
-        """
-        Returns the unique constraints for the model.
-
-        The columns must be a a list, tuple of strings or a UniqueConstraint object.
-
-        :return: Model UniqueConstraint.
-        """
-        if isinstance(columns, str):
-            return sqlalchemy.UniqueConstraint(columns)
-        elif isinstance(columns, UniqueConstraint):
-            return sqlalchemy.UniqueConstraint(*columns.fields, name=columns.name)
-        return sqlalchemy.UniqueConstraint(*columns)
-
-    @classmethod
-    def _get_indexes(cls, index: Index) -> Optional[sqlalchemy.Index]:
-        """
-        Creates the index based on the Index fields
-        """
-        return sqlalchemy.Index(index.name, *index.fields)
 
     async def execute_pre_save_hooks(
         self, column_values: dict[str, Any], original: dict[str, Any], force_insert: bool

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import inspect
 import warnings
@@ -45,7 +47,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
 
     model_config = ConfigDict(extra="ignore", arbitrary_types_allowed=True)
 
-    __proxy_model__: ClassVar[Union[type["Model"], None]] = None
+    __proxy_model__: ClassVar[Union[type[Model], None]] = None
     # is inheriting from a registered model, so the registry is true
     __db_model__: ClassVar[bool] = False
     __reflected__: ClassVar[bool] = False
@@ -95,7 +97,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
 
     @classmethod
     def transform_input(
-        cls, kwargs: Any, phase: str = "", instance: Optional["BaseModelType"] = None
+        cls, kwargs: Any, phase: str = "", instance: Optional[BaseModelType] = None
     ) -> Any:
         """
         Expand to_models and apply input modifications.
@@ -155,7 +157,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         return self.pkcolumns
 
     @cached_property
-    def proxy_model(self) -> type["Model"]:
+    def proxy_model(self) -> type[Model]:
         return self.__class__.proxy_model  # type: ignore
 
     @property
@@ -194,7 +196,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
                 )
 
     @property
-    def signals(self) -> "Broadcaster":
+    def signals(self) -> Broadcaster:
         warnings.warn(
             "'signals' has been deprecated, use 'meta.signals' instead.",
             DeprecationWarning,
@@ -203,7 +205,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         return self.meta.signals
 
     @property
-    def fields(self) -> dict[str, "BaseFieldType"]:
+    def fields(self) -> dict[str, BaseFieldType]:
         warnings.warn(
             "'fields' has been deprecated, use 'meta.fields' instead.",
             DeprecationWarning,
@@ -359,8 +361,8 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         is_update: bool = False,
         is_partial: bool = False,
         phase: str = "",
-        instance: Optional[Union["BaseModelType", "QuerySet"]] = None,
-        model_instance: Optional["BaseModelType"] = None,
+        instance: Optional[Union[BaseModelType, QuerySet]] = None,
+        model_instance: Optional[BaseModelType] = None,
     ) -> dict[str, Any]:
         validated: dict[str, Any] = {}
         token = CURRENT_PHASE.set(phase)

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -238,7 +238,6 @@ class MetaInfo:
             __slots__,
         ),
         "pk",
-        "is_multi",
     )
 
     fields: Fields
@@ -261,7 +260,7 @@ class MetaInfo:
         self.signals.set_lifecycle_signals_from(signals_module, overwrite=False)
         self.fields = {**getattr(meta, "fields", _empty_dict)}  # type: ignore
         self.managers: dict[str, BaseManager] = {**getattr(meta, "managers", _empty_dict)}
-        self.multi_related: list[str] = [*getattr(meta, "multi_related", _empty_set)]
+        self.multi_related: set[tuple[str, str]] = {*getattr(meta, "multi_related", _empty_set)}
         self.load_dict(kwargs)
 
     @property
@@ -279,6 +278,7 @@ class MetaInfo:
 
     @property
     def is_multi(self) -> bool:
+        warnings.warn("Use bool(meta.multi_related) instead", DeprecationWarning, stacklevel=2)
         return bool(self.multi_related)
 
     def model_dump(self) -> dict[Any, Any]:

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -390,7 +390,8 @@ def _handle_annotations(base: type, base_annotations: dict[str, Any]) -> None:
     if hasattr(base, "__init_annotations__") and base.__init_annotations__:
         base_annotations.update(base.__init_annotations__)
     elif hasattr(base, "__annotations__") and base.__annotations__:
-        base_annotations.update(inspect.get_annotations(base))
+        # python 3.9 has no get_annotations
+        base_annotations.update(base.__annotations__)
 
 
 def handle_annotations(

--- a/edgy/core/db/models/mixins/__init__.py
+++ b/edgy/core/db/models/mixins/__init__.py
@@ -1,5 +1,6 @@
+from .db import DatabaseMixin
 from .generics import DeclarativeMixin
 from .reflection import ReflectedModelMixin
 from .row import ModelRowMixin
 
-__all__ = ["DeclarativeMixin", "ModelRowMixin", "ReflectedModelMixin"]
+__all__ = ["DeclarativeMixin", "ModelRowMixin", "ReflectedModelMixin", "DatabaseMixin"]

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -1,0 +1,549 @@
+import contextlib
+import inspect
+import warnings
+from collections.abc import Sequence
+from functools import partial
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
+
+import sqlalchemy
+from pydantic import BaseModel
+
+from edgy.core.db.context_vars import (
+    CURRENT_INSTANCE,
+    EXPLICIT_SPECIFIED_VALUES,
+    MODEL_GETATTR_BEHAVIOR,
+    get_schema,
+)
+from edgy.core.db.datastructures import Index, UniqueConstraint
+from edgy.core.db.fields.many_to_many import BaseManyToManyForeignKeyField
+from edgy.core.db.models.metaclasses import MetaInfo
+from edgy.core.db.models.utils import build_pkcolumns, build_pknames
+from edgy.core.db.relationships.related_field import RelatedField
+from edgy.core.utils.db import check_db_connection
+from edgy.exceptions import ForeignKeyBadConfigured, ObjectNotFound
+from edgy.types import Undefined
+
+if TYPE_CHECKING:
+    from databasez.core.transaction import Transaction
+
+    from edgy.core.connection.database import Database
+    from edgy.core.connection.registry import Registry
+    from edgy.core.db.fields.types import BaseFieldType
+    from edgy.core.db.models.model import Model
+    from edgy.core.db.models.types import BaseModelType
+
+
+_empty = cast(set[str], frozenset())
+
+
+def _set_related_field(
+    target: type["BaseModelType"],
+    *,
+    foreign_key_name: str,
+    related_name: str,
+    source: type["BaseModelType"],
+    replace_related_field: bool,
+) -> None:
+    if not replace_related_field and related_name in target.meta.fields:
+        # is already correctly set, required for migrate of model_apps with registry set
+        related_field = target.meta.fields[related_name]
+        if (
+            related_field.related_from is source
+            and related_field.foreign_key_name == foreign_key_name
+        ):
+            return
+        raise ForeignKeyBadConfigured(
+            f"Multiple related_name with the same value '{related_name}' found to the same target. Related names must be different."
+        )
+
+    related_field = RelatedField(
+        foreign_key_name=foreign_key_name,
+        name=related_name,
+        owner=target,
+        related_from=source,
+    )
+
+    # Set the related name
+    target.meta.fields[related_name] = related_field
+
+
+def _set_related_name_for_foreign_keys(
+    meta: "MetaInfo", model_class: type["BaseModelType"], replace_related_field: bool = False
+) -> None:
+    """
+    Sets the related name for the foreign keys.
+    When a `related_name` is generated, creates a RelatedField from the table pointed
+    from the ForeignKey declaration and the the table declaring it.
+    """
+    if not meta.foreign_key_fields:
+        return
+
+    for name in meta.foreign_key_fields:
+        foreign_key = meta.fields[name]
+        related_name = getattr(foreign_key, "related_name", None)
+        if related_name is False:
+            # skip related_field
+            continue
+
+        if not related_name:
+            if foreign_key.unique:
+                related_name = f"{model_class.__name__.lower()}"
+            else:
+                related_name = f"{model_class.__name__.lower()}s_set"
+
+        foreign_key.related_name = related_name
+        foreign_key.reverse_name = related_name
+
+        related_field_fn = partial(
+            _set_related_field,
+            source=model_class,
+            foreign_key_name=name,
+            related_name=related_name,
+            replace_related_field=replace_related_field,
+        )
+        registry: Registry = foreign_key.target_registry
+        with contextlib.suppress(Exception):
+            registry = cast("Registry", foreign_key.target.registry)
+        registry.register_callback(foreign_key.to, related_field_fn, one_time=True)
+
+
+class DatabaseMixin:
+    @classmethod
+    def add_to_registry(
+        cls: type["BaseModelType"],
+        registry: "Registry",
+        name: str = "",
+        database: Union[bool, "Database"] = True,
+    ) -> None:
+        # when called if registry is not set
+        cls.meta.registry = registry
+        if database is True:
+            cls.database = registry.database
+        elif database is not False:
+            cls.database = database
+        meta = cls.meta
+        if name:
+            cls.__name__ = name
+
+        # Making sure it does not generate models if abstract or a proxy
+        if not meta.abstract and not cls.__is_proxy_model__:
+            if getattr(cls, "__reflected__", False):
+                registry.reflected[cls.__name__] = cls
+            else:
+                registry.models[cls.__name__] = cls
+            # after registrating the own model
+            for value in list(meta.fields.values()):
+                if isinstance(value, BaseManyToManyForeignKeyField):
+                    m2m_registry: Registry = value.target_registry
+                    with contextlib.suppress(Exception):
+                        m2m_registry = cast("Registry", value.target.registry)
+
+                    def create_through_model(x: Any, field: "BaseFieldType" = value) -> None:
+                        # we capture with field = ... the variable
+                        field.create_through_model()
+
+                    m2m_registry.register_callback(value.to, create_through_model, one_time=True)
+            # Sets the foreign key fields
+            if meta.foreign_key_fields:
+                _set_related_name_for_foreign_keys(meta, cls)
+            registry.execute_model_callbacks(cls)
+
+        cls.__db_model__ = True
+        # finalize
+        cls.model_rebuild(force=True)
+
+    @classmethod
+    def copy_edgy_model(
+        cls: type["Model"], registry: Optional["Registry"] = None, name: str = "", **kwargs: Any
+    ) -> type["Model"]:
+        """Copy the model class and optionally add it to another registry."""
+        # removes private pydantic stuff, except the prefixed ones
+        attrs = {
+            key: val
+            for key, val in cls.__dict__.items()
+            if key not in BaseModel.__dict__ or key.startswith("__")
+        }
+        attrs.pop("meta", None)
+        # managers and fields are gone, we have to readd them with the correct data
+        attrs.update(cls.meta.fields)
+        attrs.update(cls.meta.managers)
+        _copy = cast(
+            type["Model"],
+            type(cls.__name__, cls.__bases__, attrs, skip_registry=True, **kwargs),
+        )
+        _copy.meta.model = _copy
+        if name:
+            _copy.__name__ = name
+        if registry is not None:
+            _copy.add_to_registry(registry)
+        return _copy
+
+    @property
+    def table(self) -> sqlalchemy.Table:
+        if getattr(self, "_table", None) is None:
+            schema = self.__using_schema__
+            if schema is Undefined:
+                schema = get_schema()
+            return cast(
+                "sqlalchemy.Table",
+                self.table_schema(schema),
+            )
+        return self._table
+
+    @table.setter
+    def table(self, value: sqlalchemy.Table) -> None:
+        with contextlib.suppress(AttributeError):
+            del self._pknames
+        with contextlib.suppress(AttributeError):
+            del self._pkcolumns
+        self._table = value
+
+    @property
+    def database(self) -> "Database":
+        if getattr(self, "_database", None) is None:
+            return cast("Database", self.__class__.database)
+        return self._database
+
+    @database.setter
+    def database(self, value: "Database") -> None:
+        self._database = value
+
+    @property
+    def pkcolumns(self) -> Sequence[str]:
+        if self.__dict__.get("_pkcolumns", None) is None:
+            if self.__dict__.get("_table", None) is None:
+                self._pkcolumns: Sequence[str] = cast(Sequence[str], self.__class__.pkcolumns)
+            else:
+                build_pkcolumns(self)
+        return self._pkcolumns
+
+    @property
+    def pknames(self) -> Sequence[str]:
+        if self.__dict__.get("_pknames", None) is None:
+            if self.__dict__.get("_table", None) is None:
+                self._pknames: Sequence[str] = cast(Sequence[str], self.__class__.pknames)
+            else:
+                build_pknames(self)
+        return self._pknames
+
+    def get_columns_for_name(self: "Model", name: str) -> Sequence["sqlalchemy.Column"]:
+        table = self.table
+        meta = self.meta
+        if name in meta.field_to_columns:
+            return meta.field_to_columns[name]
+        elif name in table.columns:
+            return (table.columns[name],)
+        else:
+            return cast(Sequence["sqlalchemy.Column"], _empty)
+
+    def identifying_clauses(self) -> list[Any]:
+        clauses: list[Any] = []
+        for field_name in self.identifying_db_fields:
+            field = self.meta.fields.get(field_name)
+            if field is not None:
+                for column, value in field.clean(field_name, self.__dict__[field_name]).items():
+                    clauses.append(getattr(self.table.columns, column) == value)
+            else:
+                clauses.append(
+                    getattr(self.table.columns, field_name) == self.__dict__[field_name]
+                )
+        return clauses
+
+    async def _update(self: "Model", **kwargs: Any) -> Any:
+        """
+        Update operation of the database fields.
+        """
+        await self.meta.signals.pre_update.send_async(self.__class__, instance=self)
+        column_values = self.extract_column_values(
+            extracted_values=kwargs,
+            is_partial=True,
+            is_update=True,
+            phase="prepare_update",
+            instance=self,
+            model_instance=self,
+        )
+        # empty updates shouldn't cause an error. E.g. only model references are updated
+        clauses = self.identifying_clauses()
+        token = CURRENT_INSTANCE.set(self)
+        try:
+            if column_values and clauses:
+                check_db_connection(self.database)
+                async with self.database as database, database.transaction():
+                    # can update column_values
+                    column_values.update(
+                        await self.execute_pre_save_hooks(
+                            column_values, kwargs, force_insert=False
+                        )
+                    )
+                    expression = self.table.update().values(**column_values).where(*clauses)
+                    await database.execute(expression)
+
+                # Update the model instance.
+                new_kwargs = self.transform_input(
+                    column_values, phase="post_update", instance=self
+                )
+                self.__dict__.update(new_kwargs)
+
+            # updates aren't required to change the db, they can also just affect the meta fields
+            await self.execute_post_save_hooks(
+                cast(Sequence[str], kwargs.keys()), force_insert=False
+            )
+
+        finally:
+            CURRENT_INSTANCE.reset(token)
+        if column_values or kwargs:
+            # Ensure on access refresh the results is active
+            self._loaded_or_deleted = False
+        await self.meta.signals.post_update.send_async(self.__class__, instance=self)
+
+    async def update(self: "Model", **kwargs: Any) -> "Model":
+        token = EXPLICIT_SPECIFIED_VALUES.set(set(kwargs.keys()))
+        try:
+            await self._update(**kwargs)
+        finally:
+            EXPLICIT_SPECIFIED_VALUES.reset(token)
+        return self
+
+    async def delete(
+        self, skip_post_delete_hooks: bool = False, remove_referenced_call: bool = False
+    ) -> None:
+        """Delete operation from the database"""
+        await self.meta.signals.pre_delete.send_async(self.__class__, instance=self)
+        # get values before deleting
+        field_values: dict[str, Any] = {}
+        if not skip_post_delete_hooks and self.meta.post_delete_fields:
+            token = MODEL_GETATTR_BEHAVIOR.set("coro")
+            try:
+                for field_name in self.meta.post_delete_fields:
+                    try:
+                        field_value = getattr(self, field_name)
+                    except AttributeError:
+                        continue
+                    if inspect.isawaitable(field_value):
+                        try:
+                            field_value = await field_value
+                        except AttributeError:
+                            continue
+                    field_values[field_name] = field_value
+            finally:
+                MODEL_GETATTR_BEHAVIOR.reset(token)
+        clauses = self.identifying_clauses()
+        if clauses:
+            expression = self.table.delete().where(*clauses)
+            check_db_connection(self.database)
+            async with self.database as database:
+                await database.execute(expression)
+        # we cannot load anymore
+        self._loaded_or_deleted = True
+        # now cleanup with the saved values
+        for field_name, value in field_values.items():
+            field = self.meta.fields[field_name]
+            await field.post_delete_callback(value, instance=self)
+
+        await self.meta.signals.post_delete.send_async(self.__class__, instance=self)
+
+    async def load(self, only_needed: bool = False) -> None:
+        if only_needed and self._loaded_or_deleted:
+            return
+        row = None
+        clauses = self.identifying_clauses()
+        if clauses:
+            # Build the select expression.
+            expression = self.table.select().where(*clauses)
+
+            # Perform the fetch.
+            check_db_connection(self.database)
+            async with self.database as database:
+                row = await database.fetch_one(expression)
+        # check if is in system
+        if row is None:
+            raise ObjectNotFound("row does not exist anymore")
+        # Update the instance.
+        self.__dict__.update(self.transform_input(dict(row._mapping), phase="load", instance=self))
+        self._loaded_or_deleted = True
+
+    async def _insert(self: "Model", **kwargs: Any) -> "Model":
+        """
+        Performs the save instruction.
+        """
+        column_values: dict[str, Any] = self.extract_column_values(
+            extracted_values=kwargs,
+            is_partial=False,
+            is_update=False,
+            phase="prepare_insert",
+            instance=self,
+            model_instance=self,
+        )
+        check_db_connection(self.database)
+        token = CURRENT_INSTANCE.set(self)
+        try:
+            async with self.database as database, database.transaction():
+                # can update column_values
+                column_values.update(
+                    await self.execute_pre_save_hooks(column_values, kwargs, force_insert=True)
+                )
+                expression = self.table.insert().values(**column_values)
+                autoincrement_value = await database.execute(expression)
+            # sqlalchemy supports only one autoincrement column
+            if autoincrement_value:
+                column = self.table.autoincrement_column
+                if column is not None and hasattr(autoincrement_value, "_mapping"):
+                    autoincrement_value = autoincrement_value._mapping[column.key]
+                # can be explicit set, which causes an invalid value returned
+                if column is not None and column.key not in column_values:
+                    column_values[column.key] = autoincrement_value
+
+            new_kwargs = self.transform_input(column_values, phase="post_insert", instance=self)
+            self.__dict__.update(new_kwargs)
+
+            if self.meta.post_save_fields:
+                await self.execute_post_save_hooks(
+                    cast(Sequence[str], kwargs.keys()), force_insert=True
+                )
+        finally:
+            CURRENT_INSTANCE.reset(token)
+        # Ensure on access refresh the results is active
+        self._loaded_or_deleted = False
+
+        return self
+
+    async def save(
+        self: "Model",
+        force_insert: bool = False,
+        values: Union[dict[str, Any], set[str], None] = None,
+        force_save: Optional[bool] = None,
+    ) -> "Model":
+        """
+        Performs a save of a given model instance.
+        When creating a user it will make sure it can update existing or
+        create a new one.
+        """
+        if force_save is not None:
+            warnings.warn(
+                "'force_save' is deprecated in favor of 'force_insert'",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            force_insert = force_save
+
+        await self.meta.signals.pre_save.send_async(self.__class__, instance=self)
+
+        extracted_fields = self.extract_db_fields()
+        if values is None:
+            explicit_values: set[str] = set()
+        elif isinstance(values, set):
+            # special mode for marking values as explicit values
+            explicit_values = set(values)
+            values = None
+        else:
+            explicit_values = set(values.keys())
+
+        token = MODEL_GETATTR_BEHAVIOR.set("coro")
+        try:
+            for pkcolumn in self.__class__.pkcolumns:
+                # should trigger load in case of identifying_db_fields
+                value = getattr(self, pkcolumn, None)
+                if inspect.isawaitable(value):
+                    value = await value
+                if value is None and self.table.columns[pkcolumn].autoincrement:
+                    extracted_fields.pop(pkcolumn, None)
+                    force_insert = True
+                field = self.meta.fields.get(pkcolumn)
+                # this is an IntegerField with primary_key set
+                if field is not None and getattr(field, "increment_on_save", 0) != 0:
+                    # we create a new revision.
+                    force_insert = True
+                    # Note: we definitely want this because it is easy for forget a force_insert
+        finally:
+            MODEL_GETATTR_BEHAVIOR.reset(token)
+
+        token2 = EXPLICIT_SPECIFIED_VALUES.set(explicit_values)
+        try:
+            if force_insert:
+                if values:
+                    extracted_fields.update(values)
+                # force save must ensure a complete mapping
+                await self._insert(**extracted_fields)
+            else:
+                await self._update(**(extracted_fields if values is None else values))
+        finally:
+            EXPLICIT_SPECIFIED_VALUES.reset(token2)
+        await self.meta.signals.post_save.send_async(self.__class__, instance=self)
+        return self
+
+    @classmethod
+    def build(
+        cls, schema: Optional[str] = None, metadata: Optional[sqlalchemy.MetaData] = None
+    ) -> sqlalchemy.Table:
+        """
+        Builds the SQLAlchemy table representation from the loaded fields.
+        """
+        tablename: str = cls.meta.tablename
+        registry = cls.meta.registry
+        assert registry is not None, "registry is not set"
+        if metadata is None:
+            metadata = registry.metadata
+        schemes: list[str] = []
+        if schema:
+            schemes.append(schema)
+        schemes.append(registry.db_schema or "")
+
+        unique_together = cls.meta.unique_together
+        index_constraints = cls.meta.indexes
+
+        columns: list[sqlalchemy.Column] = []
+        global_constraints: list[Any] = []
+        for name, field in cls.meta.fields.items():
+            current_columns = field.get_columns(name)
+            columns.extend(current_columns)
+            global_constraints.extend(field.get_global_constraints(name, current_columns, schemes))
+
+        # Handle the uniqueness together
+        uniques = []
+        for unique_index in unique_together or []:
+            unique_constraint = cls._get_unique_constraints(unique_index)
+            uniques.append(unique_constraint)
+
+        # Handle the indexes
+        indexes = []
+        for index_c in index_constraints or []:
+            index = cls._get_indexes(index_c)
+            indexes.append(index)
+        return sqlalchemy.Table(
+            tablename,
+            metadata,
+            *columns,
+            *uniques,
+            *indexes,
+            *global_constraints,
+            extend_existing=True,
+            schema=schema or registry.db_schema,
+        )
+
+    @classmethod
+    def _get_unique_constraints(
+        cls, columns: Union[Sequence, str, sqlalchemy.UniqueConstraint]
+    ) -> Optional[sqlalchemy.UniqueConstraint]:
+        """
+        Returns the unique constraints for the model.
+
+        The columns must be a a list, tuple of strings or a UniqueConstraint object.
+
+        :return: Model UniqueConstraint.
+        """
+        if isinstance(columns, str):
+            return sqlalchemy.UniqueConstraint(columns)
+        elif isinstance(columns, UniqueConstraint):
+            return sqlalchemy.UniqueConstraint(*columns.fields, name=columns.name)
+        return sqlalchemy.UniqueConstraint(*columns)
+
+    @classmethod
+    def _get_indexes(cls, index: Index) -> Optional[sqlalchemy.Index]:
+        """
+        Creates the index based on the Index fields
+        """
+        return sqlalchemy.Index(index.name, *index.fields)
+
+    def transaction(self, *, force_rollback: bool = False, **kwargs: Any) -> "Transaction":
+        """Return database transaction for the assigned database"""
+        return self.database.transaction(force_rollback=force_rollback, **kwargs)

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -1,26 +1,23 @@
 import copy
 import inspect
-import warnings
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import ClassVar, cast
 
-from edgy.core.db.context_vars import (
-    CURRENT_INSTANCE,
-    EXPLICIT_SPECIFIED_VALUES,
-    MODEL_GETATTR_BEHAVIOR,
-)
 from edgy.core.db.models.base import EdgyBaseModel
-from edgy.core.db.models.mixins import DeclarativeMixin, ModelRowMixin, ReflectedModelMixin
+from edgy.core.db.models.managers import Manager, RedirectManager
+from edgy.core.db.models.metaclasses import BaseModelMeta, MetaInfo
+from edgy.core.db.models.mixins import (
+    DatabaseMixin,
+    DeclarativeMixin,
+    ModelRowMixin,
+    ReflectedModelMixin,
+)
 from edgy.core.db.models.model_proxy import ProxyModel
-from edgy.core.utils.db import check_db_connection
 from edgy.core.utils.models import generify_model_fields
-from edgy.exceptions import ObjectNotFound
-
-if TYPE_CHECKING:
-    from databasez.core.transaction import Transaction
 
 
-class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
+class Model(
+    ModelRowMixin, DeclarativeMixin, DatabaseMixin, EdgyBaseModel, metaclass=BaseModelMeta
+):
     """
     Representation of an Edgy `Model`.
 
@@ -51,6 +48,10 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
             registry = models
     ```
     """
+
+    query: ClassVar[Manager] = Manager()
+    query_related: ClassVar[RedirectManager] = RedirectManager(redirect_name="query")
+    meta: ClassVar[MetaInfo] = MetaInfo(None, abstract=True)
 
     class Meta:
         abstract = True
@@ -86,232 +87,6 @@ class Model(ModelRowMixin, DeclarativeMixin, EdgyBaseModel):
         proxy_model.build()
         generify_model_fields(cast(type[EdgyBaseModel], proxy_model.model))
         return cast(type[Model], proxy_model.model)
-
-    async def _update(self, **kwargs: Any) -> Any:
-        """
-        Update operation of the database fields.
-        """
-        await self.meta.signals.pre_update.send_async(self.__class__, instance=self)
-        column_values = self.extract_column_values(
-            extracted_values=kwargs,
-            is_partial=True,
-            is_update=True,
-            phase="prepare_update",
-            instance=self,
-            model_instance=self,
-        )
-        # empty updates shouldn't cause an error. E.g. only model references are updated
-        clauses = self.identifying_clauses()
-        token = CURRENT_INSTANCE.set(self)
-        try:
-            if column_values and clauses:
-                check_db_connection(self.database)
-                async with self.database as database, database.transaction():
-                    # can update column_values
-                    column_values.update(
-                        await self.execute_pre_save_hooks(
-                            column_values, kwargs, force_insert=False
-                        )
-                    )
-                    expression = self.table.update().values(**column_values).where(*clauses)
-                    await database.execute(expression)
-
-                # Update the model instance.
-                new_kwargs = self.transform_input(
-                    column_values, phase="post_update", instance=self
-                )
-                self.__dict__.update(new_kwargs)
-
-            # updates aren't required to change the db, they can also just affect the meta fields
-            await self.execute_post_save_hooks(
-                cast(Sequence[str], kwargs.keys()), force_insert=False
-            )
-
-        finally:
-            CURRENT_INSTANCE.reset(token)
-        if column_values or kwargs:
-            # Ensure on access refresh the results is active
-            self._loaded_or_deleted = False
-        await self.meta.signals.post_update.send_async(self.__class__, instance=self)
-
-    async def update(self, **kwargs: Any) -> "Model":
-        token = EXPLICIT_SPECIFIED_VALUES.set(set(kwargs.keys()))
-        try:
-            await self._update(**kwargs)
-        finally:
-            EXPLICIT_SPECIFIED_VALUES.reset(token)
-        return self
-
-    async def delete(
-        self, skip_post_delete_hooks: bool = False, remove_referenced_call: bool = False
-    ) -> None:
-        """Delete operation from the database"""
-        await self.meta.signals.pre_delete.send_async(self.__class__, instance=self)
-        # get values before deleting
-        field_values: dict[str, Any] = {}
-        if not skip_post_delete_hooks and self.meta.post_delete_fields:
-            token = MODEL_GETATTR_BEHAVIOR.set("coro")
-            try:
-                for field_name in self.meta.post_delete_fields:
-                    try:
-                        field_value = getattr(self, field_name)
-                    except AttributeError:
-                        continue
-                    if inspect.isawaitable(field_value):
-                        try:
-                            field_value = await field_value
-                        except AttributeError:
-                            continue
-                    field_values[field_name] = field_value
-            finally:
-                MODEL_GETATTR_BEHAVIOR.reset(token)
-        clauses = self.identifying_clauses()
-        if clauses:
-            expression = self.table.delete().where(*clauses)
-            check_db_connection(self.database)
-            async with self.database as database:
-                await database.execute(expression)
-        # we cannot load anymore
-        self._loaded_or_deleted = True
-        # now cleanup with the saved values
-        for field_name, value in field_values.items():
-            field = self.meta.fields[field_name]
-            await field.post_delete_callback(value, instance=self)
-
-        await self.meta.signals.post_delete.send_async(self.__class__, instance=self)
-
-    async def load(self, only_needed: bool = False) -> None:
-        if only_needed and self._loaded_or_deleted:
-            return
-        row = None
-        clauses = self.identifying_clauses()
-        if clauses:
-            # Build the select expression.
-            expression = self.table.select().where(*clauses)
-
-            # Perform the fetch.
-            check_db_connection(self.database)
-            async with self.database as database:
-                row = await database.fetch_one(expression)
-        # check if is in system
-        if row is None:
-            raise ObjectNotFound("row does not exist anymore")
-        # Update the instance.
-        self.__dict__.update(self.transform_input(dict(row._mapping), phase="load", instance=self))
-        self._loaded_or_deleted = True
-
-    async def _insert(self, **kwargs: Any) -> "Model":
-        """
-        Performs the save instruction.
-        """
-        column_values: dict[str, Any] = self.extract_column_values(
-            extracted_values=kwargs,
-            is_partial=False,
-            is_update=False,
-            phase="prepare_insert",
-            instance=self,
-            model_instance=self,
-        )
-        check_db_connection(self.database)
-        token = CURRENT_INSTANCE.set(self)
-        try:
-            async with self.database as database, database.transaction():
-                # can update column_values
-                column_values.update(
-                    await self.execute_pre_save_hooks(column_values, kwargs, force_insert=True)
-                )
-                expression = self.table.insert().values(**column_values)
-                autoincrement_value = await database.execute(expression)
-            # sqlalchemy supports only one autoincrement column
-            if autoincrement_value:
-                column = self.table.autoincrement_column
-                if column is not None and hasattr(autoincrement_value, "_mapping"):
-                    autoincrement_value = autoincrement_value._mapping[column.key]
-                # can be explicit set, which causes an invalid value returned
-                if column is not None and column.key not in column_values:
-                    column_values[column.key] = autoincrement_value
-
-            new_kwargs = self.transform_input(column_values, phase="post_insert", instance=self)
-            self.__dict__.update(new_kwargs)
-
-            if self.meta.post_save_fields:
-                await self.execute_post_save_hooks(
-                    cast(Sequence[str], kwargs.keys()), force_insert=True
-                )
-        finally:
-            CURRENT_INSTANCE.reset(token)
-        # Ensure on access refresh the results is active
-        self._loaded_or_deleted = False
-
-        return self
-
-    async def save(
-        self,
-        force_insert: bool = False,
-        values: Union[dict[str, Any], set[str], None] = None,
-        force_save: Optional[bool] = None,
-    ) -> "Model":
-        """
-        Performs a save of a given model instance.
-        When creating a user it will make sure it can update existing or
-        create a new one.
-        """
-        if force_save is not None:
-            warnings.warn(
-                "'force_save' is deprecated in favor of 'force_insert'",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            force_insert = force_save
-
-        await self.meta.signals.pre_save.send_async(self.__class__, instance=self)
-
-        extracted_fields = self.extract_db_fields()
-        if values is None:
-            explicit_values: set[str] = set()
-        elif isinstance(values, set):
-            # special mode for marking values as explicit values
-            explicit_values = set(values)
-            values = None
-        else:
-            explicit_values = set(values.keys())
-
-        token = MODEL_GETATTR_BEHAVIOR.set("coro")
-        try:
-            for pkcolumn in self.__class__.pkcolumns:
-                # should trigger load in case of identifying_db_fields
-                value = getattr(self, pkcolumn, None)
-                if inspect.isawaitable(value):
-                    value = await value
-                if value is None and self.table.columns[pkcolumn].autoincrement:
-                    extracted_fields.pop(pkcolumn, None)
-                    force_insert = True
-                field = self.meta.fields.get(pkcolumn)
-                # this is an IntegerField with primary_key set
-                if field is not None and getattr(field, "increment_on_save", 0) != 0:
-                    # we create a new revision.
-                    force_insert = True
-                    # Note: we definitely want this because it is easy for forget a force_insert
-        finally:
-            MODEL_GETATTR_BEHAVIOR.reset(token)
-
-        token2 = EXPLICIT_SPECIFIED_VALUES.set(explicit_values)
-        try:
-            if force_insert:
-                if values:
-                    extracted_fields.update(values)
-                # force save must ensure a complete mapping
-                await self._insert(**extracted_fields)
-            else:
-                await self._update(**(extracted_fields if values is None else values))
-        finally:
-            EXPLICIT_SPECIFIED_VALUES.reset(token2)
-        await self.meta.signals.post_save.send_async(self.__class__, instance=self)
-        return self
-
-    def transaction(self, *, force_rollback: bool = False, **kwargs: Any) -> "Transaction":
-        """Return database transaction for the assigned database"""
-        return self.database.transaction(force_rollback=force_rollback, **kwargs)
 
 
 class ReflectModel(ReflectedModelMixin, Model):

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import inspect
 from typing import ClassVar, cast
@@ -57,7 +59,7 @@ class Model(
         abstract = True
 
     @classmethod
-    def generate_proxy_model(cls) -> type["Model"]:
+    def generate_proxy_model(cls) -> type[Model]:
         """
         Generates a proxy model for each model. This proxy model is a simple
         shallow copy of the original model being generated.

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -43,7 +43,7 @@ class DescriptiveMeta:
 
 class BaseModelType(ABC):
     """
-    Type of EdgyBaseModel
+    Type of edgy.Model and EdgyBaseModel
     """
 
     columns: ClassVar["sqlalchemy.sql.ColumnCollection"]

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from typing import (
@@ -46,27 +48,27 @@ class BaseModelType(ABC):
     Type of edgy.Model and EdgyBaseModel
     """
 
-    columns: ClassVar["sqlalchemy.sql.ColumnCollection"]
-    database: ClassVar["Database"]
-    table: ClassVar["sqlalchemy.Table"]
+    columns: ClassVar[sqlalchemy.sql.ColumnCollection]
+    database: ClassVar[Database]
+    table: ClassVar[sqlalchemy.Table]
     # Primary key columns
     pkcolumns: ClassVar[Sequence[str]]
     # Primary key fields
     pknames: ClassVar[Sequence[str]]
-    query: ClassVar["BaseManager"]
-    query_related: ClassVar["BaseManager"]
-    meta: ClassVar["MetaInfo"]
-    _db_schemas: ClassVar[dict[str, type["BaseModelType"]]]
+    query: ClassVar[BaseManager]
+    query_related: ClassVar[BaseManager]
+    meta: ClassVar[MetaInfo]
+    _db_schemas: ClassVar[dict[str, type[BaseModelType]]]
     Meta: ClassVar[DescriptiveMeta] = DescriptiveMeta()
 
-    __parent__: ClassVar[Union[type["BaseModelType"], None]] = None
+    __parent__: ClassVar[Union[type[BaseModelType], None]] = None
     __is_proxy_model__: ClassVar[bool] = False
     __require_model_based_deletion__: ClassVar[bool] = False
     __reflected__: ClassVar[bool] = False
 
     @property
     @abstractmethod
-    def proxy_model(self) -> type["BaseModelType"]: ...
+    def proxy_model(self) -> type[BaseModelType]: ...
 
     @property
     @abstractmethod
@@ -79,11 +81,11 @@ class BaseModelType(ABC):
         """identifying_db_fields are completely specified."""
 
     @abstractmethod
-    def transaction(self, *, force_rollback: bool = False, **kwargs: Any) -> "Transaction":
+    def transaction(self, *, force_rollback: bool = False, **kwargs: Any) -> Transaction:
         """Return database transaction for the assigned database."""
 
     @abstractmethod
-    def get_columns_for_name(self, name: str) -> Sequence["sqlalchemy.Column"]:
+    def get_columns_for_name(self, name: str) -> Sequence[sqlalchemy.Column]:
         """Helper for retrieving columns from field name."""
 
     @abstractmethod
@@ -92,7 +94,7 @@ class BaseModelType(ABC):
 
     @classmethod
     @abstractmethod
-    def generate_proxy_model(cls) -> type["BaseModel"]:
+    def generate_proxy_model(cls) -> type[BaseModel]:
         """
         Generates a proxy model for each model. This proxy model is a simple
         shallow copy of the original model being generated.
@@ -113,7 +115,7 @@ class BaseModelType(ABC):
         self,
         force_insert: bool = False,
         values: Union[dict[str, Any], set[str], list[str], None] = None,
-    ) -> "BaseModelType":
+    ) -> BaseModelType:
         """Save model"""
 
     @abstractmethod
@@ -142,8 +144,8 @@ class BaseModelType(ABC):
     @classmethod
     @abstractmethod
     def build(
-        cls, schema: Optional[str] = None, metadata: Optional["sqlalchemy.MetaData"] = None
-    ) -> "sqlalchemy.Table":
+        cls, schema: Optional[str] = None, metadata: Optional[sqlalchemy.MetaData] = None
+    ) -> sqlalchemy.Table:
         """
         Builds the SQLAlchemy table representation from the loaded fields.
         """
@@ -170,8 +172,8 @@ class BaseModelType(ABC):
         extracted_values: dict[str, Any],
         is_update: bool = False,
         is_partial: bool = False,
-        instance: Optional[Union["BaseModelType", "QuerySet"]] = None,
-        model_instance: Optional["BaseModelType"] = None,
+        instance: Optional[Union[BaseModelType, QuerySet]] = None,
+        model_instance: Optional[BaseModelType] = None,
     ) -> dict[str, Any]:
         """
         Extracts all the default values from the given fields and returns the raw

--- a/edgy/core/marshalls/metaclasses.py
+++ b/edgy/core/marshalls/metaclasses.py
@@ -28,8 +28,9 @@ class MarshallMeta(ModelMetaclass):
         # TODO: should have correct types
         attrs, model_fields = extract_field_annotations_and_defaults(attrs, BaseMarshallField)
 
-        parents = [parent for parent in bases if isinstance(parent, MarshallMeta)]
-        if not parents:
+        has_parents = any(isinstance(parent, MarshallMeta) for parent in bases)
+
+        if not has_parents:
             return super().__new__(cls, name, bases, attrs)
 
         model_class: Marshall = super().__new__(cls, name, bases, attrs)  # type: ignore

--- a/edgy/core/utils/models.py
+++ b/edgy/core/utils/models.py
@@ -6,7 +6,6 @@ if TYPE_CHECKING:
     from pydantic import ConfigDict
 
     from edgy.core.db.models import Model
-    from edgy.core.db.models.base import EdgyBaseModel
     from edgy.core.db.models.metaclasses import MetaInfo
     from edgy.core.db.models.types import BaseModelType
 
@@ -53,7 +52,7 @@ def create_edgy_model(
     return model
 
 
-def generify_model_fields(model: type["EdgyBaseModel"]) -> dict[Any, Any]:
+def generify_model_fields(model: type["BaseModelType"]) -> dict[Any, Any]:
     """
     Makes all fields generic when a partial model is generated or used.
     This also removes any metadata for the field such as validations making
@@ -64,7 +63,7 @@ def generify_model_fields(model: type["EdgyBaseModel"]) -> dict[Any, Any]:
 
     # handle the nested non existing results
     for name, field in model.model_fields.items():
-        field.annotation = Any  # type: ignore
+        field.annotation = Any
         field.null = True
         # set a default to fix is_required
         if field.default is PydanticUndefined:


### PR DESCRIPTION
Changes:

- move database related stuff in Model Mixin
- move metaclass from EdgyBaseModel to edgy.Model as well as some other attributes
- remove unused attribute with limited use parents from edgy MetaInfo
- improve multi_related attribute of MetaInfo by altering it so it contains the fk tuples which are set when used as a through model for ManyToMany fields
- deprecate `is_multi` there are no users and it can be evaluated as well by checking bool(multi_related)