### PR TITLE
fix booleanfield logic during migrations

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,7 @@ hide:
 ### Fixed
 
 - `hash_names` with unique_together incorrectly fed the `uc` prefix into the hasher. This makes the names unidentificatable.
+- `BooleanField` logic for automic migrations works by using server_default.
 
 ## 0.28.0
 

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -263,7 +263,9 @@ class BooleanField(FieldFactory, bool_type):
         default: Union[None, bool, Callable[[], bool]] = False,
         **kwargs: Any,
     ) -> BaseFieldType:
-        return super().__new__(cls, default=default, **kwargs)
+        if default is not None:
+            kwargs["default"] = default
+        return super().__new__(cls, **kwargs)
 
     @classmethod
     def get_column_type(cls, kwargs: dict[str, Any]) -> Any:

--- a/tests/cli/main.py
+++ b/tests/cli/main.py
@@ -36,6 +36,8 @@ class User(edgy.StrictModel):
         # simple default
         active = edgy.fields.BooleanField(server_default=sqlalchemy.text("true"), default=False)
         profile = edgy.fields.ForeignKey("Profile", null=False, default=complex_default)
+        # auto server defaults
+        is_staff = edgy.fields.BooleanField()
 
     class Meta:
         registry = models

--- a/tests/cli/test_nullable_fields.py
+++ b/tests/cli/test_nullable_fields.py
@@ -201,6 +201,7 @@ async def main():
         async with main.models:
             user = await main.User.query.get(name="edgy")
             assert user.active
+            assert not user.is_staff
             assert user.content_type.name == "User"
             assert user.profile == await main.Profile.query.get(name="edgy")
             assert user.profile.content_type.name == "Profile"
@@ -211,6 +212,7 @@ async def main():
         async with main.models:
             user = await main.User.query.get(name="edgy")
             assert user.active
+            assert not user.is_staff
             assert user.content_type.name == "User"
             assert user.profile == await main.Profile.query.get(name="edgy")
 


### PR DESCRIPTION
Changes:

automatically add a server_default for BooleanField default in case it is trivial. This fixes migrations.
In long term a generic solution is required.