### PR TITLE
migration helpers for local defaults

### DIFF
--- a/docs/contenttypes/intro.md
+++ b/docs/contenttypes/intro.md
@@ -78,3 +78,18 @@ To opt out, override `content_type` on the model with any field. Use `ExcludeFie
 
 Given an old project and you want to use ContentTypes, there is an easy migration path via `--null-field` or `--nf` options
 of `edgy makemigrations` and `edgy revision`.
+You just need three commands:
+
+```sh
+edgy makemigrations --nf :content_type
+# update the db
+edgy migrate
+# now create a migration which undos the null-field nullification of fields.
+edgy makemigrations
+```
+
+For models with different named content_type fields (explicit ContentTypeField) you need to specify:
+
+```sh
+edgy makemigrations --nf :content_type --nf model:custom_content_type
+```

--- a/docs/contenttypes/intro.md
+++ b/docs/contenttypes/intro.md
@@ -73,7 +73,6 @@ To opt out, override `content_type` on the model with any field. Use `ExcludeFie
 
 `ContentType` is tenancy-compatible out of the box.
 
-
 ## Migrate to ContentTypes
 
 Given an old project and you want to use ContentTypes, there is an easy migration path via `--null-field` or `--nf` options

--- a/docs/contenttypes/intro.md
+++ b/docs/contenttypes/intro.md
@@ -72,3 +72,9 @@ To opt out, override `content_type` on the model with any field. Use `ExcludeFie
 ### Tenancy Compatibility
 
 `ContentType` is tenancy-compatible out of the box.
+
+
+## Migrate to ContentTypes
+
+Given an old project and you want to use ContentTypes, there is an easy migration path via `--null-field` or `--nf` options
+of `edgy makemigrations` and `edgy revision`.

--- a/docs/marshalls.md
+++ b/docs/marshalls.md
@@ -176,7 +176,7 @@ Result:
 
 Since `Marshall` is a Pydantic base model, similar to Edgy models, you can persist data directly using the marshall.
 
-Edgy provides a `save()` method for marshalls that mirrors the `save()` method of Edgy models.
+Edgy provides a `save()` method for marshalls that forwards to the `save()` method of Edgy models. It doesn't take any parameters.
 
 ### Example
 

--- a/docs/migrations/migrations.md
+++ b/docs/migrations/migrations.md
@@ -450,11 +450,13 @@ Sometimes you want to add fields to a model which are required afterwards.
 
 ### With server_default
 
-This is a bit more work and requires a supported field (all single-column fields and some multiple-columns fields like CompositeField).
-It works like follows:
-Add a column with a server_default which is used by the migrations, then create the migration and migrate then remove the server_default and make another migration.
+This is a bit more work and requires a supported field (all single-column fields and some multiple-column fields like CompositeField). It works as follows:
 
-Here an basic example:
+1. Add a column with a server_default which is used by the migrations.
+2. Create the migration and migrate.
+3. Remove the server_default and create another migration.
+
+Here is a basic example:
 
 1.  Create the field with a server_default
     ``` python
@@ -480,13 +482,12 @@ Here an basic example:
     ```
 
 ### With null-field
-
 Null-field is a feature to make fields nullable for one makemigration/revision. You can either specify
-`model:field_name` or just `:field_name` for automatically detection of models.
-Non-existing models are just ignored and only models in registry.models are migrated.
-In the migration file you will find a construct `monkay.instance.registry.apply_default_force_nullable_fields(...)`.
-The model_defaults argument can be used to provide one-time defaults which overwrite all other defaults.
-You can also pass callables, which are executed in the `extract_column_values` method and have all of the context vars available.
+`model:field_name` or just `:field_name` for automatic detection of models.
+Non-existing models are ignored, and only models in `registry.models` are migrated.
+In the migration file, you will find a construct `monkay.instance.registry.apply_default_force_nullable_fields(...)`.
+The `model_defaults` argument can be used to provide one-time defaults that overwrite all other defaults.
+You can also pass callables, which are executed in context of the `extract_column_values` method and have all of the context variables available.
 
 Let's see how to implement the last example with null-field and we add also ContentTypes.
 1. Add the field with the default (not server-default).
@@ -507,8 +508,7 @@ Let's see how to implement the last example with null-field and we add also Cont
     ```
 
 !!! Tip
-    In case you messed up the null-fields you can also fix them manually in the script file.
-    You can also specify special defaults for fields.
+    In case you mess up the null-fields, you can also fix them manually in the script file. You can also specify custom defaults for fields.
 
 ## Multi-Database Migrations
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -385,7 +385,7 @@ The `unique_together` expects one of the following:
 * **List of tuple of strings**.
 * **List of tuples of strings**.
 * **List of tuples of strings as well as strings**
-* **A List of UniqueConstraint instances**.
+* **A list of UniqueConstraint instances**.
 
 If none of these values are provided, it will raise a `ValueError`.
 

--- a/docs/permissions/intro.md
+++ b/docs/permissions/intro.md
@@ -1,6 +1,13 @@
 # Permissions in Edgy
 
-Managing permissions is a crucial aspect of database-driven applications. Edgy provides a flexible and portable way to handle permissions, using database tables rather than relying solely on database users.
+Managing permissions is a crucial aspect of database-driven applications.
+Edgy provides a flexible and portable way to handle permissions, using database tables rather than relying solely on database users.
+This feature is entirely composable in contrast to django, you can have full-fledged object-permissions to a simple user permission system
+just by providing the fields.
+It is up to you how to design e.g. the Group model. If it should have extra attributes or not.
+You just need to keep the convention, some fields are mandatory to get the results wanted.
+
+The permission system does **not** require ContentTypes. They are only required for per object permissions.
 
 ## Permission Objects
 

--- a/docs/permissions/intro.md
+++ b/docs/permissions/intro.md
@@ -1,13 +1,12 @@
 # Permissions in Edgy
 
-Managing permissions is a crucial aspect of database-driven applications.
-Edgy provides a flexible and portable way to handle permissions, using database tables rather than relying solely on database users.
-This feature is entirely composable in contrast to django, you can have full-fledged object-permissions to a simple user permission system
-just by providing the fields.
-It is up to you how to design e.g. the Group model. If it should have extra attributes or not.
-You just need to keep the convention, some fields are mandatory to get the results wanted.
+Managing permissions is a crucial aspect of database-driven applications. Edgy provides a flexible and portable way to handle permissions using database tables rather than relying solely on database users.
 
-The permission system does **not** require ContentTypes. They are only required for per object permissions.
+In contrast to Django, Edgy's permission feature is entirely composable. You can have anything from full-fledged object-permissions to a simple user permission system by just providing the necessary fields.
+
+It is up to you how to design it, such as the Group model. You can decide if it should have extra attributes or not. You just need to follow the convention, as some fields are mandatory to achieve the desired results.
+
+The permission system does **not** require ContentTypes. They are only required for per-object permissions.
 
 ## Permission Objects
 

--- a/docs/queries/queries.md
+++ b/docs/queries/queries.md
@@ -487,12 +487,17 @@ new_user = await user.save()
 
 `save` has following signature:
 
-`save(force_insert=False,values=None)`
+`save(force_insert=False, values=None)`
 
 What they do is:
 
 - `force_insert` (former `force_save`): Instead of conditionally updating, force an insert.
 - `values`: Overwrite values explicitly. Values specified here are marked as explicit set parameters.
+  You can provide here also callables which are evaluated in the `extract_column_values` method.
+
+!!! Tip
+    For the values parameter of the model instance you can also provide callables which are evaluated
+    in the `extract_column_values` method and have the ContextVars `CURRENT_INSTANCE`, `CURRENT_MODEL_INSTANCE`, `CURRENT_FIELD_CONTEXT`, `EXPLICIT_SPECIFIED_VALUES` initialized.
 
 ### Update
 
@@ -506,6 +511,10 @@ user = await User.query.get(email="foo@bar.com")
 await user.update(email="bar@example.com")
 ```
 
+!!! Tip
+    For the update method of the model instance you can also provide callables which are evaluated
+    in the `extract_column_values` method and have the ContextVars `CURRENT_INSTANCE`, `CURRENT_MODEL_INSTANCE`, `CURRENT_FIELD_CONTEXT`, `EXPLICIT_SPECIFIED_VALUES` initialized.
+
 ### Create
 
 Used to create model instances.
@@ -517,6 +526,9 @@ await User.query.create(is_active=True, email="foo@bar.com", first_name="Foo", l
 ```
 
 Create takes `ModelRef`s as positional arguments to automatically evaluate and stage them.
+
+!!! Warning
+    Because there is no model for reference, callables are not evaluated here.
 
 ### Delete
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,28 @@ hide:
 
 # Release Notes
 
+## 0.28.0
+
+### Added
+
+- `null-field` or `nf` parameter for makemigrations/revision.
+- Add `FORCE_FIELDS_NULLABLE` context var.
+- Add `force_non_partial_update` parameter to model.save for injecting defaults.
+
+### Changed
+
+- The default migration templates allow now to use complex defaults for migrations.
+- Fields must use get_columns_nullable instead of ColumnDefinitionModel null. for determining if the columns should be nullable.
+- In model.update the values can be callables which are evaluated.
+
+### Fixed
+
+- ForeignKeys aren't required to be saved models when passed.
+- Cli command revision takes now also the arg argument.
+- Revisioning works now with relative revisions with - (e.g. -2).
+- Downgrades are now possible with unique_together. Build a constraint name from the fields.
+- `is_partial` was incorrectly set to always False for the model.save update path.
+
 ## 0.27.4
 
 ### Changed
@@ -24,7 +46,7 @@ hide:
 
 ## 0.27.2
 
-### Chamged
+### Changed
 
 - Edgy now allows inheritance of `unique_together` and `indexes` from abstract classes.
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,15 +12,16 @@ hide:
 
 - `null-field` or `nf` parameter for makemigrations/revision.
 - Add `FORCE_FIELDS_NULLABLE` ContextVar.
-- Add `FIELD_CONTEXT` ContextVar.
-- Add `force_non_partial_update` parameter to model.save for injecting defaults.
+- Add `CURRENT_FIELD_CONTEXT` ContextVar.
 
 ### Changed
 
 - The default migration templates allow now to use complex defaults for migrations.
 - Fields must use get_columns_nullable instead of ColumnDefinitionModel null. for determining if the columns should be nullable.
-- In model.update the values can be callables which are evaluated.
-- Streamline ContentTypeField in using a parameter-less default function.
+- For model `save` and `update` the values can be callables which are evaluated.
+- Streamline ContentTypeField in using a parameter-less default function. Use `CURRENT_FIELD_CONTEXT` ContextVar field for referencing the owner.
+- Fail when specifying a server_default for ForeignKey, ManyToMany, FileField, ImageField. This is not possible.
+- Internals: _insert and _update have now a different signature.
 
 ### Fixed
 
@@ -28,7 +29,8 @@ hide:
 - Cli command revision takes now also the arg argument.
 - Revisioning works now with relative revisions with - (e.g. -2).
 - Downgrades are now possible with unique_together. Build a constraint name from the fields.
-- `is_partial` was incorrectly set to always False for the model.save update path.
+- `is_partial` was incorrectly set to always `False` for the model.save update path.
+- FileFields could have make problems when migrating.
 
 ## 0.27.4
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,7 +11,8 @@ hide:
 ### Added
 
 - `null-field` or `nf` parameter for makemigrations/revision.
-- Add `FORCE_FIELDS_NULLABLE` context var.
+- Add `FORCE_FIELDS_NULLABLE` ContextVar.
+- Add `FIELD_CONTEXT` ContextVar.
 - Add `force_non_partial_update` parameter to model.save for injecting defaults.
 
 ### Changed
@@ -19,6 +20,7 @@ hide:
 - The default migration templates allow now to use complex defaults for migrations.
 - Fields must use get_columns_nullable instead of ColumnDefinitionModel null. for determining if the columns should be nullable.
 - In model.update the values can be callables which are evaluated.
+- Streamline ContentTypeField in using a parameter-less default function.
 
 ### Fixed
 

--- a/edgy/__init__.py
+++ b/edgy/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.27.3"
+__version__ = "0.28.0"
 from typing import TYPE_CHECKING
 
 from ._monkay import Instance, create_monkay

--- a/edgy/cli/decorators.py
+++ b/edgy/cli/decorators.py
@@ -45,6 +45,18 @@ def add_migration_directory_option(fn: Any) -> Any:
     )(fn)
 
 
+def add_force_field_nullable_option(fn: Any) -> Any:
+    import click
+
+    return click.option(
+        "--null-field",
+        "--nf",
+        multiple=True,
+        default=(),
+        help='Force field being nullable. Syntax model:field or ":field" for auto-detection of models with such a field.',
+    )(fn)
+
+
 def add_app_module_option(fn: Any) -> Any:
     import click
 

--- a/edgy/cli/operations/downgrade.py
+++ b/edgy/cli/operations/downgrade.py
@@ -8,15 +8,15 @@ from edgy.cli.decorators import add_migration_directory_option
 
 @add_migration_directory_option
 @click.option(
-    "--sql", is_flag=True, help=("Don't emit SQL to database - dump to standard output " "instead")
+    "--sql", is_flag=True, help=("Don't emit SQL to database - dump to standard output instead")
 )
 @click.option(
-    "--tag", default=None, help=('Arbitrary "tag" name - can be used by custom env.py ' "scripts")
+    "--tag", default=None, help=('Arbitrary "tag" name - can be used by custom env.py scripts')
 )
 @click.option(
     "-x", "--arg", multiple=True, help="Additional arguments consumed by custom env.py scripts"
 )
-@click.command()
+@click.command(context_settings={"ignore_unknown_options": True})
 @click.argument("revision", default="-1")
 def downgrade(sql: bool, tag: str, arg: Any, revision: str) -> None:
     """Revert to a previous version"""

--- a/edgy/cli/operations/makemigrations.py
+++ b/edgy/cli/operations/makemigrations.py
@@ -2,35 +2,36 @@
 Client to interact with Edgy models and migrations.
 """
 
-from typing import Any
+from typing import Any, Union
 
 import click
 
 from edgy.cli.base import migrate as _migrate
-from edgy.cli.decorators import add_migration_directory_option
+from edgy.cli.decorators import add_force_field_nullable_option, add_migration_directory_option
 
 
+@add_force_field_nullable_option
 @add_migration_directory_option
 @click.option("-m", "--message", default=None, help="Revision message")
 @click.option(
-    "--sql", is_flag=True, help=("Don't emit SQL to database - dump to standard output " "instead")
+    "--sql", is_flag=True, help=("Don't emit SQL to database - dump to standard output instead")
 )
 @click.option(
     "--head",
     default="head",
-    help=("Specify head revision or <branchname>@head to base new " "revision on"),
+    help="Specify head revision or <branchname>@head to base new revision on",
 )
 @click.option(
     "--splice", is_flag=True, help=('Allow a non-head revision as the "head" to splice onto')
 )
 @click.option(
-    "--branch-label", default=None, help=("Specify a branch label to apply to the new revision")
+    "--branch-label", default=None, help="Specify a branch label to apply to the new revision"
 )
 @click.option(
-    "--version-path", default=None, help=("Specify specific path from config for version file")
+    "--version-path", default=None, help="Specify specific path from config for version file"
 )
 @click.option(
-    "--rev-id", default=None, help=("Specify a hardcoded revision id instead of generating " "one")
+    "--rev-id", default=None, help="Specify a hardcoded revision id instead of generating one"
 )
 @click.option(
     "-x", "--arg", multiple=True, help="Additional arguments consumed by custom env.py scripts"
@@ -45,7 +46,17 @@ def makemigrations(
     version_path: str,
     rev_id: str,
     arg: Any,
+    null_field: Union[list[str], tuple[str, ...]],
 ) -> None:
-    """Autogenerate a new revision file (Alias for
-    'revision --autogenerate')"""
-    _migrate(message, sql, head, splice, branch_label, version_path, rev_id, arg)
+    """Autogenerate a new revision file (Alias for 'revision --autogenerate')"""
+    _migrate(
+        message=message,
+        sql=sql,
+        head=head,
+        splice=splice,
+        branch_label=branch_label,
+        version_path=version_path,
+        revision_id=rev_id,
+        arg=arg,
+        null_fields=null_field,
+    )

--- a/edgy/cli/operations/migrate.py
+++ b/edgy/cli/operations/migrate.py
@@ -8,15 +8,15 @@ from edgy.cli.decorators import add_migration_directory_option
 
 @add_migration_directory_option
 @click.option(
-    "--sql", is_flag=True, help=("Don't emit SQL to database - dump to standard output " "instead")
+    "--sql", is_flag=True, help=("Don't emit SQL to database - dump to standard output instead")
 )
 @click.option(
-    "--tag", default=None, help=('Arbitrary "tag" name - can be used by custom env.py ' "scripts")
+    "--tag", default=None, help=('Arbitrary "tag" name - can be used by custom env.py scripts')
 )
 @click.option(
     "-x", "--arg", multiple=True, help="Additional arguments consumed by custom env.py scripts"
 )
-@click.command()
+@click.command(context_settings={"ignore_unknown_options": True})
 @click.argument("revision", default="head")
 def migrate(sql: bool, tag: str, arg: Any, revision: str) -> None:
     """

--- a/edgy/cli/operations/revision.py
+++ b/edgy/cli/operations/revision.py
@@ -1,9 +1,12 @@
+from typing import Any, Union
+
 import click
 
 from edgy.cli.base import revision as _revision
-from edgy.cli.decorators import add_migration_directory_option
+from edgy.cli.decorators import add_force_field_nullable_option, add_migration_directory_option
 
 
+@add_force_field_nullable_option
 @add_migration_directory_option
 @click.option("-m", "--message", default=None, help="Revision message")
 @click.option(
@@ -15,12 +18,12 @@ from edgy.cli.decorators import add_migration_directory_option
     ),
 )
 @click.option(
-    "--sql", is_flag=True, help=("Don't emit SQL to database - dump to standard output " "instead")
+    "--sql", is_flag=True, help=("Don't emit SQL to database - dump to standard output instead")
 )
 @click.option(
     "--head",
     default="head",
-    help=("Specify head revision or <branchname>@head to base new " "revision on"),
+    help=("Specify head revision or <branchname>@head to base new revision on"),
 )
 @click.option(
     "--splice", is_flag=True, help=('Allow a non-head revision as the "head" to splice onto')
@@ -32,9 +35,12 @@ from edgy.cli.decorators import add_migration_directory_option
     "--version-path", default=None, help=("Specify specific path from config for version file")
 )
 @click.option(
-    "--rev-id", default=None, help=("Specify a hardcoded revision id instead of generating " "one")
+    "--rev-id", default=None, help=("Specify a hardcoded revision id instead of generating one")
 )
-@click.command()
+@click.option(
+    "-x", "--arg", multiple=True, help="Additional arguments consumed by custom env.py scripts"
+)
+@click.command(context_settings={"ignore_unknown_options": True})
 def revision(
     message: str,
     autogenerate: bool,
@@ -44,15 +50,19 @@ def revision(
     branch_label: str,
     version_path: str,
     rev_id: str,
+    arg: Any,
+    null_field: Union[list[str], tuple[str, ...]],
 ) -> None:
     """Create a new revision file."""
     _revision(
-        message,
-        autogenerate,
-        sql,
-        head,
-        splice,
-        branch_label,
-        version_path,
-        rev_id,
+        message=message,
+        autogenerate=autogenerate,
+        sql=sql,
+        head=head,
+        splice=splice,
+        branch_label=branch_label,
+        version_path=version_path,
+        revision_id=rev_id,
+        arg=arg,
+        null_fields=null_field,
     )

--- a/edgy/cli/templates/default/script.py.mako
+++ b/edgy/cli/templates/default/script.py.mako
@@ -7,11 +7,14 @@ Create Date: ${create_date}
 """
 <%
     from edgy.utils.hashing import hash_to_identifier, hash_to_identifier_as_string
+    from edgy.core.utils.db import force_fields_nullable_as_list_string
+    import json
 %>
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import context, op
+from edgy import monkay, run_sync
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
@@ -21,6 +24,7 @@ branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
 
 ${hash_to_identifier_as_string}
+force_fields_nullable: list[tuple[str, str]] = ${force_fields_nullable_as_list_string()}
 
 def upgrade(engine_name: str = "") -> None:
     # hash_to_identifier adds already an "_"
@@ -48,6 +52,18 @@ def ${f"upgrade{hash_to_identifier(db_name or '')}"}():
     # Migration of:
     # ${f'"{db_name}"' if db_name else 'main database'}
     ${context.get(f"{db_name or ''}_upgrades", "pass")}
+    if not context.is_offline_mode():
+        try:
+            with monkay.instance.registry.with_async_env():
+                run_sync(
+                    monkay.instance.registry.apply_default_force_nullable_fields(
+                        force_fields_nullable=force_fields_nullable,
+                        filter_db_name=${json.dumps(db_name or '')},
+                        model_defaults={}
+                    )
+                )
+        except Exception as exc:
+            print("failure migrating defaults", exc)
 
 
 def ${f"downgrade{hash_to_identifier(db_name or '')}"}():

--- a/edgy/cli/templates/plain/script.py.mako
+++ b/edgy/cli/templates/plain/script.py.mako
@@ -5,10 +5,14 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
+<%
+    from edgy.core.utils.db import force_fields_nullable_as_list_string
+%>
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import context, op
+from edgy import monkay, run_sync
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
@@ -16,6 +20,8 @@ revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
 branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
+
+force_fields_nullable: list[tuple[str, str]] = ${force_fields_nullable_as_list_string()}
 
 def upgrade(engine_name: str = "") -> None:
     fn = globals().get(f"upgrade_{engine_name}")
@@ -37,8 +43,20 @@ def downgrade(engine_name: str = "") -> None:
 
 % for db_name in db_names:
 
-def ${f"upgrade_{db_name or ''}"}():
+def ${f"upgrade_{db_name or ''}"}(db_name: str=""):
     ${context.get(f"{db_name or ''}_upgrades", "pass")}
+    if force_fields_nullable and not context.is_offline_mode():
+        try:
+            with monkay.instance.registry.with_async_env():
+                run_sync(
+                    monkay.instance.registry.apply_default_force_nullable_fields(
+                        force_fields_nullable=force_fields_nullable,
+                        filter_db_name="${db_name or ''}",
+                        model_defaults={}
+                    )
+                )
+        except Exception as exc:
+            print("failure migrating defaults", exc)
 
 
 def ${f"downgrade_{db_name or ''}"}():

--- a/edgy/cli/templates/sequencial/script.py.mako
+++ b/edgy/cli/templates/sequencial/script.py.mako
@@ -6,12 +6,15 @@ Create Date: ${create_date}
 
 """
 <%
+    import json
     from edgy.utils.hashing import hash_to_identifier, hash_to_identifier_as_string
+    from edgy.core.utils.db import force_fields_nullable_as_list_string
 %>
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import context, op
+from edgy import monkay, run_sync
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
@@ -21,6 +24,7 @@ branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
 
 ${hash_to_identifier_as_string}
+force_fields_nullable: list[tuple[str, str]] = ${force_fields_nullable_as_list_string()}
 
 def upgrade(engine_name: str = "") -> None:
     # hash_to_identifier adds already an "_"
@@ -48,6 +52,18 @@ def ${f"upgrade{hash_to_identifier(db_name or '')}"}():
     # Migration of:
     # ${f'"{db_name}"' if db_name else 'main database'}
     ${context.get(f"{db_name or ''}_upgrades", "pass")}
+    if not context.is_offline_mode():
+        try:
+            with monkay.instance.registry.with_async_env():
+                run_sync(
+                    monkay.instance.registry.apply_default_force_nullable_fields(
+                        force_fields_nullable=force_fields_nullable,
+                        filter_db_name=${json.dumps(db_name or '')},
+                        model_defaults={}
+                    )
+                )
+        except Exception as exc:
+            print("failure migrating defaults", exc)
 
 
 def ${f"downgrade{hash_to_identifier(db_name or '')}"}():

--- a/edgy/core/connection/registry.py
+++ b/edgy/core/connection/registry.py
@@ -206,7 +206,8 @@ class Registry:
             for obj in await model.query.filter(**filter_kwargs):
                 kwargs = {k: v for k, v in obj.extract_db_fields().items() if k not in field_set}
                 kwargs.update(model_specific_defaults)
-                ops.append(obj.save(values=kwargs, force_non_partial_update=True))
+                # is_partial = False
+                ops.append(obj._update(False, kwargs))
         await asyncio.gather(*ops)
 
     def extra_name_check(self, name: Any) -> bool:

--- a/edgy/core/connection/registry.py
+++ b/edgy/core/connection/registry.py
@@ -3,7 +3,7 @@ import contextlib
 import re
 import warnings
 from collections import defaultdict
-from collections.abc import Container, Generator, Sequence
+from collections.abc import Container, Generator, Iterable, Sequence
 from copy import copy as shallow_copy
 from functools import cached_property, partial
 from types import TracebackType
@@ -18,6 +18,7 @@ from sqlalchemy.orm import declarative_base as sa_declarative_base
 from edgy.conf import evaluate_settings_once_ready
 from edgy.core.connection.database import Database, DatabaseURL
 from edgy.core.connection.schemas import Schema
+from edgy.core.db.context_vars import FORCE_FIELDS_NULLABLE
 from edgy.core.utils.sync import current_eventloop, run_sync
 from edgy.types import Undefined
 
@@ -148,6 +149,66 @@ class Registry:
         if with_content_type is not False:
             self._set_content_type(with_content_type)
 
+    async def apply_default_force_nullable_fields(
+        self,
+        *,
+        force_fields_nullable: Optional[Iterable[tuple[str, str]]] = None,
+        model_defaults: Optional[dict[str, dict[str, Any]]] = None,
+        filter_db_url: Optional[str] = None,
+        filter_db_name: Union[str, None] = None,
+    ) -> None:
+        """For online migrations and after migrations to apply defaults."""
+        if force_fields_nullable is None:
+            force_fields_nullable = set(FORCE_FIELDS_NULLABLE.get())
+        else:
+            force_fields_nullable = set(force_fields_nullable)
+        if model_defaults is None:
+            model_defaults = {}
+        for model_name, defaults in model_defaults.items():
+            for default_name in defaults:
+                force_fields_nullable.add((model_name, default_name))
+        # for empty model names extract all matching models
+        for item in list(force_fields_nullable):
+            if not item[0]:
+                force_fields_nullable.discard(item)
+                for model in self.models.values():
+                    if item[1] in model.meta.fields:
+                        force_fields_nullable.add((model.__name__, item[1]))
+
+        if not force_fields_nullable:
+            return
+        if isinstance(filter_db_name, str):
+            if filter_db_name:
+                filter_db_url = str(self.extra[filter_db_name].url)
+            else:
+                filter_db_url = str(self.database.url)
+        models_with_fields: dict[str, set[str]] = {}
+        for item in force_fields_nullable:
+            if item[0] not in self.models:
+                continue
+            if item[1] not in self.models[item[0]].meta.fields:
+                continue
+            if not self.models[item[0]].meta.fields[item[1]].has_default():
+                overwrite_default = model_defaults.get(item[0]) or {}
+                if item[1] not in overwrite_default:
+                    continue
+            field_set = models_with_fields.setdefault(item[0], set())
+            field_set.add(item[1])
+        if not models_with_fields:
+            return
+        ops = []
+        for model_name, field_set in models_with_fields.items():
+            model = self.models[model_name]
+            if filter_db_url and str(model.database.url) != filter_db_url:
+                continue
+            model_specific_defaults = model_defaults.get(model_name) or {}
+            filter_kwargs = {field_name: None for field_name in field_set}
+            for obj in await model.query.filter(**filter_kwargs):
+                kwargs = {k: v for k, v in obj.extract_db_fields().items() if k not in field_set}
+                kwargs.update(model_specific_defaults)
+                ops.append(obj.save(values=kwargs, force_non_partial_update=True))
+        await asyncio.gather(*ops)
+
     def extra_name_check(self, name: Any) -> bool:
         if not isinstance(name, str):
             logger.error(f"Extra database name: {name!r} is not a string.")
@@ -249,9 +310,9 @@ class Registry:
             if "content_type" in model_class.meta.fields:
                 return
             related_name = f"reverse_{model_class.__name__.lower()}"
-            assert (
-                related_name not in real_content_type.meta.fields
-            ), f"duplicate model name: {model_class.__name__}"
+            assert related_name not in real_content_type.meta.fields, (
+                f"duplicate model name: {model_class.__name__}"
+            )
 
             field_args: dict[str, Any] = {
                 "name": "content_type",

--- a/edgy/core/db/context_vars.py
+++ b/edgy/core/db/context_vars.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Literal, Optional, Union, cast
 from warnings import warn
 
 if TYPE_CHECKING:
+    from edgy.core.db.fields.types import FIELD_CONTEXT_TYPE
     from edgy.core.db.models.types import BaseModelType
     from edgy.core.db.querysets.base import QuerySet
 
@@ -12,6 +13,7 @@ _empty: set = cast(set, frozenset())
 FORCE_FIELDS_NULLABLE: ContextVar[set[tuple[str, str]]] = ContextVar(
     "FORCE_FIELDS_NULLABLE", default=_empty
 )
+CURRENT_FIELD_CONTEXT: ContextVar["FIELD_CONTEXT_TYPE"] = ContextVar("CURRENT_FIELD_CONTEXT")
 CURRENT_INSTANCE: ContextVar[Optional[Union["BaseModelType", "QuerySet"]]] = ContextVar(
     "CURRENT_INSTANCE", default=None
 )

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -172,6 +172,7 @@ class ConcreteFileField(BaseCompositeField):
                 key=field_name,
                 type_=model.column_type,
                 name=column_name,
+                nullable=self.get_columns_nullable(),
                 **model.model_dump(by_alias=True, exclude_none=True, exclude={"column_name"}),
             ),
             sqlalchemy.Column(

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -125,7 +125,8 @@ class ConcreteFileField(BaseCompositeField):
                 file_instance = self.field_file_class(
                     self,
                     name=field_instance_or_value[field_name],
-                    storage=field_instance_or_value.get(f"{field_name}_storage", self.storage),
+                    # can be empty string after migrations
+                    storage=field_instance_or_value.get(f"{field_name}_storage") or self.storage,
                     size=field_instance_or_value.get(f"{field_name}_size"),
                     metadata=field_instance_or_value.get(f"{field_name}_metadata", {}),
                     approved=field_instance_or_value.get(
@@ -173,13 +174,17 @@ class ConcreteFileField(BaseCompositeField):
                 type_=model.column_type,
                 name=column_name,
                 nullable=self.get_columns_nullable(),
-                **model.model_dump(by_alias=True, exclude_none=True, exclude={"column_name"}),
+                **model.model_dump(
+                    by_alias=True, exclude_none=True, exclude={"column_name", "server_default"}
+                ),
             ),
             sqlalchemy.Column(
                 key=f"{field_name}_storage",
                 name=f"{column_name}_storage",
                 type_=sqlalchemy.String(length=20, collation=self.column_type.collation),
                 default=self.storage.name,
+                # for migrations
+                server_default=sqlalchemy.text("''"),
             ),
         ]
 
@@ -195,6 +200,8 @@ class ConcreteFileField(BaseCompositeField):
                 retdict[size_name] = BigIntegerField(
                     ge=0,
                     null=self.null,
+                    # we need to overwrite the method
+                    get_columns_nullable=self.get_columns_nullable,
                     exclude=True,
                     read_only=True,
                     name=size_name,
@@ -207,6 +214,7 @@ class ConcreteFileField(BaseCompositeField):
                 retdict[approval_name] = BooleanField(
                     null=False,
                     default=False,
+                    server_default=sqlalchemy.text("false"),
                     exclude=True,
                     column_name=f"{column_name}_ok",
                     name=approval_name,
@@ -221,6 +229,7 @@ class ConcreteFileField(BaseCompositeField):
                     name=metadata_name,
                     owner=self.owner,
                     default=dict,
+                    server_default=sqlalchemy.text("'{}'"),
                 )
         return retdict
 
@@ -277,6 +286,10 @@ class FileField(FieldFactory):
     @classmethod
     def validate(cls, kwargs: dict[str, Any]) -> None:
         super().validate(kwargs)
+        if kwargs.get("server_default"):
+            raise FieldDefinitionError(
+                '"server_default" is not supported for FileField or ImageField.'
+            ) from None
         if kwargs.get("mime_use_magic"):
             try:
                 import magic  # noqa: F401

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -376,6 +376,10 @@ class ForeignKey(ForeignKeyFieldFactory):
     @classmethod
     def validate(cls, kwargs: dict[str, Any]) -> None:
         super().validate(kwargs)
+        if kwargs.get("server_default"):
+            raise FieldDefinitionError(
+                '"server_default" is not supported for ForeignKeys.'
+            ) from None
         embed_parent = kwargs.get("embed_parent")
         if embed_parent and "__" in embed_parent[1]:
             raise FieldDefinitionError(

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -406,6 +406,10 @@ class ManyToManyField(ForeignKeyFieldFactory):
     @classmethod
     def validate(cls, kwargs: dict[str, Any]) -> None:
         super().validate(kwargs)
+        if kwargs.get("server_default"):
+            raise FieldDefinitionError(
+                '"server_default" is not supported for ManyToMany.'
+            ) from None
         embed_through = kwargs.get("embed_through")
         if embed_through and "__" in embed_through:
             raise FieldDefinitionError('"embed_through" cannot contain "__".')

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -39,8 +39,7 @@ class ColumnDefinition(_ColumnDefinition):
 class ColumnDefinitionModel(
     _ColumnDefinition, BaseModel, extra="ignore", arbitrary_types_allowed=True
 ):
-    # no default extraction, edgy uses a custom logic
-    null: bool = Field(serialization_alias="nullable", default=False)
+    # no default and null extraction, edgy uses a custom logic
     column_name: Optional[str] = Field(exclude=True, default=None)
     column_type: Any = Field(exclude=True, default=None)
     constraints: Sequence[sqlalchemy.Constraint] = Field(exclude=True, default=())

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union, cast
 
 import sqlalchemy
 from pydantic import BaseModel, Field
@@ -15,6 +15,13 @@ if TYPE_CHECKING:
     from edgy.core.db.fields.factories import FieldFactory
     from edgy.core.db.models.metaclasses import MetaInfo
     from edgy.core.db.models.types import BaseModelType
+
+
+class FIELD_CONTEXT_TYPE(TypedDict):
+    field: BaseFieldType
+
+
+FIELD_CONTEXT_TYPE.__total__ = False
 
 
 class _ColumnDefinition:

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -106,8 +106,11 @@ class BaseModelType(ABC):
         self,
         force_insert: bool = False,
         values: Union[dict[str, Any], set[str], list[str], None] = None,
+        force_non_partial_update: bool = False,
     ) -> BaseModelType:
         """Save model"""
+        # force_non_partial_update: force assumption values are complete. Triggers all defaults.
+        # Useful to set defaults after migration
 
     @abstractmethod
     async def delete(
@@ -167,6 +170,7 @@ class BaseModelType(ABC):
         is_partial: bool = False,
         instance: Optional[Union[BaseModelType, QuerySet]] = None,
         model_instance: Optional[BaseModelType] = None,
+        evaluate_kwarg_values: bool = False,
     ) -> dict[str, Any]:
         """
         Extracts all the default values from the given fields and returns the raw

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -106,11 +106,8 @@ class BaseModelType(ABC):
         self,
         force_insert: bool = False,
         values: Union[dict[str, Any], set[str], list[str], None] = None,
-        force_non_partial_update: bool = False,
     ) -> BaseModelType:
         """Save model"""
-        # force_non_partial_update: force assumption values are complete. Triggers all defaults.
-        # Useful to set defaults after migration
 
     @abstractmethod
     async def delete(

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -1475,7 +1475,7 @@ class QuerySet(BaseQuerySet):
                 table=queryset.table,
                 database=queryset.database,
             )
-            # values=kwargs is required for ensuring all kwargs are seen as explicit kwargs
+            # values=set(kwargs.keys()) is required for marking the provided kwargs as explicit provided kwargs
             instance = await instance.save(force_insert=True, values=set(kwargs.keys()))
             result = await self._embed_parent_in_result(instance)
             self._clear_cache(True)

--- a/edgy/utils/hashing.py
+++ b/edgy/utils/hashing.py
@@ -21,7 +21,7 @@ def hash_to_identifier(key: str | bytes) -> str:
     return f"_{b32encode(blake2b(key, digest_size=16).digest()).decode().rstrip('=')}"
 
 
-# for migrations
+# for migrations, so the function can be changed in future
 # needs however either python 3.10 or from __future__ import annotations
 hash_to_identifier_as_string: str = """
 def hash_to_identifier(key: str | bytes) -> str:

--- a/tests/cli/main.py
+++ b/tests/cli/main.py
@@ -1,20 +1,41 @@
 import os
 
 import pytest
+import sqlalchemy
 
 import edgy
 from edgy import Instance
 from edgy.contrib.permissions import BasePermission
+from edgy.core.db.context_vars import CURRENT_MODEL_INSTANCE
 from tests.settings import TEST_DATABASE
 
 pytestmark = pytest.mark.anyio
-models = edgy.Registry(database=TEST_DATABASE, with_content_type=True)
+models = edgy.Registry(
+    database=TEST_DATABASE,
+    with_content_type=os.environ.get("TEST_NO_CONTENT_TYPE", "false") != "true",
+)
 
 basedir = os.path.abspath(os.path.dirname(__file__))
+
+if os.environ.get("TEST_ADD_NULLABLE_FIELDS", "false") == "true":
+
+    class Profile(edgy.StrictModel):
+        name = edgy.fields.CharField(max_length=100)
+
+        class Meta:
+            registry = models
+
+    def complex_default() -> Profile:
+        instance = CURRENT_MODEL_INSTANCE.get()
+        return Profile(name=instance.name)
 
 
 class User(edgy.StrictModel):
     name = edgy.fields.CharField(max_length=100)
+    if os.environ.get("TEST_ADD_NULLABLE_FIELDS", "false") == "true":
+        # simple default
+        active = edgy.fields.BooleanField(server_default=sqlalchemy.text("true"), default=False)
+        profile = edgy.fields.ForeignKey("Profile", null=False, default=complex_default)
 
     class Meta:
         registry = models
@@ -25,6 +46,7 @@ class Group(edgy.StrictModel):
     users = edgy.fields.ManyToMany(
         "User", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
     )
+    content_type = edgy.fields.ExcludeField()
 
     class Meta:
         registry = models
@@ -38,11 +60,14 @@ class Permission(BasePermission):
         "Group", embed_through=False, through_tablename=edgy.NEW_M2M_NAMING
     )
     name_model: str = edgy.fields.CharField(max_length=100, null=True)
-    obj = edgy.fields.ForeignKey("ContentType", null=True)
+    if os.environ.get("TEST_NO_CONTENT_TYPE", "false") != "true":
+        obj = edgy.fields.ForeignKey("ContentType", null=True)
+    content_type = edgy.fields.ExcludeField()
 
     class Meta:
         registry = models
-        unique_together = [("name", "name_model", "obj")]
+        if os.environ.get("TEST_NO_CONTENT_TYPE", "false") != "true":
+            unique_together = [("name", "name_model", "obj")]
 
 
 edgy.monkay.set_instance(Instance(registry=models))

--- a/tests/cli/test_nullable_fields.py
+++ b/tests/cli/test_nullable_fields.py
@@ -1,0 +1,219 @@
+import contextlib
+import os
+import shutil
+import sys
+from asyncio import run
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from tests.cli.utils import arun_cmd
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+
+base_path = Path(os.path.abspath(__file__)).absolute().parent
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup_folders():
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations"))
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations2"))
+
+    yield
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations"))
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations2"))
+
+
+async def recreate_db():
+    engine = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(sqlalchemy.text("DROP DATABASE test_edgy"))
+    except Exception:
+        pass
+    async with engine.connect() as conn:
+        await conn.execute(sqlalchemy.text("CREATE DATABASE test_edgy"))
+
+
+@pytest.fixture(scope="function", autouse=True)
+async def cleanup_prepare_db():
+    await recreate_db()
+
+
+@pytest.mark.parametrize(
+    "template_param",
+    ["", " -t default", " -t plain", " -t url"],
+    ids=["default_empty", "default", "plain", "url"],
+)
+async def test_migrate_nullable_upgrade(template_param):
+    os.chdir(base_path)
+    assert not (base_path / "migrations").exists()
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"edgy init{template_param}",
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main", "edgy makemigrations", extra_env={"TEST_NO_CONTENT_TYPE": "true"}
+    )
+    assert ss == 0
+    assert b"No changes in schema detected" not in o
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main", "edgy migrate", extra_env={"TEST_NO_CONTENT_TYPE": "true"}
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"python {__file__} add",
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_NO_CONTENT_TYPE": "true",
+        },
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        "edgy makemigrations --null-field User:content_type --null-field User:profile",
+        extra_env={"TEST_ADD_NULLABLE_FIELDS": "true"},
+    )
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main", "edgy migrate", extra_env={"TEST_ADD_NULLABLE_FIELDS": "true"}
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"python {__file__} add2",
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_ADD_NULLABLE_FIELDS": "true",
+        },
+    )
+    assert ss == 0
+
+    # check there are no nulls anymore
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"python {__file__} check_no_null",
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_ADD_NULLABLE_FIELDS": "true",
+        },
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        "edgy makemigrations",
+        extra_env={"TEST_ADD_NULLABLE_FIELDS": "true"},
+    )
+
+    migrations = list((base_path / "migrations" / "versions").glob("*.py"))
+    assert len(migrations) == 3
+
+    # now remove the nulls
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main", "edgy migrate", extra_env={"TEST_ADD_NULLABLE_FIELDS": "true"}
+    )
+    assert ss == 0
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"python {__file__} check",
+        with_app_environment=False,
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_ADD_NULLABLE_FIELDS": "true",
+        },
+    )
+    assert ss == 0
+
+    # now reset
+    await recreate_db()
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main", "edgy migrate +1", extra_env={"TEST_ADD_NULLABLE_FIELDS": "true"}
+    )
+    assert ss == 0
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"hatch run python {__file__} add",
+        with_app_environment=False,
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_NO_CONTENT_TYPE": "true",
+        },
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main", "edgy migrate", extra_env={"TEST_ADD_NULLABLE_FIELDS": "true"}
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"python {__file__} check2",
+        with_app_environment=False,
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_ADD_NULLABLE_FIELDS": "true",
+        },
+    )
+    assert ss == 0
+
+
+async def main():
+    if sys.argv[1] == "add":
+        from tests.cli import main
+
+        async with main.models:
+            user = await main.User.query.create(name="edgy")
+    elif sys.argv[1] == "add2":
+        from tests.cli import main
+
+        async with main.models:
+            user = await main.User.query.create(name="edgy2")
+    elif sys.argv[1] == "check_no_null":
+        from tests.cli import main
+
+        async with main.models:
+            null_users_profile = await main.User.query.filter(profile=None)
+            assert null_users_profile == [], null_users_profile
+            null_users_content_type = await main.User.query.filter(content_type=None)
+            assert null_users_content_type == [], null_users_content_type
+            null_profile_content_type = await main.Profile.query.filter(content_type=None)
+            assert null_profile_content_type == [], null_profile_content_type
+    elif sys.argv[1] == "check":
+        from tests.cli import main
+
+        async with main.models:
+            user = await main.User.query.get(name="edgy")
+            assert user.active
+            assert user.content_type.name == "User"
+            assert user.profile == await main.Profile.query.get(name="edgy")
+            assert user.profile.content_type.name == "Profile"
+            assert (await main.Profile.query.get(name="edgy2")).content_type.name == "Profile"
+    elif sys.argv[1] == "check2":
+        from tests.cli import main
+
+        async with main.models:
+            user = await main.User.query.get(name="edgy")
+            assert user.active
+            assert user.content_type.name == "User"
+            assert user.profile == await main.Profile.query.get(name="edgy")
+
+
+if __name__ == "__main__":
+    run(main())

--- a/tests/cli/test_nullable_generic_fields.py
+++ b/tests/cli/test_nullable_generic_fields.py
@@ -1,0 +1,128 @@
+import contextlib
+import os
+import shutil
+import sys
+from asyncio import run
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from tests.cli.utils import arun_cmd
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+
+base_path = Path(os.path.abspath(__file__)).absolute().parent
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup_folders():
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations"))
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations2"))
+
+    yield
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations"))
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations2"))
+
+
+async def recreate_db():
+    engine = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(sqlalchemy.text("DROP DATABASE test_edgy"))
+    except Exception:
+        pass
+    async with engine.connect() as conn:
+        await conn.execute(sqlalchemy.text("CREATE DATABASE test_edgy"))
+
+
+@pytest.fixture(scope="function", autouse=True)
+async def cleanup_prepare_db():
+    await recreate_db()
+
+
+@pytest.mark.parametrize(
+    "template_param",
+    ["", " -t default", " -t plain", " -t url"],
+    ids=["default_empty", "default", "plain", "url"],
+)
+async def test_migrate_nullable_upgrade(template_param):
+    os.chdir(base_path)
+    assert not (base_path / "migrations").exists()
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"edgy init{template_param}",
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        "edgy makemigrations",
+        extra_env={"TEST_NO_CONTENT_TYPE": "true", "TEST_ADD_NULLABLE_FIELDS": "true"},
+    )
+    assert ss == 0
+    assert b"No changes in schema detected" not in o
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        "edgy migrate",
+        extra_env={"TEST_NO_CONTENT_TYPE": "true", "TEST_ADD_NULLABLE_FIELDS": "true"},
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"python {__file__} add",
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_NO_CONTENT_TYPE": "true",
+            "TEST_ADD_NULLABLE_FIELDS": "true",
+        },
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        "edgy makemigrations --null-field :content_type",
+        extra_env={"TEST_ADD_NULLABLE_FIELDS": "true"},
+    )
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main", "edgy migrate", extra_env={"TEST_ADD_NULLABLE_FIELDS": "true"}
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main",
+        f"python {__file__} check",
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_ADD_NULLABLE_FIELDS": "true",
+        },
+    )
+    assert ss == 0
+
+
+async def main():
+    if sys.argv[1] == "add":
+        from tests.cli import main
+
+        async with main.models:
+            user = await main.User.query.create(name="edgy")
+    elif sys.argv[1] == "check":
+        from tests.cli import main
+
+        async with main.models:
+            user = await main.User.query.get(name="edgy")
+            assert user.content_type.name == "User"
+            assert user.profile.content_type.name == "Profile"
+
+
+if __name__ == "__main__":
+    run(main())

--- a/tests/fields/test_multi_column_fields.py
+++ b/tests/fields/test_multi_column_fields.py
@@ -34,12 +34,14 @@ class MultiColumnFieldInner(BaseField):
                 field_name,
                 model.column_type,
                 *model.constraints,
+                nullable=self.get_columns_nullable(),
                 **model.model_dump(by_alias=True, exclude_none=True),
             ),
             sqlalchemy.Column(
                 field_name + "_inner",
                 model.column_type,
                 *model.constraints,
+                nullable=self.get_columns_nullable(),
                 **model.model_dump(by_alias=True, exclude_none=True),
             ),
         ]

--- a/tests/fields/test_password_field.py
+++ b/tests/fields/test_password_field.py
@@ -58,7 +58,10 @@ async def create_test_database():
 
 
 def test_can_create_password_field():
-    field = PasswordField(derive_fn=hasher.derive)
+    class MyModel2(edgy.StrictModel):
+        pass
+
+    field = PasswordField(derive_fn=hasher.derive, owner=MyModel2)
 
     assert isinstance(field, BaseField)
     assert field.min_length is None

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -140,6 +140,15 @@ async def test_create_via_relation_create():
     assert len(tracks) == 2
 
 
+async def test_create_dynamic():
+    track = await Track.query.create(title="The Waters", position=3)
+    track.album = Album(name="Malibu")
+    await track.save()
+    assert await Album.query.get(name="Malibu")
+    await track.update(album=Album(name="Foo"))
+    assert await Album.query.get(name="Foo")
+
+
 async def test_select_related():
     album = await Album.query.create(name="Malibu")
     await Track.query.create(album=album, title="The Bird", position=1)


### PR DESCRIPTION
Problem:

Sometimes you want to add new fields (note: not column) with a default (edgy) to the database.
This is until this PR quite cumbersome.

The most important change by this PR is adding a help command/API which temporarily make the affected columns nullable and tries to use the default or an additional given default.

Changes:
- `null-field` or `nf` parameter for makemigrations/revision.
- The default migration templates allow now to use complex defaults for migrations.
- Fields must use get_columns_nullable instead of ColumnDefinitionModel null. for determining if the columns should be nullable.
- ForeignKeys aren't required to be saved models when passed.
- Cli command revision takes now also the arg argument.
- Revisioning works now with relative revisions with - (e.g. -2).
- Downgrades are now possible with unique_together. Build a constraint name from the fields.
- streamline contentype fields with CURRENT_FIELD_CONTEXT contextvar
- update docs
- fix migration issues with FileFields