### PR TITLE
add with_async_env

### DIFF
--- a/docs/connection.md
+++ b/docs/connection.md
@@ -45,6 +45,12 @@ Or doing it manually (that applies to every framework):
 {!> ../docs_src/connections/simple.py !}
 ```
 
+Or just as an async contexmanager
+
+```python
+{!> ../docs_src/connections/asynccontextmanager.py !}
+```
+
 And that is pretty much this. Once the connection is hooked into your application lifecycle.
 Otherwise you will get warnings about decreased performance because the databasez backend is not connected and will be
 reininitialized for each operation.
@@ -80,10 +86,38 @@ This warning appears, when an unconnected Database object is used for an operati
 
 Despite bailing out the warning `DatabaseNotConnectedWarning` is raised.
 You should connect correctly like shown above.
+In sync environments it is a bit trickier.
 
 !!! Note
     When passing Database objects via using, make sure they are connected. They are not necessarily connected
     when not in extra.
+
+## Integration in sync environments
+
+When the framework is sync by default and no async loop is active we can fallback to `run_sync`.
+It is required to build an async evnironment via the `with_async_env` method of registry. Otherwise
+we run in bad performance problems and have `DatabaseNotConnectedWarning` warnings.
+`run_sync` calls **must** happen within the scope of `with_async_env`. `with_async_env` is reentrant and has an optional loop parameter.
+
+```python
+{!> ../docs_src/connections/contextmanager.py !}
+```
+To keep the loop alive for performance reasons we can either wrap the server worker loop or in case of
+a single-threaded server the server loop which runs the application. As an alternative you can also keep the asyncio eventloop alive.
+This is easier for sync first frameworks like flask.
+Here an example which is even multithreading save.
+
+```python
+{!> ../docs_src/connections/contextmanager_with_loop.py !}
+```
+
+That was complicated, huh? Let's unroll it in a simpler example with explicit loop cleanup.
+
+
+```python
+{!> ../docs_src/connections/contextmanager_with_loop_and_cleanup.py !}
+```
+
 
 ## Querying other schemas
 

--- a/docs/queries/queries.md
+++ b/docs/queries/queries.md
@@ -1045,47 +1045,21 @@ Let us see some examples.
 **Async mode**
 
 ```python
-async with registry:
-    await User.query.all()
-    await User.query.filter(name__icontains="example")
-    await User.query.create(name="Edgy")
+await User.query.all()
+await User.query.filter(name__icontains="example")
+await User.query.create(name="Edgy")
 ```
 
 **With run_sync**
 
 ```python
-from edgy import run_sync
-with registry:
-    run_sync(User.query.all())
-    run_sync(User.query.filter(name__icontains="example"))
-    run_sync(User.query.create(name="Edgy"))
+run_sync(User.query.all())
+run_sync(User.query.filter(name__icontains="example"))
+run_sync(User.query.create(name="Edgy"))
 ```
 
-**With run_sync and existing loop**
-
-```python
-from edgy import run_sync
-with registry.with_loop(loop):
-    run_sync(User.query.all())
-    run_sync(User.query.filter(name__icontains="example"))
-    run_sync(User.query.create(name="Edgy"))
-```
-
-**With run_sync and a wrapper method**
-
-```python
-from edgy import run_sync
-async main():
-    async with registry:
-        await User.query.all()
-        await User.query.filter(name__icontains="example")
-        await User.query.create(name="Edgy")
-run_sync(main)
-# or
-# asyncio.run(main)
-```
-
-And that is it! You can now run all queries synchronously within any framework, literally.
+And that is it! You can now run all queries synchronously within any framework. You still have to connect
+the Registry with its dbs first via `async with registry: ...` or in sync-frameworks with `with registry.with_async_env(): ...`.
 
 ## Cross database queries
 

--- a/docs/queries/queries.md
+++ b/docs/queries/queries.md
@@ -1045,19 +1045,44 @@ Let us see some examples.
 **Async mode**
 
 ```python
-await User.query.all()
-await User.query.filter(name__icontains="example")
-await User.query.create(name="Edgy")
+async with registry:
+    await User.query.all()
+    await User.query.filter(name__icontains="example")
+    await User.query.create(name="Edgy")
 ```
 
 **With run_sync**
 
 ```python
 from edgy import run_sync
+with registry:
+    run_sync(User.query.all())
+    run_sync(User.query.filter(name__icontains="example"))
+    run_sync(User.query.create(name="Edgy"))
+```
 
-run_sync(User.query.all())
-run_sync(User.query.filter(name__icontains="example"))
-run_sync(User.query.create(name="Edgy"))
+**With run_sync and existing loop**
+
+```python
+from edgy import run_sync
+with registry.with_loop(loop):
+    run_sync(User.query.all())
+    run_sync(User.query.filter(name__icontains="example"))
+    run_sync(User.query.create(name="Edgy"))
+```
+
+**With run_sync and a wrapper method**
+
+```python
+from edgy import run_sync
+async main():
+    async with registry:
+        await User.query.all()
+        await User.query.filter(name__icontains="example")
+        await User.query.create(name="Edgy")
+run_sync(main)
+# or
+# asyncio.run(main)
 ```
 
 And that is it! You can now run all queries synchronously within any framework, literally.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,8 @@ hide:
 
 - Add `exclude_autoincrement` parameter/class attribute to ModelFactory.
 - Add `build_values` method to ModelFactory. It can be used to extract the values without a model.
+- Make Registry initialization compatible with sync contexts via `with_async_env(loop=None)` method.
+- `run_sync` has now an optional loop parameter.
 
 ### Changed
 
@@ -24,6 +26,8 @@ hide:
 - `to_list_factory_field` honors the min and max parameter specified by parameters.
   It defaults however to the provided min and max parameters.
 - RefForeignKey has now an extra subclass of BaseField. This way the exclusion of works reliable.
+- `run_sync` reuses idling loops.
+- `run_sync` uses the loop set by the Registry contextmanager `with_async_env`.
 
 ### Fixed
 

--- a/docs_src/connections/asynccontextmanager.py
+++ b/docs_src/connections/asynccontextmanager.py
@@ -1,0 +1,12 @@
+from edgy import Registry, Instance, monkay
+
+models = Registry(database="sqlite:///db.sqlite", echo=True)
+
+
+async def main():
+    # check if settings are loaded
+    monkay.evaluate_settings_once(ignore_import_errors=False)
+    # monkey-patch so you can use edgy shell
+    monkay.set_instance(Instance(registry=registry))
+    async with models:
+        ...

--- a/docs_src/connections/contextmanager.py
+++ b/docs_src/connections/contextmanager.py
@@ -1,0 +1,14 @@
+from edgy import Registry, Instance, monkay
+
+models = Registry(database="sqlite:///db.sqlite", echo=True)
+
+
+# check if settings are loaded
+monkay.evaluate_settings_once(ignore_import_errors=False)
+# monkey-patch app so you can use edgy shell
+monkay.set_instance(Instance(registry=registry))
+
+
+def main():
+    with models.with_async_env():
+        edgy.run_sync(User.query.all())

--- a/docs_src/connections/contextmanager_with_loop.py
+++ b/docs_src/connections/contextmanager_with_loop.py
@@ -1,0 +1,31 @@
+import asyncio
+from contextvars import ContextVar
+from edgy import Registry, Instance, monkay, run_sync
+
+models = Registry(database="sqlite:///db.sqlite", echo=True)
+
+
+# multithreading safe
+event_loop = ContextVar("event_loop", default=None)
+
+
+def handle_request():
+    loop = event_loop.get()
+    if loop is None:
+        # eventloops die by default with the thread
+        loop = asyncio.new_event_loop()
+        event_loop.set(loop)
+    with models.with_loop(loop):
+        edgy.run_sync(User.query.all())
+
+
+def get_application():
+    app = ...
+    # check if settings are loaded
+    monkay.evaluate_settings_once(ignore_import_errors=False)
+    # monkey-patch app so you can use edgy shell
+    monkay.set_instance(Instance(registry=registry, app=app))
+    return app
+
+
+app = get_application()

--- a/docs_src/connections/contextmanager_with_loop_and_cleanup.py
+++ b/docs_src/connections/contextmanager_with_loop_and_cleanup.py
@@ -1,0 +1,21 @@
+import asyncio
+from edgy import Registry, Instance, monkay, run_sync
+
+models = Registry(database="sqlite:///db.sqlite", echo=True)
+
+# check if settings are loaded
+monkay.evaluate_settings_once(ignore_import_errors=False)
+# monkey-patch app so you can use edgy shell
+monkay.set_instance(Instance(registry=registry))
+
+loop = asyncio.new_event_loop()
+with models.with_loop(loop):
+    edgy.run_sync(User.query.all())
+
+# uses the same loop
+with models.with_loop(loop):
+    edgy.run_sync(User.query.all())
+
+
+loop.run_until_complete(loop.shutdown_asyncgens())
+loop.close()

--- a/edgy/core/connection/registry.py
+++ b/edgy/core/connection/registry.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import declarative_base as sa_declarative_base
 from edgy.conf import evaluate_settings_once_ready
 from edgy.core.connection.database import Database, DatabaseURL
 from edgy.core.connection.schemas import Schema
-from edgy.core.utils.sync import current_eventloop_and_registry, run_sync
+from edgy.core.utils.sync import current_eventloop, run_sync
 from edgy.types import Undefined
 
 from .asgi import ASGIApp, ASGIHelper
@@ -579,51 +579,30 @@ class Registry:
         await asyncio.gather(*ops)
 
     @contextlib.contextmanager
-    def with_loop(self, loop: asyncio.AbstractEventLoop) -> Generator["Registry", None, None]:
-        token = current_eventloop_and_registry.set((loop, self, False))
-        try:
-            yield self.__enter__()
-        finally:
-            current_eventloop_and_registry.reset(token)
-
-    def __enter__(self) -> "Registry":
-        _loop = current_eventloop_and_registry.get()
-        try:
-            loop = asyncio.get_running_loop()
-            # when in async context we don't create a loop
-        except RuntimeError:
-            # also when called recursively and current_eventloop_and_registry is available
-            _loop = current_eventloop_and_registry.get()
-            if _loop is None:
-                loop = asyncio.new_event_loop()
-                current_eventloop_and_registry.set((loop, self, True))
-            else:
-                loop = _loop[0]
-        return run_sync(self.__aenter__(), loop=loop)
-
-    def __exit__(
-        self,
-        exc_type: Optional[type[BaseException]] = None,
-        exc_value: Optional[BaseException] = None,
-        traceback: Optional[TracebackType] = None,
-        *,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
-    ) -> None:
-        _loop = current_eventloop_and_registry.get()
+    def with_async_env(
+        self, loop: Optional[asyncio.AbstractEventLoop] = None
+    ) -> Generator["Registry", None, None]:
+        close: bool = False
         if loop is None:
             try:
                 loop = asyncio.get_running_loop()
+                # when in async context we don't create a loop
             except RuntimeError:
-                if _loop is not None:
-                    loop = _loop[0]
+                # also when called recursively and current_eventloop is available
+                loop = current_eventloop.get()
+                if loop is None:
+                    loop = asyncio.new_event_loop()
+                    close = True
+
+        token = current_eventloop.set(loop)
         try:
-            return run_sync(self.__aexit__(exc_type, exc_value, traceback))
+            yield run_sync(self.__aenter__(), loop=loop)
         finally:
-            if _loop and _loop[1] is self:
-                current_eventloop_and_registry.set(None)
-                if _loop[2]:
-                    _loop[0].run_until_complete(_loop[0].shutdown_asyncgens())
-                    _loop[0].close()
+            run_sync(self.__aexit__(), loop=loop)
+            current_eventloop.reset(token)
+            if close:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.close()
 
     @overload
     def asgi(

--- a/edgy/core/utils/sync.py
+++ b/edgy/core/utils/sync.py
@@ -3,15 +3,11 @@ import weakref
 from collections.abc import Awaitable
 from contextvars import ContextVar, copy_context
 from threading import Event, Thread
-from typing import TYPE_CHECKING, Any, Optional
-
-if TYPE_CHECKING:
-    from edgy.core.connection.registry import Registry
-
+from typing import Any, Optional
 
 # for registry with
-current_eventloop_and_registry: ContextVar[tuple[asyncio.AbstractEventLoop, "Registry", bool]] = (
-    ContextVar("current_eventloop_and_registry", default=None)
+current_eventloop: ContextVar[Optional[asyncio.AbstractEventLoop]] = ContextVar(
+    "current_eventloop", default=None
 )
 
 
@@ -77,9 +73,7 @@ def run_sync(
             loop = asyncio.get_running_loop()
         except RuntimeError:
             # in sync contexts there is no asyncio.get_running_loop()
-            _loop = current_eventloop_and_registry.get()
-            if _loop is not None:
-                loop = _loop[0]
+            loop = current_eventloop.get()
 
     if loop is None:
         return asyncio.run(_coro_helper(awaitable, timeout))

--- a/tests/registry/test_registry_run_sync.py
+++ b/tests/registry/test_registry_run_sync.py
@@ -1,0 +1,53 @@
+import asyncio
+
+import pytest
+
+import edgy
+from edgy.testing.client import DatabaseTestClient
+from tests.settings import DATABASE_URL
+
+database = DatabaseTestClient(
+    DATABASE_URL,
+    full_isolation=False,
+    use_existing=False,
+    drop_database=True,
+    force_rollback=False,
+)
+models = edgy.Registry(database=database)
+
+
+class User(edgy.StrictModel):
+    name: str = edgy.fields.CharField(max_length=100)
+
+    class Meta:
+        registry = models
+
+
+def test_run_sync_lifecyle():
+    with models.with_async_env():
+        edgy.run_sync(models.create_all())
+        user = edgy.run_sync(User(name="edgy").save())
+        assert user
+        assert edgy.run_sync(User.query.get()) == user
+
+
+def test_run_sync_lifecyle_sub():
+    with models.with_async_env(), models.with_async_env():
+        edgy.run_sync(models.create_all())
+        user = edgy.run_sync(User(name="edgy").save())
+        assert user
+        assert edgy.run_sync(User.query.get()) == user
+
+
+def test_run_sync_lifecyle_with_idle_loop():
+    with pytest.raises(RuntimeError):
+        asyncio.get_running_loop()
+    loop = asyncio.new_event_loop()
+    with models.with_async_env(loop=loop):
+        edgy.run_sync(models.create_all())
+        user = edgy.run_sync(User(name="edgy").save())
+        assert user
+        assert edgy.run_sync(User.query.get()) == user
+    loop.close()
+    with pytest.raises(RuntimeError):
+        asyncio.get_running_loop()


### PR DESCRIPTION
Changes:

- add `with_async_env` method to registry
- `run_sync` reuses idling loops.
- `run_sync` uses the loop set by the Registry contextmanager `with_async_env`.