### PR TITLE
fix autodetection when dotted directories are in the cwd

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,11 @@ hide:
 
 # Release Notes
 
+## 0.23.2
+
+### Fixed
+
+- Autodetection of the instance was broken when a directory containing dots is in the folder.
 
 ## 0.23.1
 

--- a/edgy/cli/decorators.py
+++ b/edgy/cli/decorators.py
@@ -68,7 +68,7 @@ def add_app_module_option(fn: Any) -> Any:
                 if edgy.monkay.instance is not None:
                     return  # type: ignore
             for path in cwd.iterdir():
-                if path.is_dir():
+                if "." not in path.name and path.is_dir():
                     for preload in DISCOVERY_PRELOADS:
                         with suppress(ImportError):
                             import_module(f"{path.name}.{preload}")


### PR DESCRIPTION
Changes:
- fix autodetection when having dotted directories in the cwd and edgy doesn't load before