### PR TITLE
ModelFactoryContext instead of Faker parameter + we have now Sequences

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,15 @@ hide:
 - `SubFactory` in the model factory helpers allowing to import ModelFactory objects from
   other parts of the codebase and apply them directly as dependencies.
 - New `template` to `edgy init` migrations for [sequencial](./migrations/migrations.md#templates) migration file names.
+- Sequences like calls for ModelFactory.
+
+### Changed
+
+- The faker argument was switched out to `context`. The `context` parameter however behaves like a faker instance.
+
+### Fixed
+
+- `exclude_autoincrement` argument applies now also for the sub-factories. Previously we would have need to provide the parameters.
 
 ## 0.27.0
 

--- a/docs/testing/model-factory.md
+++ b/docs/testing/model-factory.md
@@ -215,10 +215,21 @@ If you only want even numbers you can also use `inc_callcount` which advances th
 {!> ../docs_src/testing/factory/sequences_even.py !}
 ```
 
-!!! Tip
-    Only the callcounts of the main factories meta are used by default. SubFactories use also the callcounts of the main factory.
-    You can however drop in a dict in the build* method and it is used instead.
-    This can be useful if you want to have a global call count or don't want the counter advance.
+Wanting odd sequences is a bit more difficult. Here we have to manipulate the callcounter before entering a context.
+This can be archived by passing `callcounts` explicitly to `inc_callcount`. Otherwise the not yet existing context is tried
+to be used.
+
+```python
+{!> ../docs_src/testing/factory/sequences_odd.py !}
+```
+
+What happens when we use a [SubFactory](#subfactory)? Only the callcounts of the entrypoint Factory increase.
+You can also pass exclicitly a callcounts dict which will be increased.
+Here we see how to pass the callcounts of a different factory.
+
+```python
+{!> ../docs_src/testing/factory/sequences_subfactory.py !}
+```
 
 ## Build & build_and_save
 

--- a/docs/testing/model-factory.md
+++ b/docs/testing/model-factory.md
@@ -78,7 +78,9 @@ Known items are:
 - `faker`: The faker instance.
 - `exclude_autoincrement`: The current value of `exclude_autoincrement`. It is used in sub-factories.
 - `depth`: The current depth.
-- `callcounts`: Don't use directly. Use `field.get_callcount()`.or `field.inc_callcount()` to artifically increase the callcount.
+- `callcounts`: Don't use directly. Use `field.get_callcount()` to get.or `field.inc_callcount()` to artifically manipulate the callcount.
+
+You can however save arbitary items here. They should not collide with the known items, so think of non-colliding names to future proof the code.
 
 ### Saving
 

--- a/docs/testing/model-factory.md
+++ b/docs/testing/model-factory.md
@@ -198,14 +198,27 @@ Sometimes you want to have increasing sequences. This can be archived by using t
 Every field has a method named `get_callcount()` which returns the current amount of calls.
 By default it starts with 1. First field call = 1.
 
+#### Resetting sequences
+
+For resetting the sequences, simply call `Factory.meta.callcounts.clear()` of the main factory or of the passed dict object.
+You can also use throw away dicts as callcounts for archiving the reset.
+
+#### Examples
+
+```python
+{!> ../docs_src/testing/factory/sequences.py !}
+```
+
+If you only want even numbers you can also use `inc_callcount` which advances the callcount by two:
+
+```python
+{!> ../docs_src/testing/factory/sequences_even.py !}
+```
+
 !!! Tip
     Only the callcounts of the main factories meta are used by default. SubFactories use also the callcounts of the main factory.
     You can however drop in a dict in the build* method and it is used instead.
     This can be useful if you want to have a global call count or don't want the counter advance.
-
-#### Resetting sequences
-
-For resetting the sequences, simply call `Factory.meta.callcounts.clear()` of the main factory.
 
 ## Build & build_and_save
 
@@ -246,9 +259,12 @@ class UserFactory(ModelFactory, model_validation="none"):
 You have following options:
 
 - `none`: No implicit validation.
-- `warn`: Warn for unsound factory/model definitions which produce other errors than pydantic validation errors. Default.
+- `warn`: Warn for unsound factory/model definitions which produce other errors than pydantic validation errors. The default.
 - `error`: Same as warn but reraise the exception instead of a warning.
 - `pedantic`: Raise even for pydantic validation errors.
+
+!!! Note
+    The validation doesn't increase the callcount of sequences.
 
 ## SubFactory
 

--- a/docs_src/testing/factory/factory_exclude.py
+++ b/docs_src/testing/factory/factory_exclude.py
@@ -6,7 +6,7 @@ test_database = DatabaseTestClient(...)
 models = edgy.Registry(database=...)
 
 
-def callback(field_instance, faker, parameters):
+def callback(field_instance, context, parameters):
     raise ExcludeValue
 
 

--- a/docs_src/testing/factory/factory_mapping2.py
+++ b/docs_src/testing/factory/factory_mapping2.py
@@ -7,8 +7,8 @@ models = edgy.Registry(database=...)
 
 
 # the true user password simulator
-def PasswordField_callback(field: FactoryField, faker: Faker, parameters: dict[str, Any]) -> Any:
-    return faker.random_element(["company", "password123", "querty", "asdfg"])
+def PasswordField_callback(field: FactoryField, context, parameters: dict[str, Any]) -> Any:
+    return context["faker"].random_element(["company", "password123", "querty", "asdfg"])
 
 
 class User(edgy.Model):

--- a/docs_src/testing/factory/factory_parametrize.py
+++ b/docs_src/testing/factory/factory_parametrize.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import edgy
-from edgy.testing.factory import ModelFactory, FactoryField
+from edgy.testing.factory import ModelFactory, FactoryField, ModelFactoryContext
 from faker import Faker
 
 test_database = DatabaseTestClient(...)
@@ -16,7 +16,9 @@ class User(edgy.Model):
         registry = models
 
 
-def name_callback(field_instance: FactoryField, faker: Faker, parameters: dict[str, Any]) -> Any:
+def name_callback(
+    field_instance: FactoryField, context: ModelFactoryContext, parameters: dict[str, Any]
+) -> Any:
     return f"{parameters['first_name']} {parameters['last_name']}"
 
 
@@ -26,13 +28,16 @@ class UserFactory(ModelFactory):
 
     # strings are an abbrevation for faker methods
     language = FactoryField(
-        callback=lambda field_instance, faker, parameters: faker.language_code(**parameters)
+        callback=lambda field_instance, context, parameters: context["faker"].language_code(
+            **parameters
+        )
     )
     name = FactoryField(
         callback=name_callback,
+        # a ModelFactoryContext forwards to faker, so you can pretend it is a faker instance
         parameters={
-            "first_name": lambda field_instance, faker, parameters: faker.first_name(),
-            "last_name": lambda field_instance, faker, parameters: faker.last_name(),
+            "first_name": lambda field_instance, fake_faker, parameters: fake_faker.first_name(),
+            "last_name": lambda field_instance, fake_faker, parameters: fake_faker.last_name(),
         },
     )
 

--- a/docs_src/testing/factory/sequences.py
+++ b/docs_src/testing/factory/sequences.py
@@ -1,0 +1,35 @@
+import edgy
+from edgy.testing.factory import ModelFactory, FactoryField
+
+models = edgy.Registry(database=...)
+
+
+class User(edgy.Model):
+    name: str = edgy.CharField(max_length=100)
+
+    class Meta:
+        registry = models
+
+
+class UserFactory(ModelFactory):
+    class Meta:
+        model = User
+
+    name = FactoryField(
+        callback=lambda field, context, parameters: f"user-{field.get_callcount()}"
+    )
+
+
+user_model_instance = UserFactory().build()
+assert user_model_instance.name == "user-1"
+user_model_instance = UserFactory().build()
+assert user_model_instance.name == "user-2"
+# reset
+UserFactory.meta.callcounts.clear()
+
+user_model_instance = UserFactory().build()
+assert user_model_instance.name == "user-1"
+
+# provide a different callcounts dict
+user_model_instance = UserFactory().build(callcounts={})
+assert user_model_instance.name == "user-1"

--- a/docs_src/testing/factory/sequences_even.py
+++ b/docs_src/testing/factory/sequences_even.py
@@ -1,0 +1,35 @@
+import edgy
+from edgy.testing.factory import ModelFactory, FactoryField
+
+models = edgy.Registry(database=...)
+
+
+class User(edgy.Model):
+    name: str = edgy.CharField(max_length=100)
+
+    class Meta:
+        registry = models
+
+
+class UserFactory(ModelFactory):
+    class Meta:
+        model = User
+
+    name = FactoryField(
+        callback=lambda field, context, parameters: f"user-{field.inc_callcount()}"
+    )
+
+
+user_model_instance = UserFactory().build()
+assert user_model_instance.name == "user-2"
+user_model_instance = UserFactory().build()
+assert user_model_instance.name == "user-4"
+# reset
+UserFactory.meta.callcounts.clear()
+
+user_model_instance = UserFactory().build()
+assert user_model_instance.name == "user-2"
+
+# provide a different callcounts dict
+user_model_instance = UserFactory().build(callcounts={})
+assert user_model_instance.name == "user-2"

--- a/docs_src/testing/factory/sequences_odd.py
+++ b/docs_src/testing/factory/sequences_odd.py
@@ -1,0 +1,28 @@
+import edgy
+from edgy.testing.factory import ModelFactory, FactoryField
+
+models = edgy.Registry(database=...)
+
+
+class User(edgy.Model):
+    name: str = edgy.CharField(max_length=100)
+
+    class Meta:
+        registry = models
+
+
+class UserFactory(ModelFactory):
+    class Meta:
+        model = User
+
+    name = FactoryField(
+        callback=lambda field, context, parameters: f"user-{field.inc_callcount()}"
+    )
+
+
+# manipulate the callcounter. Requires callcounts argument as no context is available here
+UserFactory.meta.fields["name"].inc_callcount(amount=-1, callcounts=UserFactory.meta.callcounts)
+user_model_instance = UserFactory().build()
+assert user_model_instance.name == "user-1"
+user_model_instance = UserFactory().build()
+assert user_model_instance.name == "user-3"

--- a/docs_src/testing/factory/sequences_subfactory.py
+++ b/docs_src/testing/factory/sequences_subfactory.py
@@ -1,0 +1,62 @@
+import edgy
+from edgy.testing.factory import ModelFactory, FactoryField, SubFactory
+
+models = edgy.Registry(database=...)
+
+
+class Group(edgy.Model):
+    name: str = edgy.CharField(max_length=100, null=True)
+
+    class Meta:
+        registry = models
+
+
+class User(edgy.Model):
+    name: str = edgy.CharField(max_length=100)
+    group = edgy.ForeignKey(Group)
+
+    class Meta:
+        registry = models
+
+
+class GroupFactory(ModelFactory):
+    class Meta:
+        model = Group
+
+    name = FactoryField(
+        callback=lambda field, context, parameters: f"group-{field.get_callcount()}"
+    )
+
+
+class UserFactory(ModelFactory):
+    class Meta:
+        model = User
+
+    name = FactoryField(
+        callback=lambda field, context, parameters: f"user-{field.get_callcount()}"
+    )
+
+    group = SubFactory(GroupFactory())
+
+
+user = UserFactory().build()
+assert user.name == "user-1"
+assert user.group.name == "group-1"
+
+user = UserFactory().build()
+assert user.name == "user-2"
+assert user.group.name == "group-2"
+
+# now group callcount is at 1 again because the callcounts of the GroupFactory are used
+group = GroupFactory().build()
+assert group.name == "group-1"
+
+# now group name callcount is at 3 because the callcounts of the UserFactory are used
+group = GroupFactory().build(callcounts=UserFactory.meta.callcounts)
+assert group.name == "group-3"
+
+# now we see the group name callcount has been bumped but not the one of user name because the field wasn't in the
+# GroupFactory build tree
+user = UserFactory().build()
+assert user.name == "user-3"
+assert user.group.name == "group-4"

--- a/edgy/testing/__init__.py
+++ b/edgy/testing/__init__.py
@@ -4,15 +4,29 @@ from monkay import Monkay
 
 if TYPE_CHECKING:
     from .client import DatabaseTestClient
-    from .factory import FactoryField, ListSubFactory, ModelFactory, SubFactory
+    from .factory import (
+        FactoryField,
+        ListSubFactory,
+        ModelFactory,
+        ModelFactoryContext,
+        SubFactory,
+    )
 
-__all__ = ["DatabaseTestClient", "ModelFactory", "SubFactory", "ListSubFactory", "FactoryField"]
+__all__ = [
+    "DatabaseTestClient",
+    "ModelFactory",
+    "SubFactory",
+    "ListSubFactory",
+    "FactoryField",
+    "ModelFactoryContext",
+]
 
 
 Monkay(
     globals(),
     lazy_imports={
         "ModelFactory": ".factory.ModelFactory",
+        "ModelFactoryContext": ".factory.ModelFactoryContext",
         "SubFactory": ".factory.SubFactory",
         "ListSubFactory": ".factory.ListSubFactory",
         "FactoryField": ".factory.FactoryField",

--- a/edgy/testing/factory/__init__.py
+++ b/edgy/testing/factory/__init__.py
@@ -1,5 +1,6 @@
 from .base import ModelFactory
 from .fields import FactoryField
 from .subfactory import ListSubFactory, SubFactory
+from .types import ModelFactoryContext
 
-__all__ = ["ModelFactory", "FactoryField", "ListSubFactory", "SubFactory"]
+__all__ = ["ModelFactory", "FactoryField", "ListSubFactory", "SubFactory", "ModelFactoryContext"]

--- a/edgy/testing/factory/context_vars.py
+++ b/edgy/testing/factory/context_vars.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .types import ModelFactoryContext
+
+model_factory_context: ContextVar[ModelFactoryContext] = ContextVar("model_factory_context")

--- a/edgy/testing/factory/fields.py
+++ b/edgy/testing/factory/fields.py
@@ -111,11 +111,13 @@ class FactoryField:
             _copy.original_name = self.original_name
         return _copy
 
-    def inc_callcount(self) -> int:
-        context = model_factory_context.get()
-        count = context["callcounts"].setdefault(id(self), 0)
-        count += 1
-        context["callcounts"][id(self)] = count
+    def inc_callcount(self, *, amount: int = 1, callcounts: dict[int, int] | None = None) -> int:
+        if callcounts is None:
+            context = model_factory_context.get()
+            callcounts = context["callcounts"]
+        count = callcounts.setdefault(id(self), 0)
+        count += amount
+        callcounts[id(self)] = count
         return count
 
     def get_callcount(self) -> int:

--- a/edgy/testing/factory/fields.py
+++ b/edgy/testing/factory/fields.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 from inspect import isclass
 from typing import TYPE_CHECKING, Any, cast
 
-if TYPE_CHECKING:
-    from faker import Faker
+from .context_vars import model_factory_context
 
+if TYPE_CHECKING:
     from edgy.core.db.fields.types import BaseFieldType
     from edgy.core.db.models.metaclasses import MetaInfo as ModelMetaInfo
 
     from .base import ModelFactory
-    from .types import FactoryCallback, FactoryFieldType, FactoryParameters, FieldFactoryCallback
+    from .types import (
+        FactoryCallback,
+        FactoryFieldType,
+        FactoryParameters,
+        FieldFactoryCallback,
+        ModelFactoryContext,
+    )
 
 
 class FactoryField:
@@ -38,7 +44,9 @@ class FactoryField:
         self.field_type = field_type  # type: ignore
         if isinstance(callback, str):
             callback_name = callback
-            callback = lambda field, faker, parameters: getattr(faker, callback_name)(**parameters)  # noqa
+            callback = lambda field, context, parameters: getattr(context["faker"], callback_name)(  # noqa
+                **parameters
+            )
         self.callback = callback
 
     def get_field_type(self, *, db_model_meta: ModelMetaInfo | None = None) -> str:
@@ -58,7 +66,7 @@ class FactoryField:
     def get_parameters(
         self,
         *,
-        faker: Faker,
+        context: ModelFactoryContext,
         parameters: FactoryParameters | None = None,
     ) -> dict[str, Any]:
         current_parameters: FactoryParameters = {}
@@ -66,7 +74,7 @@ class FactoryField:
             for name, parameter in parameter_dict.items():
                 if name not in current_parameters:
                     if callable(parameter) and not isclass(parameter):
-                        current_parameters[name] = parameter(self, faker, name)
+                        current_parameters[name] = parameter(self, context, name)
                     else:
                         current_parameters[name] = parameter
         return current_parameters
@@ -103,8 +111,19 @@ class FactoryField:
             _copy.original_name = self.original_name
         return _copy
 
-    def __call__(self, *, faker: Faker, parameters: FactoryParameters) -> Any:
-        return self.get_callback()(self, faker, parameters)
+    def inc_callcount(self) -> int:
+        context = model_factory_context.get()
+        count = context["callcounts"].setdefault(id(self), 0)
+        count += 1
+        context["callcounts"][id(self)] = count
+        return count
+
+    def get_callcount(self) -> int:
+        context = model_factory_context.get()
+        return context["callcounts"].get(id(self), 0)
+
+    def __call__(self, *, context: ModelFactoryContext, parameters: FactoryParameters) -> Any:
+        return self.get_callback()(self, context, parameters)
 
 
 __all__ = ["FactoryField"]

--- a/edgy/testing/factory/metaclasses.py
+++ b/edgy/testing/factory/metaclasses.py
@@ -24,18 +24,14 @@ terminal = Print()
 
 # this is not models MetaInfo
 class MetaInfo:
-    __slots__ = (
-        "model",
-        "fields",
-        "faker",
-        "mappings",
-    )
+    __slots__ = ("model", "fields", "faker", "mappings", "callcounts")
     model: type[Model]
     mappings: dict[str, FactoryCallback | None]
 
     def __init__(self, meta: Any = None, **kwargs: Any) -> None:
         self.fields: dict[str, FactoryField] = {}
         self.mappings: dict[str, FactoryCallback | None] = {}
+        self.callcounts: dict[int, int] = {}
         for slot in self.__slots__:
             value = getattr(meta, slot, None)
             if value is not None:
@@ -168,7 +164,8 @@ class ModelFactoryMeta(type):
         # validate
         if model_validation != "none":
             try:
-                new_class().build()
+                # we don't want to updat ethe counts yet
+                new_class().build(callcounts={})
             except ValidationError as exc:
                 if model_validation == "pedantic":
                     raise exc

--- a/edgy/testing/factory/types.py
+++ b/edgy/testing/factory/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict, Union
 
 if TYPE_CHECKING:
     from faker import Faker
@@ -11,15 +11,30 @@ if TYPE_CHECKING:
     from .fields import FactoryField
 
 
+class _ModelFactoryContext(TypedDict):
+    faker: Faker
+    exclude_autoincrement: bool
+    depth: int
+    callcounts: dict[int, int]
+
+
+if TYPE_CHECKING:
+
+    class ModelFactoryContext(Faker, _ModelFactoryContext, Protocol):
+        pass
+else:
+    ModelFactoryContext = _ModelFactoryContext
+
+
 FactoryParameterCallback = Callable[
     [
         "FactoryField",
-        "Faker",
+        ModelFactoryContext,
         str,
     ],
     Any,
 ]
 FactoryParameters = dict[str, Union[Any, FactoryParameterCallback]]
-FactoryCallback = Callable[["FactoryField", "Faker", dict[str, Any]], Any]
+FactoryCallback = Callable[["FactoryField", ModelFactoryContext, dict[str, Any]], Any]
 FieldFactoryCallback = Union[FactoryCallback, str]
 FactoryFieldType = Union[str, "BaseFieldType", type["BaseFieldType"]]

--- a/tests/factory/test_factory.py
+++ b/tests/factory/test_factory.py
@@ -151,6 +151,34 @@ def test_sequences():
     assert product.user.name == "name-2"
 
 
+def test_sequences_even():
+    class UserFactory(ModelFactory):
+        class Meta:
+            model = User
+
+        name = FactoryField(
+            callback=lambda field, context, parameters: f"name-{field.inc_callcount()}"
+        )
+        product_ref = FactoryField(exclude=True)
+
+    class ProductFactory(ModelFactory):
+        class Meta:
+            model = Product
+
+        user = UserFactory().to_factory_field()
+
+    user = UserFactory().build()
+    assert user.name == "name-2"
+    user = UserFactory().build()
+    assert user.name == "name-4"
+
+    # use the callcounts of the main factory
+    product = ProductFactory().build()
+    assert product.user.name == "name-2"
+    product = ProductFactory().build()
+    assert product.user.name == "name-4"
+
+
 def test_exclude_autoincrement_build():
     class UserFactory(ModelFactory):
         class Meta:

--- a/tests/factory/test_factory.py
+++ b/tests/factory/test_factory.py
@@ -179,6 +179,40 @@ def test_sequences_even():
     assert product.user.name == "name-4"
 
 
+def test_sequences_odd():
+    class UserFactory(ModelFactory):
+        class Meta:
+            model = User
+
+        name = FactoryField(
+            callback=lambda field, context, parameters: f"name-{field.inc_callcount()}"
+        )
+        product_ref = FactoryField(exclude=True)
+
+    class ProductFactory(ModelFactory):
+        class Meta:
+            model = Product
+
+        user = UserFactory().to_factory_field()
+
+    UserFactory.meta.fields["name"].inc_callcount(
+        amount=-1, callcounts=UserFactory.meta.callcounts
+    )
+    UserFactory.meta.fields["name"].inc_callcount(
+        amount=-1, callcounts=ProductFactory.meta.callcounts
+    )
+    user = UserFactory().build()
+    assert user.name == "name-1"
+    user = UserFactory().build()
+    assert user.name == "name-3"
+
+    # use the callcounts of the main factory
+    product = ProductFactory().build()
+    assert product.user.name == "name-1"
+    product = ProductFactory().build()
+    assert product.user.name == "name-3"
+
+
 def test_exclude_autoincrement_build():
     class UserFactory(ModelFactory):
         class Meta:

--- a/tests/factory/test_factory.py
+++ b/tests/factory/test_factory.py
@@ -6,7 +6,8 @@ from pydantic import ValidationError
 import edgy
 from edgy.testing import DatabaseTestClient
 from edgy.testing.exceptions import ExcludeValue
-from edgy.testing.factory import FactoryField, ModelFactory, ModelFactoryContext
+from edgy.testing.factory import FactoryField, ModelFactory
+from edgy.testing.factory.base import ModelFactoryContextImplementation
 from edgy.testing.factory.metaclasses import DEFAULT_MAPPING
 from tests.settings import DATABASE_URL
 
@@ -341,27 +342,33 @@ def test_mapping():
         }:
             DEFAULT_MAPPING[field_type_name](
                 ProductFactory.meta.fields["user"],
-                ModelFactoryContext(
+                ModelFactoryContextImplementation(
                     faker=ProductFactory.meta.faker,
                     exclude_autoincrement=ProductFactory.exclude_autoincrement,
+                    depth=0,
+                    callcounts={},
                 ),
                 {},
             )
         elif field_type_name == "ChoiceField":
             DEFAULT_MAPPING[field_type_name](
                 ProductFactory.meta.fields["type"],
-                ModelFactoryContext(
+                ModelFactoryContextImplementation(
                     faker=ProductFactory.meta.faker,
                     exclude_autoincrement=ProductFactory.exclude_autoincrement,
+                    depth=0,
+                    callcounts={},
                 ),
                 {},
             )
         elif field_type_name == "RefForeignKey":
             DEFAULT_MAPPING[field_type_name](
                 UserFactory.meta.fields["product_ref"],
-                ModelFactoryContext(
+                ModelFactoryContextImplementation(
                     faker=UserFactory.meta.faker,
                     exclude_autoincrement=UserFactory.exclude_autoincrement,
+                    depth=0,
+                    callcounts={},
                 ),
                 {},
             )
@@ -370,9 +377,11 @@ def test_mapping():
             if callback:
                 callback(
                     UserFactory.meta.fields["name"],
-                    ModelFactoryContext(
+                    ModelFactoryContextImplementation(
                         faker=UserFactory.meta.faker,
                         exclude_autoincrement=UserFactory.exclude_autoincrement,
+                        depth=0,
+                        callcounts={},
                     ),
                     {},
                 )

--- a/tests/factory/test_parameters.py
+++ b/tests/factory/test_parameters.py
@@ -61,6 +61,27 @@ def test_parametrize_factory():
     assert len(user.language) <= 3
     assert user.name == "edgy edgy"
 
+def test_parametrize_factory_context():
+    class UserFactory(ModelFactory):
+        class Meta:
+            model = User
+
+        language = FactoryField(callback="language_code")
+        name = FactoryField(
+            callback=lambda field_instance,
+            context,
+            parameters: f"{parameters['first_name']} {parameters['last_name']}",
+            parameters={
+                "first_name": lambda field_instance, context, parameters: context["faker"].name(),
+                "last_name": lambda field_instance, context, parameters: context["faker"].name(),
+            },
+        )
+
+    UserFactory().build()
+    user = UserFactory().build(parameters={"name": {"first_name": "edgy", "last_name": "edgy"}})
+    assert len(user.language) <= 3
+    assert user.name == "edgy edgy"
+
 
 def test_can_generate_and_parametrize():
     class CartFactory(ModelFactory):


### PR DESCRIPTION
Changes:
- Replace Faker with ModelFactoryContext which is compatible to a Faker instance
- Add support for Sequences via get_callcount
- `exclude_autoincrement` is now also applied on subfactories thanks to the context