### PR TITLE
remove `__db_model__` and replace by registry = False

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -263,6 +263,11 @@ yourself.
 The way of declaring an abstract model in **Edgy** is by passing `True` to the `abstract`
 attribute in the [meta](#the-meta-class) class.
 
+### Explicitly disable registry registration
+
+Sometimes you want to add a model manually to the registry and not to retrieve a registry by the parents.
+This can be archived by setting Meta registry to False.
+
 #### In a nutshell
 
 In this document we already mentioned abstract models and how to use them but let us use some more

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,7 +9,7 @@ hide:
 
 ### Removed
 
-- `__db_model__` is removed. Disabling registry retrieval via False is sufficient.
+- `__db_model__` is removed. Replaced by registry = False.
 
 ### Changed
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,17 @@ hide:
 
 # Release Notes
 
+## 0.18.2
+
+### Removed
+
+- `__db_model__` is removed. Disabling registry retrieval via False is sufficient.
+
+### Changed
+
+- Allow setting registry = False, for disabling retrieving the registry from parents.
+
+
 ## 0.18.1
 
 ### Changed

--- a/edgy/contrib/autoreflection/metaclasses.py
+++ b/edgy/contrib/autoreflection/metaclasses.py
@@ -86,7 +86,7 @@ class AutoReflectionMeta(BaseModelMeta):
             not skip_registry
             and isinstance(new_model.meta, AutoReflectionMetaInfo)
             and not new_model.meta.abstract
-            and new_model.meta.registry is not None
+            and new_model.meta.registry
         ):
             new_model.meta.registry.pattern_models[new_model.__name__] = new_model
         return new_model

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -423,9 +423,7 @@ class BaseForeignKey(RelationshipField):
     @cached_property
     def target_registry(self) -> "Registry":
         """Registry searched in case to is a string"""
-        assert (
-            self.owner.meta.registry is not None
-        ), "no registry found neither 'target_registry' set"
+        assert self.owner.meta.registry, "no registry found neither 'target_registry' set"
         return self.owner.meta.registry
 
     @property

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -93,7 +93,6 @@ class ConcreteFileField(BaseCompositeField):
         if (
             phase in {"post_update", "post_insert"}
             and instance is not None
-            and getattr(instance, "__db_model__", False)
             and isinstance(instance.__dict__.get(self.name), FieldFile)
         ):
             # use old one, when instance is no queryset

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -158,7 +158,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         pknames = set()
         if self.through:
             if isinstance(self.through, str):
-                assert self.owner.meta.registry is not None, "no registry found"
+                assert self.owner.meta.registry, "no registry found"
                 self.through = self.owner.meta.registry.models[self.through]
             through = self.through
             if through.meta.abstract:
@@ -191,6 +191,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
                     self.to_foreign_key = candidate
                 through.meta.multi_related.add((self.from_foreign_key, self.to_foreign_key))
                 return
+        assert self.owner.meta.registry, "no registry set"
         owner_name = self.owner.__name__
         to_name = self.target.__name__
         class_name = f"{owner_name}{to_name}"

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -48,8 +48,6 @@ class EdgyBaseModel(BaseModel, BaseModelType):
     model_config = ConfigDict(extra="ignore", arbitrary_types_allowed=True)
 
     __proxy_model__: ClassVar[Union[type[Model], None]] = None
-    # is inheriting from a registered model, so the registry is set
-    __db_model__: ClassVar[bool] = False
     __reflected__: ClassVar[bool] = False
     __show_pk__: ClassVar[bool] = False
     __using_schema__: Union[str, None, Any] = Undefined

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -48,7 +48,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
     model_config = ConfigDict(extra="ignore", arbitrary_types_allowed=True)
 
     __proxy_model__: ClassVar[Union[type[Model], None]] = None
-    # is inheriting from a registered model, so the registry is true
+    # is inheriting from a registered model, so the registry is set
     __db_model__: ClassVar[bool] = False
     __reflected__: ClassVar[bool] = False
     __show_pk__: ClassVar[bool] = False

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -480,7 +480,7 @@ class DatabaseMixin:
         """
         tablename: str = cls.meta.tablename
         registry = cls.meta.registry
-        assert registry is not None, "registry is not set"
+        assert registry, "registry is not set"
         if metadata is None:
             metadata = registry.metadata
         schemes: list[str] = []

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -148,7 +148,6 @@ class DatabaseMixin:
                 _set_related_name_for_foreign_keys(meta, cls)
             registry.execute_model_callbacks(cls)
 
-        cls.__db_model__ = True
         # finalize
         cls.model_rebuild(force=True)
 

--- a/edgy/core/db/models/mixins/reflection.py
+++ b/edgy/core/db/models/mixins/reflection.py
@@ -28,7 +28,7 @@ class ReflectedModelMixin:
         The inspect is done in an async manner and reflects the objects from the database.
         """
         registry = cls.meta.registry
-        assert registry is not None, "registry is not set"
+        assert registry, "registry is not set"
         if metadata is None:
             metadata = registry.metadata
         if cls.__using_schema__ is not Undefined:

--- a/edgy/core/db/models/mixins/row.py
+++ b/edgy/core/db/models/mixins/row.py
@@ -26,7 +26,7 @@ class ModelRowMixin:
         """Check if a model_class can be loaded from a row for the table."""
 
         return bool(
-            cls.meta.registry is not None
+            cls.meta.registry
             and not cls.meta.abstract
             and all(
                 row._mapping.get(f"{table.key.replace('.', '_')}_{col}") is not None

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -53,6 +53,7 @@ class Model(
 
     query: ClassVar[Manager] = Manager()
     query_related: ClassVar[RedirectManager] = RedirectManager(redirect_name="query")
+    # registry = False, stops the retrieval of the registry from base classes
     meta: ClassVar[MetaInfo] = MetaInfo(None, abstract=True, registry=False)
 
     class Meta:
@@ -99,4 +100,5 @@ class ReflectModel(ReflectedModelMixin, Model):
 
     class Meta:
         abstract = True
+        # registry = False, stops the retrieval of the registry from base classes
         registry = False

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -53,7 +53,7 @@ class Model(
 
     query: ClassVar[Manager] = Manager()
     query_related: ClassVar[RedirectManager] = RedirectManager(redirect_name="query")
-    meta: ClassVar[MetaInfo] = MetaInfo(None, abstract=True)
+    meta: ClassVar[MetaInfo] = MetaInfo(None, abstract=True, registry=False)
 
     class Meta:
         abstract = True
@@ -99,3 +99,4 @@ class ReflectModel(ReflectedModelMixin, Model):
 
     class Meta:
         abstract = True
+        registry = False


### PR DESCRIPTION
Changes:

- Allow stopping the retrieval of the registry from parents by setting registry = False.
- remove `__db_model__` it was serving a similar purpose but wasn't really configurable by users.