### PR TITLE
fix bulk_get_or_create

### DIFF
--- a/docs/queries/queries.md
+++ b/docs/queries/queries.md
@@ -902,7 +902,7 @@ users = await User.query.all() # 2 as total
 
 !!! Note
     `bulk_get_or_create` fetches when using `unique_fields` all matching entries in a list.
-    For reducing the amount searched, use something like `limit(100).bulk_get_or_create()`.
+    For reducing the amount searched, use something like `limit(100).bulk_get_or_create(..., unique_fields=[...])`.
 
 ## Operators
 

--- a/docs/queries/queries.md
+++ b/docs/queries/queries.md
@@ -900,6 +900,10 @@ await User.query.bulk_get_or_create([
 users = await User.query.all() # 2 as total
 ```
 
+!!! Note
+    `bulk_get_or_create` fetches when using `unique_fields` all matching entries in a list.
+    For reducing the amount searched, use something like `limit(100).bulk_get_or_create()`.
+
 ## Operators
 
 There are sometimes the need of adding some extra conditions like `AND`, or `OR` or even the `NOT`

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,6 +30,7 @@ hide:
 
 - `QuerySet.create` passed the model instance as CURRENT_INSTANCE.
 - Virtual cascade deletions doesn't trigger delete signals anymore.
+- Fix spurious iterate bug in `bulk_get_or_create`, triggered in `edgy-guardian`.
 
 ### Breaking
 

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -1701,6 +1701,7 @@ class QuerySet(BaseQuerySet):
                 # This fixes edgy-guardian bug when using databasez.iterate indirectly and
                 # is safe in case force_rollback is active
                 # Models can also issue loads by accessing attrs for building unique_fields
+                # For limiting use something like QuerySet.limit(100).bulk_get_or_create(...)
                 for model in await queryset.filter(**filter_kwargs):
                     if all(
                         getattr(model, k) == expected for k, expected in dict_fields.items()

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -1700,6 +1700,7 @@ class QuerySet(BaseQuerySet):
                 found = False
                 # This fixes edgy-guardian bug when using databasez.iterate indirectly and
                 # is safe in case force_rollback is active
+                # Models can also issue loads by accessing attrs for building unique_fields
                 for model in await queryset.filter(**filter_kwargs):
                     if all(
                         getattr(model, k) == expected for k, expected in dict_fields.items()

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -1701,10 +1701,10 @@ class QuerySet(BaseQuerySet):
                 # This fixes edgy-guardian bug when using databasez.iterate indirectly and
                 # is safe in case force_rollback is active
                 # Because there shouldn't be many records, we can use always fetch_all
-                # For extra safety disallow loading records, this prevents accidentally loads
+                # For extra safety disallow accidentally loads by getattr
                 token_behavior = MODEL_GETATTR_BEHAVIOR.set("passdown")
                 try:
-                    for model in await queryset.filter(**filter_kwargs):
+                    for model in await queryset.filter(**filter_kwargs).limit(self._batch_size):
                         if all(
                             getattr(model, k) == expected for k, expected in dict_fields.items()
                         ):


### PR DESCRIPTION
Despite the root source wasn't found this fixes the `bulk_get_or_create` with edgy-guardian:

the force_fallback path is used (there shouldn't be many results either) and loads are now disabled. They shouldn't happen
for fields which are used for querying
