### PR TITLE
add automatic generation of server_defaults for improving migrations

### DIFF
--- a/docs/fields/index.md
+++ b/docs/fields/index.md
@@ -24,6 +24,7 @@ Check the [unique_together](../models.md#unique-together) for more details.
 - `comment` - A comment to be added with the field in the SQL database.
 - `secret` - A special attribute that allows to call the [exclude_secrets](../queries/secrets.md#exclude-secrets) and avoid
 accidental leakage of sensitive data.
+- `server_onupdate` - Like a `server_default` for updates. You may can use the fields `customize_default_for_server_default` to convert a static python value to `server_onupdate`.
 - `auto_compute_server_default` - A special attribute which allows to calculate the `server_default` from the `default` if not set explicitly and a default was set. It has four possible values:
     - `False` - Default for basic fields. Disables the feature. For field authors.
     - `None` - Default for basic single column fields. When not disabled by the `allow_auto_compute_server_defaults` setting,
@@ -1078,7 +1079,6 @@ Note: When using in-db updates of QuerySet there is no instance.
 
 Note: There is one exception of a QuerySet method which use a model instance as `CURRENT_INSTANCE`: `create`.
 
-
 #### Finding out which values are explicit set
 
 The `EXPLICIT_SPECIFIED_VALUES` ContextVar is either None or contains the key names of the explicit specified values.
@@ -1112,7 +1112,6 @@ Fields using `__get__` must consider the context_var `MODEL_GETATTR_BEHAVIOR`. T
 2. `coro`: `__get__` needs to issue the load itself (in case this is wanted) and to handle returned coroutines. AttributeErrors are passed through.
 
 The third mode `load` is only relevant for models and querysets.
-
 
 ## Customizing fields after model initialization
 

--- a/docs/fields/index.md
+++ b/docs/fields/index.md
@@ -161,8 +161,10 @@ class MyModel(edgy.Model):
     is_active: bool = edgy.BooleanField(default=True)
     is_completed: bool = edgy.BooleanField(default=False)
     ...
-
 ```
+
+!!! Note
+    Until edgy 0.29.0 there was an undocumented default of `False`.
 
 #### CharField
 
@@ -753,7 +755,6 @@ class User(edgy.Model):
 class MyModel(edgy.Model):
     user: User = edgy.OneToOne("User")
     ...
-
 ```
 
 Derives from the same as [ForeignKey](#foreignkey) and applies a One to One direction.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,7 +6,7 @@ hide:
 
 # Release Notes
 
-## 0.28.3
+## 0.29
 
 ### Added
 
@@ -16,11 +16,18 @@ hide:
 ### Changed
 
 - `get_default_value` is now also overwritable by factories.
+- The undocumented default of `BooleanField` of `False` is removed.
 
 ### Fixed
 
 - JSONField `default` is deepcopied to prevent accidental modifications of the default.
   There is no need anymore to provide a lambda.
+
+### Breaking
+
+- The undocumented default of `BooleanField` of `False` is removed.
+- Fields compute now `server_default`s for a set default. This can be turned off via the `allow_auto_compute_server_defaults` setting.
+
 
 ## 0.28.2
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,22 @@ hide:
 
 # Release Notes
 
+## 0.28.3
+
+### Added
+
+- Convert for most fields defaults to server_default to ease migrations. There are some exceptions.
+- Add the setting `allow_auto_compute_server_defaults` which allows to disable the automatic generation of server defaults.
+
+### Changed
+
+- `get_default_value` is now also overwritable by factories.
+
+### Fixed
+
+- JSONField `default` is deepcopied to prevent accidental modifications of the default.
+  There is no need anymore to provide a lambda.
+
 ## 0.28.2
 
 ### Fixed

--- a/docs_src/models/constraints.py
+++ b/docs_src/models/constraints.py
@@ -9,7 +9,7 @@ models = Registry(database=database)
 
 class User(edgy.Model):
     name = edgy.fields.CharField(max_length=255)
-    is_admin = edgy.fields.BooleanField()
+    is_admin = edgy.fields.BooleanField(default=False)
     age = edgy.IntegerField(null=True)
 
     class Meta:

--- a/edgy/conf/global_settings.py
+++ b/edgy/conf/global_settings.py
@@ -47,6 +47,7 @@ class MigrationSettings(BaseSettings):
 
 class EdgySettings(MediaSettings, MigrationSettings):
     model_config = SettingsConfigDict(extra="allow", ignored_types=(cached_property,))
+    allow_auto_compute_server_defaults: bool = True
     preloads: Union[list[str], tuple[str, ...]] = ()
     extensions: Union[list[ExtensionProtocol], tuple[ExtensionProtocol, ...]] = ()
     ipython_args: Union[list[str], tuple[str, ...]] = ("--no-banner",)

--- a/edgy/core/connection/registry.py
+++ b/edgy/core/connection/registry.py
@@ -206,7 +206,7 @@ class Registry:
             if filter_db_url and str(model.database.url) != filter_db_url:
                 continue
             model_specific_defaults = model_defaults.get(model_name) or {}
-            filter_kwargs = {field_name: None for field_name in field_set}
+            filter_kwargs = dict.fromkeys(field_set)
             for obj in await model.query.filter(**filter_kwargs):
                 kwargs = {k: v for k, v in obj.extract_db_fields().items() if k not in field_set}
                 kwargs.update(model_specific_defaults)

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -234,7 +234,7 @@ class Field(BaseField):
 
     def clean(self, name: str, value: Any, for_query: bool = False) -> dict[str, Any]:
         """
-        Applies
+        Converts a field value via check method to a column value.
         """
         return {name: self.check(value)}
 
@@ -255,6 +255,9 @@ class Field(BaseField):
         )
 
     def get_columns(self, name: str) -> Sequence[sqlalchemy.Column]:
+        """
+        Return the single column from get_column for the field declared.
+        """
         column = self.get_column(name)
         if column is None:
             return []

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -89,7 +89,8 @@ class BaseField(BaseFieldType, FieldInfo):
             self.default = default
         # check if there was an explicit defined server_default=None
         if (
-            default is not None and default is not Undefined
+            default is not None
+            and default is not Undefined
             and self.server_default is None
             and "server_default" not in kwargs
         ):
@@ -107,17 +108,19 @@ class BaseField(BaseFieldType, FieldInfo):
 
             if auto_compute_server_default:
                 # required because the patching is done later
-                if hasattr(self, "factory") and hasattr(self.factory, "customize_default_for_server_default"):
-                    self.server_default = self.factory.customize_default_for_server_default(self, default, original_fn=self.customize_default_for_server_default)
+                if hasattr(self, "factory") and getattr(
+                    self.factory, "customize_default_for_server_default", None
+                ):
+                    self.server_default = self.factory.customize_default_for_server_default(
+                        self, default, original_fn=self.customize_default_for_server_default
+                    )
                 else:
                     self.server_default = self.customize_default_for_server_default(default)
 
     def customize_default_for_server_default(self, default: Any) -> Any:
         if callable(default):
             default = default()
-        return sqlalchemy.text(":value").bindparams(
-            value=default
-        )
+        return sqlalchemy.text(":value").bindparams(value=default)
 
     def get_columns_nullable(self) -> bool:
         """

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -259,16 +259,6 @@ class BooleanField(FieldFactory, bool_type):
 
     field_type = bool
 
-    def __new__(  # type: ignore
-        cls,
-        *,
-        default: Union[None, bool, Callable[[], bool]] = False,
-        **kwargs: Any,
-    ) -> BaseFieldType:
-        if default is not None:
-            kwargs["default"] = default
-        return super().__new__(cls, **kwargs)
-
     @classmethod
     def get_column_type(cls, kwargs: dict[str, Any]) -> Any:
         return sqlalchemy.Boolean()
@@ -390,14 +380,14 @@ class JSONField(FieldFactory, pydantic.Json):  # type: ignore
         return default
 
     @classmethod
-    def customize_default_for_server_default(cls, field_obj: BaseFieldType, default: Any, original_fn: Any = None) -> Any:
+    def customize_default_for_server_default(
+        cls, field_obj: BaseFieldType, default: Any, original_fn: Any = None
+    ) -> Any:
         if callable(default):
             default = default()
         if not isinstance(default, str):
             default = orjson.dumps(default)
-        return sqlalchemy.text(":value").bindparams(
-            value=default
-        )
+        return sqlalchemy.text(":value").bindparams(value=default)
 
 
 class BinaryField(FieldFactory, bytes):
@@ -463,13 +453,12 @@ class ChoiceField(FieldFactory):
         return sqlalchemy.Enum(choice_class)
 
     @classmethod
-    def customize_default_for_server_default(cls, field_obj: BaseFieldType, default: Any, original_fn: Any = None) -> Any:
+    def customize_default_for_server_default(
+        cls, field_obj: BaseFieldType, default: Any, original_fn: Any = None
+    ) -> Any:
         if callable(default):
             default = default()
-        return sqlalchemy.text(":value").bindparams(
-            value=default.name
-        )
-
+        return sqlalchemy.text(":value").bindparams(value=default.name)
 
 
 class PasswordField(CharField):

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -17,6 +17,9 @@ default_methods_overwritable_by_factory: set[str] = {
 default_methods_overwritable_by_factory.discard("get_column_names")
 default_methods_overwritable_by_factory.discard("__init__")
 
+# useful helpers
+default_methods_overwritable_by_factory.add("get_default_value")
+
 # extra methods
 default_methods_overwritable_by_factory.add("__set__")
 default_methods_overwritable_by_factory.add("__get__")
@@ -38,7 +41,6 @@ default_methods_overwritable_by_factory.add("is_cross_db")
 
 # ForeignKey
 default_methods_overwritable_by_factory.add("expand_relationship")
-
 
 class FieldFactoryMeta(type):
     def __instancecheck__(self, instance: Any) -> bool:

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -42,6 +42,7 @@ default_methods_overwritable_by_factory.add("is_cross_db")
 # ForeignKey
 default_methods_overwritable_by_factory.add("expand_relationship")
 
+
 class FieldFactoryMeta(type):
     def __instancecheck__(self, instance: Any) -> bool:
         return super().__instancecheck__(instance) or isinstance(

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -169,7 +169,6 @@ class ForeignKeyFieldFactory(FieldFactory):
         on_update: str = CASCADE,
         on_delete: str = RESTRICT,
         related_name: Union[str, Literal[False]] = "",
-        server_onupdate: Any = None,
         **kwargs: Any,
     ) -> BaseFieldType:
         kwargs = {

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -288,6 +288,11 @@ class FileField(FieldFactory):
     @classmethod
     def validate(cls, kwargs: dict[str, Any]) -> None:
         super().validate(kwargs)
+        if kwargs.get("auto_compute_server_default"):
+            raise FieldDefinitionError(
+                '"auto_compute_server_default" is not supported for FileField or ImageField.'
+            ) from None
+        kwargs["auto_compute_server_default"] = False
         if kwargs.get("server_default"):
             raise FieldDefinitionError(
                 '"server_default" is not supported for FileField or ImageField.'

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -297,6 +297,10 @@ class FileField(FieldFactory):
             raise FieldDefinitionError(
                 '"server_default" is not supported for FileField or ImageField.'
             ) from None
+        if kwargs.get("server_onupdate"):
+            raise FieldDefinitionError(
+                '"server_onupdate" is not supported for FileField or ImageField.'
+            ) from None
         if kwargs.get("mime_use_magic"):
             try:
                 import magic  # noqa: F401  # pyright: ignore[reportMissingImports]

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -140,7 +140,7 @@ class BaseForeignKeyField(BaseForeignKey):
             elif target.pkcolumns:
                 # placeholder for extracting column
                 # WARNING: this can recursively loop
-                columns = {col: None for col in target.pkcolumns}
+                columns = dict.fromkeys(target.pkcolumns)
         return columns
 
     def expand_relationship(self, value: Any) -> Any:
@@ -376,9 +376,14 @@ class ForeignKey(ForeignKeyFieldFactory):
     @classmethod
     def validate(cls, kwargs: dict[str, Any]) -> None:
         super().validate(kwargs)
+        if kwargs.get("auto_compute_server_default"):
+            raise FieldDefinitionError(
+                '"auto_compute_server_default" is not supported for ForeignKey.'
+            ) from None
+        kwargs["auto_compute_server_default"] = False
         if kwargs.get("server_default"):
             raise FieldDefinitionError(
-                '"server_default" is not supported for ForeignKeys.'
+                '"server_default" is not supported for ForeignKey.'
             ) from None
         embed_parent = kwargs.get("embed_parent")
         if embed_parent and "__" in embed_parent[1]:

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -385,6 +385,10 @@ class ForeignKey(ForeignKeyFieldFactory):
             raise FieldDefinitionError(
                 '"server_default" is not supported for ForeignKey.'
             ) from None
+        if kwargs.get("server_onupdate"):
+            raise FieldDefinitionError(
+                '"server_onupdate" is not supported for ForeignKey.'
+            ) from None
         embed_parent = kwargs.get("embed_parent")
         if embed_parent and "__" in embed_parent[1]:
             raise FieldDefinitionError(

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -406,6 +406,11 @@ class ManyToManyField(ForeignKeyFieldFactory):
     @classmethod
     def validate(cls, kwargs: dict[str, Any]) -> None:
         super().validate(kwargs)
+        if kwargs.get("auto_compute_server_default"):
+            raise FieldDefinitionError(
+                '"auto_compute_server_default" is not supported for ManyToMany.'
+            ) from None
+        kwargs["auto_compute_server_default"] = False
         if kwargs.get("server_default"):
             raise FieldDefinitionError(
                 '"server_default" is not supported for ManyToMany.'

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -415,6 +415,10 @@ class ManyToManyField(ForeignKeyFieldFactory):
             raise FieldDefinitionError(
                 '"server_default" is not supported for ManyToMany.'
             ) from None
+        if kwargs.get("server_onupdate"):
+            raise FieldDefinitionError(
+                '"server_onupdate" is not supported for ManyToMany.'
+            ) from None
         embed_through = kwargs.get("embed_through")
         if embed_through and "__" in embed_through:
             raise FieldDefinitionError('"embed_through" cannot contain "__".')

--- a/edgy/core/db/fields/mixins.py
+++ b/edgy/core/db/fields/mixins.py
@@ -59,7 +59,7 @@ class IncrementOnSaveBaseField(Field):
     ) -> dict[str, Any]:
         if self.increment_on_save != 0:
             phase = CURRENT_PHASE.get()
-            if phase in "prepare_update":
+            if phase == "prepare_update":
                 return {field_name: None}
         return super().get_default_values(field_name, cleaned_data)
 
@@ -158,4 +158,6 @@ class AutoNowMixin(FieldFactory):
         if auto_now_add or auto_now:
             # date.today cannot handle timezone so use alway datetime and convert back to date
             kwargs["default"] = partial(datetime.datetime.now, default_timezone)
+            # ensure no automatic calculation happens
+            kwargs.setdefault("auto_compute_server_default", False)
         return super().__new__(cls, **kwargs)

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -174,6 +174,17 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         """
 
     @abstractmethod
+    def customize_default_for_server_default(self, value: Any) -> Any:
+        """
+        Modify default for server_default.
+
+        Args:
+            field_name: the field name (can be different from name)
+            cleaned_data: currently validated data. Useful to check if the default was already applied.
+
+        """
+
+    @abstractmethod
     def embed_field(
         self,
         prefix: str,

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -31,6 +31,7 @@ class _ColumnDefinition:
     index: bool = False
     unique: bool = False
     comment: Optional[str] = None
+    # keep both any, so multi-column field authors can set a dict
     server_default: Optional[Any] = None
     server_onupdate: Optional[Any] = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,6 @@ Source = "https://github.com/dymmond/edgy"
 edgy = "edgy.__main__:run_cli"
 
 [project.optional-dependencies]
-
-# we need it anyway in databasez
 test = ["faker>=33.3.1", "sqlalchemy_utils>=0.41.1"]
 testing = [
     "anyio>=4.0.0,<5",

--- a/tests/cli/main_server_defaults.py
+++ b/tests/cli/main_server_defaults.py
@@ -28,7 +28,7 @@ class User(edgy.StrictModel):
     if os.environ.get("TEST_ADD_AUTO_SERVER_DEFAULTS", "false") == "true":
         # auto server defaults
         active = edgy.fields.BooleanField(default=True)
-        is_staff = edgy.fields.BooleanField()
+        is_staff = edgy.fields.BooleanField(default=False)
         age = edgy.fields.IntegerField(default=18)
         size = edgy.fields.DecimalField(default="1.8", decimal_places=2)
         blob = edgy.fields.BinaryField(default=b"abc")

--- a/tests/cli/test_nullable_fields.py
+++ b/tests/cli/test_nullable_fields.py
@@ -201,7 +201,6 @@ async def main():
         async with main.models:
             user = await main.User.query.get(name="edgy")
             assert user.active
-            assert not user.is_staff
             assert user.content_type.name == "User"
             assert user.profile == await main.Profile.query.get(name="edgy")
             assert user.profile.content_type.name == "Profile"
@@ -212,7 +211,6 @@ async def main():
         async with main.models:
             user = await main.User.query.get(name="edgy")
             assert user.active
-            assert not user.is_staff
             assert user.content_type.name == "User"
             assert user.profile == await main.Profile.query.get(name="edgy")
 

--- a/tests/cli/test_server_default_fields.py
+++ b/tests/cli/test_server_default_fields.py
@@ -1,0 +1,149 @@
+import contextlib
+import decimal
+import os
+import shutil
+import sys
+from asyncio import run
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from tests.cli.utils import arun_cmd
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+
+base_path = Path(os.path.abspath(__file__)).absolute().parent
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup_folders():
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations"))
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations2"))
+
+    yield
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations"))
+    with contextlib.suppress(OSError):
+        shutil.rmtree(str(base_path / "migrations2"))
+
+
+async def recreate_db():
+    engine = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(sqlalchemy.text("DROP DATABASE test_edgy"))
+    except Exception:
+        pass
+    async with engine.connect() as conn:
+        await conn.execute(sqlalchemy.text("CREATE DATABASE test_edgy"))
+
+
+@pytest.fixture(scope="function", autouse=True)
+async def cleanup_prepare_db():
+    await recreate_db()
+
+
+@pytest.mark.parametrize(
+    "template_param",
+    ["", " -t default", " -t plain", " -t url"],
+    ids=["default_empty", "default", "plain", "url"],
+)
+async def test_migrate_server_defaults_upgrade(template_param):
+    os.chdir(base_path)
+    assert not (base_path / "migrations").exists()
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main_server_defaults",
+        f"edgy init{template_param}",
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main_server_defaults", "edgy makemigrations"
+    )
+    assert ss == 0
+    assert b"No changes in schema detected" not in o
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main_server_defaults", "edgy migrate"
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main_server_defaults",
+        f"python {__file__} add",
+        with_app_environment=False,
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+        },
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main_server_defaults",
+        "edgy makemigrations",
+        extra_env={"TEST_ADD_AUTO_SERVER_DEFAULTS": "true"},
+    )
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main_server_defaults", "edgy migrate", extra_env={"TEST_ADD_AUTO_SERVER_DEFAULTS": "true"}
+    )
+    assert ss == 0
+
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main_server_defaults",
+        f"python {__file__} add2",
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_ADD_AUTO_SERVER_DEFAULTS": "true",
+        },
+    )
+    assert ss == 0
+    (o, e, ss) = await arun_cmd(
+        "tests.cli.main_server_defaults",
+        f"python {__file__} check",
+        with_app_environment=False,
+        extra_env={
+            "EDGY_SETTINGS_MODULE": "tests.settings.multidb.TestSettings",
+            "TEST_ADD_AUTO_SERVER_DEFAULTS": "true",
+        },
+    )
+    assert ss == 0
+
+    migrations = list((base_path / "migrations" / "versions").glob("*.py"))
+    assert len(migrations) == 2
+
+async def main():
+    if sys.argv[1] == "add":
+        from tests.cli import main_server_defaults as main
+
+        async with main.models:
+            user = await main.User.query.create(name="edgy")
+    elif sys.argv[1] == "add2":
+        from tests.cli import main_server_defaults as main
+
+        async with main.models:
+            user = await main.User.query.create(name="edgy2", active=False)
+    elif sys.argv[1] == "check":
+        from tests.cli import main_server_defaults as main
+
+        async with main.models:
+            user = await main.User.query.get(name="edgy")
+            assert user.active
+            assert not user.is_staff
+            assert user.age == 18
+            assert user.size == decimal.Decimal("1.8")
+            assert user.blob == b"abc"
+            assert user.data == {"test": "test"}
+            # assert user.user_type == main.UserTypeEnum.INTERNAL
+            assert user.content_type.name == "User"
+
+            user2 = await main.User.query.get(name="edgy2")
+            assert not user2.active
+            assert user.content_type.name == "User"
+if __name__ == "__main__":
+    run(main())

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -260,10 +260,15 @@ def test_can_overwrite_method_autonow_field(mocker):
 
 
 def test_can_create_json_field():
-    field = JSONField(default={"json": "json"})
+    default = {"json": "json"}
+    field = JSONField(default=default)
 
     assert isinstance(field, BaseField)
     assert field.default == {"json": "json"}
+    # test if return mutations affect the default
+    returned = field.get_default_value()
+    returned["json"] = "not_json"
+    assert default == {"json": "json"}
 
 
 def test_can_create_binary_field():

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -193,9 +193,6 @@ def test_can_create_boolean_field():
     field = BooleanField(default=True)
     assert field.default is True
 
-    field = BooleanField()
-    assert field.default is False
-
 
 def test_can_create_datetime_field():
     field = DateTimeField(auto_now=True)

--- a/tests/settings/disabled_auto_server_defaults.py
+++ b/tests/settings/disabled_auto_server_defaults.py
@@ -1,0 +1,12 @@
+import os
+from pathlib import Path
+from typing import Union
+
+from edgy.contrib.multi_tenancy.settings import TenancySettings
+
+
+class TestSettings(TenancySettings):
+    tenant_model: str = "Tenant"
+    auth_user_model: str = "User"
+    media_root: Union[str, os.PathLike] = Path(__file__).parent.parent / "test_media/"
+    allow_auto_compute_server_defaults: bool = False

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -14,7 +14,7 @@ models = edgy.Registry(database=edgy.Database(database, force_rollback=True))
 
 class User(edgy.StrictModel):
     name = edgy.fields.CharField(max_length=255)
-    is_admin = edgy.fields.BooleanField()
+    is_admin = edgy.fields.BooleanField(default=False)
     age = edgy.IntegerField(null=True)
 
     class Meta:


### PR DESCRIPTION
Changes:

- Convert for most fields defaults to server_default to ease migrations. There are some exceptions.
- Add the setting `allow_auto_compute_server_defaults` which allows to disable the automatic generation of server defaults.
- `get_default_value` is now also overwritable by factories.
- JSONField `default` is deepcopied to prevent accidental modifications of the default. There is no need anymore to provide a lambda.
