### PR TITLE
add real name in comment in migrations

### DIFF
--- a/edgy/cli/templates/default/script.py.mako
+++ b/edgy/cli/templates/default/script.py.mako
@@ -40,10 +40,14 @@ def downgrade(engine_name: str = "") -> None:
 % for db_name in db_names:
 
 def ${f"upgrade_{hash_to_identifier(db_name or '')}"}():
+    # Migration of:
+    # ${db_name or 'main database'}
     ${context.get(f"{db_name or ''}_upgrades", "pass")}
 
 
 def ${f"downgrade_{hash_to_identifier(db_name or '')}"}():
+    # Migration of:
+    # ${db_name or 'main database'}
     ${context.get(f"{db_name or ''}_downgrades", "pass")}
 
 % endfor

--- a/edgy/cli/templates/url/script.py.mako
+++ b/edgy/cli/templates/url/script.py.mako
@@ -54,10 +54,14 @@ def downgrade(url: Optional["DatabaseURL"] = None) -> None:
 % for db_name in db_names:
 
 def ${f"upgrade_{hash_to_identifier(url_for_name(db_name))}"}():
+    # Migration of:
+    # ${url_for_name(db_name)} (${db_name or 'main database'})
     ${context.get(f"{db_name or ''}_upgrades", "pass")}
 
 
 def ${f"downgrade_{hash_to_identifier(url_for_name(db_name))}"}():
+    # Migration of:
+    # ${url_for_name(db_name)} (${db_name or 'main database'})
     ${context.get(f"{db_name or ''}_downgrades", "pass")}
 
 % endfor


### PR DESCRIPTION
Changes:

- add real database name / url as comment when mangling the database name/url