### PR TITLE
fix missing cleanup of subloops

### DIFF
--- a/docs/connection.md
+++ b/docs/connection.md
@@ -118,6 +118,24 @@ That was complicated, huh? Let's unroll it in a simpler example with explicit lo
 {!> ../docs_src/connections/contextmanager_with_loop_and_cleanup.py !}
 ```
 
+Note: `with_async_env` also calls `__aenter__` and `__aexit__` internally. So the database is connected during the
+with scope spanned by `with_async_env`.
+
+## `run_sync` function
+
+`run_sync` needs a bit more explaination. On the one hand it hooks into the async environment
+spawned by `with_async_env`. On the other hand it prefers checking for an active running loop (except if an explicit loop was provided).
+If an active loop was found, a subloop is spawned which is only torn down when the found loop (or explicit provided loop) was collected.
+When an idling loop was found, it will be reused, instead of creating a subloop.
+
+What is a subloop?
+
+A subloop is an eventloop running in an extra thread. This enables us to run multiple eventloops simultanously.
+They are removed when the parent eventloop is garbage collected.
+
+However given that the eventloops are quite sticky despite they should have been garbage collected
+we additionally poll if the old loop had stopped.
+
 
 ## Querying other schemas
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,12 +76,7 @@ First you have to prepare the setup via:
 ``` shell
 # only once required until stopped or db leftovers clogging up
 $ docker compose up -d
-# required for every terminal session the tests are executed in, except for setups with higher file descriptor limits
-$ ulimit -n 10000
 ```
-Note: currently we need to increase the file descriptor limit otherwise later tests cannot execute anymore because of missing file descriptors.
-Exact reasons are unknown but we may recreate the engine too often and the filedecriptors close too slow.
-This only affects user systems with low file descriptor limits.
 
 To run the tests, use:
 
@@ -102,7 +97,6 @@ To run the linting, use:
 ```shell
 $ hatch fmt
 ```
-
 
 #### Tests especially wanted
 
@@ -134,9 +128,7 @@ Alternatively running:
 ```shell
 $ hatch shell
 ```
-
 It will install the requirements and create a local build in your virtual environment.
-
 
 ## Releasing
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,13 @@ hide:
 
 # Release Notes
 
+## 0.25.2
+
+### Fixed
+
+- Cleanup of event-loops and threads in run_sync.
+
+
 ## 0.25.1
 
 ### Added

--- a/edgy/__init__.py
+++ b/edgy/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.25.1"
+__version__ = "0.25.2"
 from typing import TYPE_CHECKING
 
 from ._monkay import Instance, create_monkay

--- a/edgy/core/utils/sync.py
+++ b/edgy/core/utils/sync.py
@@ -29,7 +29,7 @@ async def _startup(old_loop: asyncio.AbstractEventLoop, is_initialized: Event) -
     is_initialized.set()
     # poll old loop
     while True:
-        if old_loop.is_running():
+        if not old_loop.is_closed():
             await asyncio.sleep(0.5)
         else:
             break


### PR DESCRIPTION
Changes:

- fix missing cleanup of subloops by polling (sry no better idea, the loop should have been collected)
- update docs
- bump version

This fixes a nasty testing bug
In practice this shouldn't have any bigger effects. Normally the loops are not changed that often.