### PR TITLE
Fix clashing name on same many 2 many fields

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,29 @@ hide:
 
 # Release Notes
 
+## 0.27.0
+
+### Changed
+
+- Added a new table naming schema for through models of ManyToMany fields. This requires however setting
+  an explicit table naming schema via the `through_tablename` parameter.
+- When `through_tablename` is a string, it is formatted with the field injected as field in the context.
+
+### Fixed
+
+- Multiple ManyFields from the same model to the same target model. Note: this is unrelated to `related_name`, setting the
+  the `related_name` would not help.
+
+### BREAKING
+
+For now ManyToMany fields **must** explicitly have a `through_tablename` parameter in which
+the table naming schema for the through model is selected.
+For existing ManyToMany fields you should pass `edgy.OLD_M2M_NAMING"` so migrations doesn't drop the tables,
+for new ManyToMany fields `edgy.NEW_M2M_NAMING"` which prevents clashes of through model names.
+You may can also rename the through model table via migration and use the `edgy.NEW_M2M_NAMING"`
+or simply use a non-empty string for the `through_tablename` parameter.
+
+
 ## 0.26.1
 
 ### Added

--- a/docs_src/contenttypes/m2m_with_contenttypes.py
+++ b/docs_src/contenttypes/m2m_with_contenttypes.py
@@ -24,7 +24,9 @@ class Person(edgy.Model):
 
 class Organisation(edgy.Model):
     name = edgy.fields.CharField(max_length=100, unique=True)
-    persons = edgy.fields.ManyToMany(to=Person, through=PersonsOrganisations)
+    persons = edgy.fields.ManyToMany(
+        to=Person, through=PersonsOrganisations, through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models

--- a/docs_src/permissions/advanced.py
+++ b/docs_src/permissions/advanced.py
@@ -13,15 +13,15 @@ class User(edgy.Model):
 
 class Group(edgy.Model):
     name = edgy.fields.CharField(max_length=100)
-    users = edgy.fields.ManyToMany("User", embed_through=False)
+    users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
 
 
 class Permission(BasePermission):
-    users = edgy.fields.ManyToMany("User", embed_through=False)
-    groups = edgy.fields.ManyToMany("Group", embed_through=False)
+    users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
+    groups = edgy.fields.ManyToMany("Group", through_tablename=edgy.NEW_M2M_NAMING)
     name_model: str = edgy.fields.CharField(max_length=100, null=True)
     obj = edgy.fields.ForeignKey("ContentType", null=True)
 

--- a/docs_src/permissions/primary_key.py
+++ b/docs_src/permissions/primary_key.py
@@ -13,7 +13,9 @@ class User(edgy.Model):
 
 class Group(edgy.Model):
     name = edgy.fields.CharField(max_length=100)
-    users = edgy.fields.ManyToMany("User", embed_through=False)
+    users = edgy.fields.ManyToMany(
+        "User", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models
@@ -22,8 +24,12 @@ class Group(edgy.Model):
 class Permission(BasePermission):
     # overwrite name of BasePermission with a CharField with primary_key=True
     name: str = edgy.fields.CharField(max_length=100, primary_key=True)
-    users = edgy.fields.ManyToMany("User", embed_through=False)
-    groups = edgy.fields.ManyToMany("Group", embed_through=False)
+    users = edgy.fields.ManyToMany(
+        "User", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
+    groups = edgy.fields.ManyToMany(
+        "Group", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
     name_model: str = edgy.fields.CharField(max_length=100, null=True, primary_key=True)
     obj = edgy.fields.ForeignKey("ContentType", null=True, primary_key=True)
 

--- a/docs_src/permissions/quickstart.py
+++ b/docs_src/permissions/quickstart.py
@@ -12,7 +12,9 @@ class User(edgy.Model):
 
 
 class Permission(BasePermission):
-    users = edgy.fields.ManyToMany("User", embed_through=False)
+    users = edgy.fields.ManyToMany(
+        "User", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models

--- a/docs_src/queries/manytomany/example.py
+++ b/docs_src/queries/manytomany/example.py
@@ -16,7 +16,9 @@ class Team(edgy.Model):
 
 class Organisation(edgy.Model):
     ident: str = edgy.CharField(max_length=100)
-    teams: List[Team] = edgy.ManyToManyField(Team, related_name="organisation_teams")
+    teams: List[Team] = edgy.ManyToManyField(
+        Team, related_name="organisation_teams", through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models

--- a/docs_src/queries/manytomany/no_rel.py
+++ b/docs_src/queries/manytomany/no_rel.py
@@ -16,7 +16,7 @@ class Team(edgy.Model):
 
 class Organisation(edgy.Model):
     ident: str = edgy.CharField(max_length=100)
-    teams: List[Team] = edgy.ManyToManyField(Team)
+    teams: List[Team] = edgy.ManyToManyField(Team, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/edgy/__init__.py
+++ b/edgy/__init__.py
@@ -11,6 +11,17 @@ if TYPE_CHECKING:
     from .core import files
     from .core.connection import Database, DatabaseURL, Registry
     from .core.db import fields
+    from .core.db.constants import (
+        CASCADE,
+        DO_NOTHING,
+        NEW_M2M_NAMING,
+        OLD_M2M_NAMING,
+        PROTECT,
+        RESTRICT,
+        SET_DEFAULT,
+        SET_NULL,
+        ConditionalRedirect,
+    )
     from .core.db.datastructures import Index, UniqueConstraint
 
     # for type checking import all fields
@@ -92,6 +103,8 @@ __all__ = [
     "SET_NULL",
     "SET_DEFAULT",
     "PROTECT",
+    "NEW_M2M_NAMING",
+    "OLD_M2M_NAMING",
     "ConditionalRedirect",
     # models
     "ReflectModel",

--- a/edgy/_monkay.py
+++ b/edgy/_monkay.py
@@ -60,6 +60,8 @@ def create_monkay(global_dict: dict, all_var: list[str]) -> Monkay[Instance, Edg
         "SET_NULL",
         "SET_DEFAULT",
         "PROTECT",
+        "NEW_M2M_NAMING",
+        "OLD_M2M_NAMING",
         "ConditionalRedirect",
     ]:
         monkay.add_lazy_import(name, f"edgy.core.db.constants.{name}")

--- a/edgy/core/db/constants.py
+++ b/edgy/core/db/constants.py
@@ -6,6 +6,12 @@ SET_DEFAULT = "SET DEFAULT"
 PROTECT = "PROTECT"
 
 
+class OLD_M2M_NAMING: ...
+
+
+class NEW_M2M_NAMING: ...
+
+
 class ConditionalRedirect(dict): ...
 
 

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -232,14 +232,16 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         assert self.owner.meta.registry, "no registry set"
         owner_name = self.owner.__name__
         to_name = self.target.__name__
-        class_name = f"{owner_name}{to_name}"
+
+        class_name = f"{owner_name}{self.name.capitalize()}{to_name}"
+
         if not self.from_foreign_key:
             self.from_foreign_key = owner_name.lower()
 
         if not self.to_foreign_key:
             self.to_foreign_key = to_name.lower()
 
-        tablename = self.through_tablename or f"{self.from_foreign_key}s_{self.to_foreign_key}s"
+        tablename = self.through_tablename or f"{self.from_foreign_key}s_{self.name}_{self.to_foreign_key}s"
         meta_args = {
             "tablename": tablename,
             "multi_related": {(self.from_foreign_key, self.to_foreign_key)},

--- a/tests/cli/main.py
+++ b/tests/cli/main.py
@@ -22,15 +22,21 @@ class User(edgy.StrictModel):
 
 class Group(edgy.StrictModel):
     name = edgy.fields.CharField(max_length=100)
-    users = edgy.fields.ManyToMany("User", embed_through=False)
+    users = edgy.fields.ManyToMany(
+        "User", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models
 
 
 class Permission(BasePermission):
-    users = edgy.fields.ManyToMany("User", embed_through=False)
-    groups = edgy.fields.ManyToMany("Group", embed_through=False)
+    users = edgy.fields.ManyToMany(
+        "User", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
+    groups = edgy.fields.ManyToMany(
+        "Group", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
     name_model: str = edgy.fields.CharField(max_length=100, null=True)
     obj = edgy.fields.ForeignKey("ContentType", null=True)
 

--- a/tests/cli/main_multidb.py
+++ b/tests/cli/main_multidb.py
@@ -25,15 +25,15 @@ class User(edgy.StrictModel):
 
 class Group(edgy.StrictModel):
     name = edgy.fields.CharField(max_length=100)
-    users = edgy.fields.ManyToMany("User", embed_through=False)
+    users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
 
 
 class Permission(BasePermission):
-    users = edgy.fields.ManyToMany("User", embed_through=False)
-    groups = edgy.fields.ManyToMany("Group", embed_through=False)
+    users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
+    groups = edgy.fields.ManyToMany("Group", through_tablename=edgy.NEW_M2M_NAMING)
     name_model: str = edgy.fields.CharField(max_length=100, null=True)
     obj = edgy.fields.ForeignKey("ContentType", null=True)
 

--- a/tests/cli/main_multidb_nonidentifier.py
+++ b/tests/cli/main_multidb_nonidentifier.py
@@ -25,15 +25,15 @@ class User(edgy.StrictModel):
 
 class Group(edgy.StrictModel):
     name = edgy.fields.CharField(max_length=100)
-    users = edgy.fields.ManyToMany("User", embed_through=False)
+    users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
 
 
 class Permission(BasePermission):
-    users = edgy.fields.ManyToMany("User", embed_through=False)
-    groups = edgy.fields.ManyToMany("Group", embed_through=False)
+    users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
+    groups = edgy.fields.ManyToMany("Group", through_tablename=edgy.NEW_M2M_NAMING)
     name_model: str = edgy.fields.CharField(max_length=100, null=True)
     obj = edgy.fields.ForeignKey("ContentType", null=True)
 

--- a/tests/contrib/multi_tenancy/test_mt_models.py
+++ b/tests/contrib/multi_tenancy/test_mt_models.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 import pytest
 
-from edgy import Database, Registry
+from edgy import NEW_M2M_NAMING, Database, Registry
 from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields, set_tenant
@@ -72,7 +72,7 @@ class Product(TenantModel):
 
 
 class Cart(TenantModel):
-    products = fields.ManyToMany(Product)
+    products = fields.ManyToMany(Product, through_tablename=NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/tests/contrib/multi_tenancy/test_tenant_models_using.py
+++ b/tests/contrib/multi_tenancy/test_tenant_models_using.py
@@ -1,6 +1,6 @@
 import pytest
 
-from edgy import Database, Registry
+from edgy import NEW_M2M_NAMING, Database, Registry
 from edgy.contrib.multi_tenancy import TenantModel
 from edgy.contrib.multi_tenancy.models import TenantMixin
 from edgy.core.db import fields
@@ -53,7 +53,7 @@ class Product(TenantModel):
 
 
 class Cart(TenantModel):
-    products = fields.ManyToMany(Product)
+    products = fields.ManyToMany(Product, through_tablename=NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/tests/contrib/permissions/test_advanced_permissions.py
+++ b/tests/contrib/permissions/test_advanced_permissions.py
@@ -22,15 +22,15 @@ class User(edgy.StrictModel):
 
 class Group(edgy.StrictModel):
     name = edgy.fields.CharField(max_length=100)
-    users = edgy.fields.ManyToMany("User", embed_through=False)
+    users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
 
 
 class Permission(BasePermission):
-    users = edgy.fields.ManyToMany("User", embed_through=False)
-    groups = edgy.fields.ManyToMany("Group", embed_through=False)
+    users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
+    groups = edgy.fields.ManyToMany("Group", through_tablename=edgy.NEW_M2M_NAMING)
     name_model: str = edgy.fields.CharField(max_length=100, null=True)
     obj = edgy.fields.ForeignKey("ContentType", null=True)
 

--- a/tests/contrib/permissions/test_group_permissions.py
+++ b/tests/contrib/permissions/test_group_permissions.py
@@ -20,15 +20,21 @@ class User(edgy.StrictModel):
 
 class Group(edgy.StrictModel):
     name = edgy.fields.CharField(max_length=100)
-    users = edgy.fields.ManyToMany("User", embed_through=False)
+    users = edgy.fields.ManyToMany(
+        "User", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models
 
 
 class Permission(BasePermission):
-    users = edgy.fields.ManyToMany("User", embed_through=False)
-    groups = edgy.fields.ManyToMany("Group", embed_through=False)
+    users = edgy.fields.ManyToMany(
+        "User", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
+    groups = edgy.fields.ManyToMany(
+        "Group", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models

--- a/tests/contrib/permissions/test_simple_permissions.py
+++ b/tests/contrib/permissions/test_simple_permissions.py
@@ -19,7 +19,7 @@ class User(edgy.StrictModel):
 
 
 class Permission(BasePermission):
-    users = edgy.fields.ManyToMany("User", embed_through=False)
+    users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/tests/extensions/test_extensions.py
+++ b/tests/extensions/test_extensions.py
@@ -25,7 +25,7 @@ class PermissionExtension:
                 registry = value.instance.registry
 
         class Permission(BasePermission):
-            users = edgy.fields.ManyToMany("User", embed_through=False)
+            users = edgy.fields.ManyToMany("User", through_tablename=edgy.NEW_M2M_NAMING)
 
             class Meta:
                 registry = value.instance.registry

--- a/tests/factory/test_factory.py
+++ b/tests/factory/test_factory.py
@@ -47,7 +47,7 @@ class Product(edgy.StrictModel):
 
 
 class Cart(edgy.StrictModel):
-    products = edgy.fields.ManyToMany(Product)
+    products = edgy.fields.ManyToMany(Product, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/tests/factory/test_factory_errors.py
+++ b/tests/factory/test_factory_errors.py
@@ -32,7 +32,7 @@ class Product(edgy.StrictModel):
 
 
 class Cart(edgy.StrictModel):
-    products = edgy.fields.ManyToMany(Product)
+    products = edgy.fields.ManyToMany(Product, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/tests/factory/test_parameters.py
+++ b/tests/factory/test_parameters.py
@@ -34,7 +34,7 @@ class Product(edgy.StrictModel):
 
 
 class Cart(edgy.StrictModel):
-    products = edgy.fields.ManyToMany(Product)
+    products = edgy.fields.ManyToMany(Product, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/tests/factory/test_save.py
+++ b/tests/factory/test_save.py
@@ -45,7 +45,7 @@ class Product(edgy.StrictModel):
 
 
 class Cart(edgy.StrictModel):
-    products = edgy.fields.ManyToMany(Product)
+    products = edgy.fields.ManyToMany(Product, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/tests/factory/test_to_field.py
+++ b/tests/factory/test_to_field.py
@@ -33,7 +33,7 @@ class Product(edgy.StrictModel):
 
 
 class Cart(edgy.StrictModel):
-    products = edgy.fields.ManyToMany(Product)
+    products = edgy.fields.ManyToMany(Product, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/m2m_string/test_many_to_many.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many.py
@@ -16,7 +16,9 @@ models = edgy.Registry(database=database)
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField("Track", embed_through="embedded")
+    tracks = edgy.ManyToManyField(
+        "Track", embed_through="embedded", through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models
@@ -24,8 +26,8 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToManyField("User")
-    albums = edgy.ManyToManyField("Album")
+    users = edgy.ManyToManyField("User", through_tablename=edgy.NEW_M2M_NAMING)
+    albums = edgy.ManyToManyField("Album", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -160,7 +162,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTracksThrough'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/m2m_string/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_field.py
@@ -15,8 +15,12 @@ models = edgy.Registry(database=database)
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany("User", embed_through="embedded")
-    albums = edgy.ManyToMany("Album", embed_through="embedded")
+    users = edgy.ManyToMany(
+        "User", embed_through="embedded", through_tablename=edgy.NEW_M2M_NAMING
+    )
+    albums = edgy.ManyToMany(
+        "Album", embed_through="embedded", through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models
@@ -32,7 +36,9 @@ class User(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany("Track", embed_through="embedded")
+    tracks = edgy.ManyToMany(
+        "Track", embed_through="embedded", through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models
@@ -145,7 +151,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTracksThrough'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/m2m_string/test_many_to_many_field_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_field_related_name.py
@@ -15,7 +15,12 @@ models = edgy.Registry(database=database)
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField("Track", related_name="album_tracks", embed_through="embedded")
+    tracks = edgy.ManyToManyField(
+        "Track",
+        related_name="album_tracks",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models
@@ -23,8 +28,18 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToManyField("User", related_name="studio_users", embed_through="embedded")
-    albums = edgy.ManyToManyField("Album", related_name="studio_albums", embed_through="embedded")
+    users = edgy.ManyToManyField(
+        "User",
+        related_name="studio_users",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
+    albums = edgy.ManyToManyField(
+        "Album",
+        related_name="studio_albums",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_no_related_name.py
@@ -15,7 +15,7 @@ models = edgy.Registry(database=database)
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.fields.CharField(max_length=100)
-    tracks = edgy.ManyToMany("Track", related_name=False)
+    tracks = edgy.ManyToMany("Track", related_name=False, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/m2m_string/test_many_to_many_related_name.py
@@ -15,7 +15,12 @@ models = edgy.Registry(database=database)
 class Album(edgy.StrictModel):
     id = edgy.fields.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.fields.CharField(max_length=100)
-    tracks = edgy.fields.ManyToMany("Track", related_name="album_tracks", embed_through="embedded")
+    tracks = edgy.fields.ManyToMany(
+        "Track",
+        related_name="album_tracks",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models
@@ -23,8 +28,18 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany("User", related_name="studio_users", embed_through="embedded")
-    albums = edgy.ManyToMany("Album", related_name="studio_albums", embed_through="embedded")
+    users = edgy.ManyToMany(
+        "User",
+        related_name="studio_users",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
+    albums = edgy.ManyToMany(
+        "Album",
+        related_name="studio_albums",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many.py
@@ -30,7 +30,7 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField("Track", embed_through="")
+    tracks = edgy.ManyToManyField("Track", embed_through="", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -38,8 +38,8 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToManyField("User", embed_through="")
-    albums = edgy.ManyToManyField("Album", embed_through="")
+    users = edgy.ManyToManyField("User", embed_through="", through_tablename=edgy.NEW_M2M_NAMING)
+    albums = edgy.ManyToManyField("Album", embed_through="", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -154,7 +154,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTracksThrough'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_field.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_field.py
@@ -30,7 +30,7 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany("Track", embed_through="")
+    tracks = edgy.ManyToMany("Track", embed_through="", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -38,8 +38,8 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany("User", embed_through="")
-    albums = edgy.ManyToMany("Album", embed_through="")
+    users = edgy.ManyToMany("User", embed_through="", through_tablename=edgy.NEW_M2M_NAMING)
+    albums = edgy.ManyToMany("Album", embed_through="", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -143,7 +143,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTracksThrough'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_field_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_field_related_name.py
@@ -29,7 +29,12 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField("Track", related_name="album_tracks", embed_through="")
+    tracks = edgy.ManyToManyField(
+        "Track",
+        related_name="album_tracks",
+        embed_through="",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models
@@ -37,8 +42,18 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToManyField("User", related_name="studio_users", embed_through="")
-    albums = edgy.ManyToManyField("Album", related_name="studio_albums", embed_through="")
+    users = edgy.ManyToManyField(
+        "User",
+        related_name="studio_users",
+        embed_through="",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
+    albums = edgy.ManyToManyField(
+        "Album",
+        related_name="studio_albums",
+        embed_through="",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_no_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_no_related_name.py
@@ -22,7 +22,9 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany("Track", related_name=False, embed_through="")
+    tracks = edgy.ManyToMany(
+        "Track", related_name=False, embed_through="", through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/m2m_string_old/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/m2m_string_old/test_many_to_many_related_name.py
@@ -29,7 +29,12 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany("Track", related_name="album_tracks", embed_through="")
+    tracks = edgy.ManyToMany(
+        "Track",
+        related_name="album_tracks",
+        embed_through="",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models
@@ -37,8 +42,18 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany("User", related_name="studio_users", embed_through="")
-    albums = edgy.ManyToMany("Album", related_name="studio_albums", embed_through="")
+    users = edgy.ManyToMany(
+        "User",
+        related_name="studio_users",
+        embed_through="",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
+    albums = edgy.ManyToMany(
+        "Album",
+        related_name="studio_albums",
+        embed_through="",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/test_many_to_many.py
+++ b/tests/foreign_keys/test_many_to_many.py
@@ -31,7 +31,9 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField(Track, embed_through="embedded")
+    tracks = edgy.ManyToManyField(
+        Track, embed_through="embedded", through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models
@@ -39,8 +41,8 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToManyField(User)
-    albums = edgy.ManyToManyField(Album)
+    users = edgy.ManyToManyField(User, through_tablename=edgy.NEW_M2M_NAMING)
+    albums = edgy.ManyToManyField(Album, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -160,7 +162,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTracksThrough'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/test_many_to_many_field.py
+++ b/tests/foreign_keys/test_many_to_many_field.py
@@ -30,7 +30,9 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany(Track, embed_through="embedded")
+    tracks = edgy.ManyToMany(
+        Track, embed_through="embedded", through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models
@@ -38,8 +40,8 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany(User)
-    albums = edgy.ManyToMany(Album)
+    users = edgy.ManyToMany(User, through_tablename=edgy.NEW_M2M_NAMING)
+    albums = edgy.ManyToMany(Album, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -155,7 +157,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTracksThrough'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/test_many_to_many_field_new_naming_multiple.py
+++ b/tests/foreign_keys/test_many_to_many_field_new_naming_multiple.py
@@ -22,9 +22,11 @@ class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
     users = edgy.ManyToMany(
         Üser,
-        to_foreign_key="usr",
-        from_foreign_key="fromage",
-        through_tablename=edgy.OLD_M2M_NAMING,
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
+    admins = edgy.ManyToMany(
+        Üser,
+        through_tablename=edgy.NEW_M2M_NAMING,
     )
 
     class Meta:
@@ -32,7 +34,8 @@ class Studio(edgy.StrictModel):
 
 
 def test_check_tablename():
-    assert Studio.meta.fields["users"].through.meta.tablename == "fromages_usrs"
+    assert Studio.meta.fields["users"].through.meta.tablename == "studiousersthrough"
+    assert Studio.meta.fields["admins"].through.meta.tablename == "studioadminsthrough"
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -54,6 +57,7 @@ async def test_many_to_many_many_fields():
     # Add users and albums to studio
     await studio.users.add(user1)
     await studio.users.add(user2)
+    await studio.admins.add(user2)
     await studio.users.add(user3)
 
     # Start querying
@@ -64,3 +68,7 @@ async def test_many_to_many_many_fields():
     assert total_users[0].pk == user1.pk
     assert total_users[1].pk == user2.pk
     assert total_users[2].pk == user3.pk
+
+    total_admins = await studio.admins.all()
+    assert len(total_admins) == 1
+    assert total_admins[0].pk == user2.pk

--- a/tests/foreign_keys/test_many_to_many_field_old.py
+++ b/tests/foreign_keys/test_many_to_many_field_old.py
@@ -30,7 +30,7 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany(Track, embed_through="")
+    tracks = edgy.ManyToMany(Track, embed_through="", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -38,8 +38,8 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany(User)
-    albums = edgy.ManyToMany(Album, embed_through="")
+    users = edgy.ManyToMany(User, through_tablename=edgy.NEW_M2M_NAMING)
+    albums = edgy.ManyToMany(Album, embed_through="", through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -143,7 +143,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTracksThrough'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/test_many_to_many_field_related_name.py
+++ b/tests/foreign_keys/test_many_to_many_field_related_name.py
@@ -29,7 +29,12 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField(Track, related_name="album_tracks", embed_through="embedded")
+    tracks = edgy.ManyToManyField(
+        Track,
+        related_name="album_tracks",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models
@@ -37,8 +42,18 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToManyField(User, related_name="studio_users", embed_through="embedded")
-    albums = edgy.ManyToManyField(Album, related_name="studio_albums", embed_through="embedded")
+    users = edgy.ManyToManyField(
+        User,
+        related_name="studio_users",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
+    albums = edgy.ManyToManyField(
+        Album,
+        related_name="studio_albums",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/test_many_to_many_field_related_name_old.py
+++ b/tests/foreign_keys/test_many_to_many_field_related_name_old.py
@@ -29,7 +29,9 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField(Track, related_name="album_tracks", embed_through="")
+    tracks = edgy.ManyToManyField(
+        Track, related_name="album_tracks", embed_through="", through_tablename=edgy.OLD_M2M_NAMING
+    )
 
     class Meta:
         registry = models
@@ -37,8 +39,15 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToManyField(User, related_name="studio_users", embed_through="")
-    albums = edgy.ManyToManyField(Album, related_name="studio_albums", embed_through="")
+    users = edgy.ManyToManyField(
+        User, related_name="studio_users", embed_through="", through_tablename=edgy.OLD_M2M_NAMING
+    )
+    albums = edgy.ManyToManyField(
+        Album,
+        related_name="studio_albums",
+        embed_through="",
+        through_tablename=edgy.OLD_M2M_NAMING,
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/test_many_to_many_old.py
+++ b/tests/foreign_keys/test_many_to_many_old.py
@@ -31,7 +31,7 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField(Track, embed_through="")
+    tracks = edgy.ManyToManyField(Track, embed_through="", through_tablename=edgy.OLD_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -39,8 +39,8 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToManyField(User, embed_through="")
-    albums = edgy.ManyToManyField(Album, embed_through="")
+    users = edgy.ManyToManyField(User, embed_through="", through_tablename=edgy.OLD_M2M_NAMING)
+    albums = edgy.ManyToManyField(Album, embed_through="", through_tablename=edgy.OLD_M2M_NAMING)
 
     class Meta:
         registry = models
@@ -156,7 +156,7 @@ async def test_raises_RelationshipIncompatible():
     with pytest.raises(RelationshipIncompatible) as raised:
         await album.tracks.add(user)
 
-    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTrack'."
+    assert raised.value.args[0] == "The child is not from the types 'Track', 'AlbumTracksThrough'."
 
 
 async def test_raises_RelationshipNotFound():

--- a/tests/foreign_keys/test_many_to_many_related_name.py
+++ b/tests/foreign_keys/test_many_to_many_related_name.py
@@ -29,7 +29,9 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany(Track, related_name="album_tracks")
+    tracks = edgy.ManyToMany(
+        Track, related_name="album_tracks", through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models
@@ -37,8 +39,12 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany(User, related_name="studio_users")
-    albums = edgy.ManyToMany(Album, related_name="studio_albums")
+    users = edgy.ManyToMany(
+        User, related_name="studio_users", through_tablename=edgy.NEW_M2M_NAMING
+    )
+    albums = edgy.ManyToMany(
+        Album, related_name="studio_albums", through_tablename=edgy.NEW_M2M_NAMING
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/test_many_to_many_related_name_embedded.py
+++ b/tests/foreign_keys/test_many_to_many_related_name_embedded.py
@@ -29,7 +29,12 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany(Track, related_name="album_tracks", embed_through="embedded")
+    tracks = edgy.ManyToMany(
+        Track,
+        related_name="album_tracks",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models
@@ -37,8 +42,18 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany(User, related_name="studio_users", embed_through="embedded")
-    albums = edgy.ManyToMany(Album, related_name="studio_albums", embed_through="embedded")
+    users = edgy.ManyToMany(
+        User,
+        related_name="studio_users",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
+    albums = edgy.ManyToMany(
+        Album,
+        related_name="studio_albums",
+        embed_through="embedded",
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/test_many_to_many_related_name_old.py
+++ b/tests/foreign_keys/test_many_to_many_related_name_old.py
@@ -29,7 +29,9 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany(Track, related_name="album_tracks", embed_through="")
+    tracks = edgy.ManyToMany(
+        Track, related_name="album_tracks", embed_through="", through_tablename=edgy.OLD_M2M_NAMING
+    )
 
     class Meta:
         registry = models
@@ -37,8 +39,15 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany(User, related_name="studio_users", embed_through="")
-    albums = edgy.ManyToMany(Album, related_name="studio_albums", embed_through="")
+    users = edgy.ManyToMany(
+        User, related_name="studio_users", embed_through="", through_tablename=edgy.OLD_M2M_NAMING
+    )
+    albums = edgy.ManyToMany(
+        Album,
+        related_name="studio_albums",
+        embed_through="",
+        through_tablename=edgy.OLD_M2M_NAMING,
+    )
 
     class Meta:
         registry = models

--- a/tests/foreign_keys/test_many_to_many_unique.py
+++ b/tests/foreign_keys/test_many_to_many_unique.py
@@ -23,7 +23,13 @@ class Track(edgy.StrictModel):
 class Album(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToManyField(Track, embed_through="embedded", unique=True, index=True)
+    tracks = edgy.ManyToManyField(
+        Track,
+        embed_through="embedded",
+        unique=True,
+        index=True,
+        through_tablename=edgy.NEW_M2M_NAMING,
+    )
 
     class Meta:
         registry = models

--- a/tests/models/test_model_copying.py
+++ b/tests/models/test_model_copying.py
@@ -23,7 +23,9 @@ async def test_copy_model_abstract(unlink_same_registry):
             abstract = True
 
     class Cart(edgy.StrictModel):
-        products = edgy.fields.ManyToMany(to=Product, through=ThroughModel)
+        products = edgy.fields.ManyToMany(
+            to=Product, through=ThroughModel, through_tablename=edgy.NEW_M2M_NAMING
+        )
 
         class Meta:
             registry = models
@@ -80,7 +82,9 @@ async def test_copy_model_concrete_same(unlink_same_registry):
             registry = models
 
     class Cart(edgy.StrictModel):
-        products = edgy.fields.ManyToMany(to=Product, through=ThroughModel)
+        products = edgy.fields.ManyToMany(
+            to=Product, through=ThroughModel, through_tablename=edgy.NEW_M2M_NAMING
+        )
 
         class Meta:
             registry = models
@@ -135,7 +139,9 @@ async def test_copy_model_concrete_other(unlink_same_registry):
             registry = models3
 
     class Cart(edgy.StrictModel):
-        products = edgy.fields.ManyToMany(to=Product, through=ThroughModel)
+        products = edgy.fields.ManyToMany(
+            to=Product, through=ThroughModel, through_tablename=edgy.NEW_M2M_NAMING
+        )
 
         class Meta:
             registry = models

--- a/tests/models/test_nested_dump.py
+++ b/tests/models/test_nested_dump.py
@@ -28,7 +28,7 @@ class Profile(Base):
     # by default excluded
     computed = edgy.fields.ComputedField(callback, exclude=False, secret=True)
     # should be always excluded otherwise we end up with a relationship in a model_dump
-    m2m = edgy.fields.ManyToMany("Profile")
+    m2m = edgy.fields.ManyToMany("Profile", through_tablename=edgy.NEW_M2M_NAMING)
 
 
 class User(Base):

--- a/tests/registry/test_registry_copying.py
+++ b/tests/registry/test_registry_copying.py
@@ -21,7 +21,9 @@ async def test_copy_registry_abstract():
             abstract = True
 
     class Cart(edgy.StrictModel):
-        products = edgy.fields.ManyToMany(to=Product, through=ThroughModel)
+        products = edgy.fields.ManyToMany(
+            to=Product, through=ThroughModel, through_tablename=edgy.NEW_M2M_NAMING
+        )
 
         class Meta:
             registry = models
@@ -67,7 +69,9 @@ async def test_copy_registry_concrete(registry_used):
                 registry = False
 
     class Cart(edgy.StrictModel):
-        products = edgy.fields.ManyToMany(to=Product, through=ThroughModel)
+        products = edgy.fields.ManyToMany(
+            to=Product, through=ThroughModel, through_tablename=edgy.NEW_M2M_NAMING
+        )
 
         class Meta:
             registry = models

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -26,7 +26,7 @@ class User(edgy.StrictModel):
 class Profile(User):
     age = edgy.IntegerField()
     parent = edgy.ForeignKey("Profile", null=True, inherit=False)
-    related = edgy.ManyToMany("Profile", inherit=False)
+    related = edgy.ManyToMany("Profile", inherit=False, through_tablename=edgy.NEW_M2M_NAMING)
 
     class Meta:
         registry = models


### PR DESCRIPTION
When having a model with 2 many to many fields pointing to the same table, it does not generate properly the through models because of a name clashing. What we need to guarantee its that uses always the name of the field declaring the M2M in the name of the through model.

Example:

```python
class Workspace(edgy.Model):
    """
    Base document for the generation of workspaces.
    """

    name: str = fields.CharField(max_length=255, index=True, unique=True)
    users: list["User"] = fields.ManyToManyField(
        "User",
        related_name="workspaces",
    )
    admins: list["User"] = fields.ManyToManyField(
        "User",
        related_name="admin_spaces",
    )
    is_active: bool = fields.BooleanField(
        default=True
```

This was only generating a `WorkspaceUser` because it was only found the `user` and even if the `admins` was found since it was using the from table name and destination (Workspace/User) it wouldn't work.

Now it generates the `WorkspaceUsersUser` and `WorkspaceAdminsUser` because it uses the name of the attribute declaring the M2M.


@devkral  we need to add testing on this and add in the release notes as breaking change since this changes the internal fundamentals of the M2M naming.

Can you continue this PR and add tests for these cases, please? Even using this example or extending to 10 M2Ms pointing to the same table or 2 to one table and 3 to another and query them all (adding, removing...) should always work, pelase?