### PR TITLE
align deletion signal interface with save interface & signal fixes

### DIFF
--- a/docs/fields/index.md
+++ b/docs/fields/index.md
@@ -602,8 +602,9 @@ from `edgy`.
     ```
 * `relation_fn` - Optionally drop a function which returns a Relation for the reverse side. This will be used by the RelatedField (if it is created). Used by the ManyToMany field.
 * `reverse_path_fn` - Optionally drop a function which handles the traversal from the reverse side. Used by the ManyToMany field.
-- `column_name` - A string. Base database name of the column (by default the same as the name). Useful for models with special characters in their name.
-
+* `column_name` - A string. Base database name of the column (by default the same as the name). Useful for models with special characters in their name.
+* `force_cascade_deletion_relation` enforces a deletion in edgy instead in the db.
+* `use_model_based_deletion` - A bool. Defaults to False. Can be used to force model based deletions when using `force_cascade_deletion_relation`.
 
 !!! Note
     The index parameter can improve the performance and is strongly recommended especially with `no_constraint` but also

--- a/docs/models.md
+++ b/docs/models.md
@@ -178,8 +178,9 @@ for customizing the deletion for QuerySet deletions and direct deletions of a mo
 If you only want a special deletion when called directly on a model instance,
 then overload `async def delete(skip_post_delete_hooks=False)`.
 
-If you prefer having also delete signals for virtual cascade deletions and model based deletions
-you set the class variable: `__deletion_with_signals__ = True`.
+If you want having also delete signals for virtual cascade deletions and model based deletions
+you set the variable `__deletion_with_signals__` to `True` before calling the internal `raw_delete`.
+You can also set it as a classvariable.
 
 ##### Copying a model to a new registry
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -77,11 +77,12 @@ There are few special attributes which can be set
 
 - `database`: Different database/access current database of model. Should be in registry extra. It is set per instance when using queries.
 - `__using_schema__`: Different schema. The schema must be created first. Default is Undefined. It is set per instance for tenant models.
-- ``
+
 These attributes work on instances as well as classes.
 
 There are a few more exotic ones:
 
+- `__deletion_with_signals__`: (Default False): For every model deletion a deletion signal is raised, no matter if it is the originator or not. By default only for toplevel deletes the signals are raised. Useful in combination with model based deletion.
 - `__require_model_based_deletion__`: (Default False): Enforce a deletion in edgy instead of the database (Query iterates through models and deletes each explicitly). This is quite imperformant, so only set it if you really require that the delete method of a model is called.
 - `__reflected__`: Only read but don't set it. It shows if a model has the reflected state.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -178,6 +178,9 @@ for customizing the deletion for QuerySet deletions and direct deletions of a mo
 If you only want a special deletion when called directly on a model instance,
 then overload `async def delete(skip_post_delete_hooks=False)`.
 
+If you prefer having also delete signals for virtual cascade deletions and model based deletions
+you set the class variable: `__deletion_with_signals__ = True`.
+
 ##### Copying a model to a new registry
 
 We have now a method:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,14 +22,14 @@ hide:
 - Split `delete` in `delete` (only used for direct calls) and `raw_delete` for better customizations.
 - Split `save` in `save` (only used for direct calls) and `real_save` for better customizations.
 - Remove internal only parameter `remove_referenced_call` from delete (but not from raw_delete).
-- Virtual cascade deletions doesn't trigger delete signals anymore.
+- Virtual cascade and model based deletions doesn't trigger delete signals anymore (except if `__deletion_with_signals__=True` is set as class variable).
 - `QuerySet.create` passes now the QuerySet instance as CURRENT_INSTANCE.
 - `QuerySet.create` passes now the QuerySet instance as signal parameter instance.
 
 ### Fixed
 
 - `QuerySet.create` passed the model instance as CURRENT_INSTANCE.
-- Virtual cascade deletions doesn't trigger delete signals anymore.
+- Virtual cascade and model based deletions doesn't trigger delete signals anymore.
 - Fix spurious iterate bug in `bulk_get_or_create`, triggered in `edgy-guardian`.
 
 ### Breaking

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,13 +22,13 @@ hide:
 - Split `delete` in `delete` (only used for direct calls) and `raw_delete` for better customizations.
 - Split `save` in `save` (only used for direct calls) and `real_save` for better customizations.
 - Remove internal only parameter `remove_referenced_call` from delete (but not from raw_delete).
-- Virtual cascade and model based deletions doesn't trigger delete signals anymore (except if `__deletion_with_signals__=True` is set as class variable).
-- `QuerySet.create` passes now the QuerySet instance as CURRENT_INSTANCE.
+- Virtual cascade and model based deletions doesn't trigger delete signals anymore (except if `__deletion_with_signals__=True` is set).
+- `QuerySet.create` passes now the QuerySet instance as `CURRENT_INSTANCE`.
 - `QuerySet.create` passes now the QuerySet instance as signal parameter instance.
 
 ### Fixed
 
-- `QuerySet.create` passed the model instance as CURRENT_INSTANCE.
+- `QuerySet.create` passed the model instance as `CURRENT_INSTANCE`.
 - Virtual cascade and model based deletions doesn't trigger delete signals anymore.
 - Fix spurious iterate bug in `bulk_get_or_create`, triggered in `edgy-guardian`.
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,7 @@ hide:
 - Split `delete` in `delete` (only used for direct calls) and `raw_delete` for better customizations.
 - Split `save` in `save` (only used for direct calls) and `real_save` for better customizations.
 - Remove internal only parameter `remove_referenced_call` from delete (but not from raw_delete).
+- Change the `remove_referenced_call` to also accept strings, which are the fields from which the deletion originates from.
 - Virtual cascade and model based deletions doesn't trigger delete signals anymore (except if `__deletion_with_signals__=True` is set).
 - `QuerySet.create` passes now the QuerySet instance as `CURRENT_INSTANCE`.
 - `QuerySet.create` passes now the QuerySet instance as signal parameter instance.
@@ -31,6 +32,7 @@ hide:
 - `QuerySet.create` passed the model instance as `CURRENT_INSTANCE`.
 - Virtual cascade and model based deletions doesn't trigger delete signals anymore.
 - Fix spurious iterate bug in `bulk_get_or_create`, triggered in `edgy-guardian`.
+- Fix wrong signal sender class for proxy models.
 
 ### Breaking
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -77,13 +77,12 @@ The receiver function receives following parameters:
 Triggered before a model is deleted (during `Model.delete()` and `Model.query.delete()`).
 
 ```python
-pre_delete(send: Type["Model"], instance: Union["Model", "QuerySet"], model_instance: Optional["Model"], row_count: Optional[int])
+pre_delete(send: Type["Model"], instance: Union["Model", "QuerySet"], model_instance: Optional["Model"])
 ```
 
 ##### pre_delete parameters
 
 - instance - The model or QuerySet instance.
-- row_count - How many rows are deleted already (model_based deletions and `__deletion_with_signals__=True`).
 - model_instance -The model instance if available.
 
 #### post_delete

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -77,25 +77,28 @@ The receiver function receives following parameters:
 Triggered before a model is deleted (during `Model.delete()` and `Model.query.delete()`).
 
 ```python
-pre_delete(send: Type["Model"], instance: Union["Model", "QuerySet"],)
+pre_delete(send: Type["Model"], instance: Union["Model", "QuerySet"], model_instance: Optional["Model"], row_count: Optional[int])
 ```
 
 ##### pre_delete parameters
 
 - instance - The model or QuerySet instance.
+- row_count - How many rows are deleted already (model_based deletions and `__deletion_with_signals__=True`).
+- model_instance -The model instance if available.
 
 #### post_delete
 
 Triggered after a model is deleted (during `Model.delete()` and `Model.query.delete()`).
 
 ```python
-post_delete(send: Type["Model"], instance: Union["Model", "QuerySet"], row_count: Optional[int])
+post_delete(send: Type["Model"], instance: Union["Model", "QuerySet"], model_instance: Optional["Model"], row_count: Optional[int])
 ```
 
 ##### post_delete parameters
 
 - instance - The model or QuerySet instance.
 - row_count - How many rows are deleted (only some dbs can be None).
+- model_instance -The model instance if available.
 
 #### pre_migrate
 

--- a/docs_src/signals/logic.py
+++ b/docs_src/signals/logic.py
@@ -15,3 +15,5 @@ async def is_verified_user(id: int):
     if user.is_verified:
         # triggers the custom signal
         await User.meta.signals.on_verify.send_async(User, instance=user)
+        # or when maybe a proxy
+        await User.meta.signals.on_verify.send_async(User.get_real_class(), instance=user)

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -13,7 +13,7 @@ import sqlalchemy
 from pydantic import BaseModel
 
 from edgy.core.db.constants import SET_DEFAULT, SET_NULL
-from edgy.core.db.context_vars import CURRENT_INSTANCE, CURRENT_PHASE
+from edgy.core.db.context_vars import CURRENT_FIELD_CONTEXT, CURRENT_INSTANCE, CURRENT_PHASE
 from edgy.core.db.fields.base import BaseForeignKey
 from edgy.core.db.fields.factories import ForeignKeyFieldFactory
 from edgy.core.db.fields.types import BaseFieldType
@@ -72,18 +72,15 @@ class BaseForeignKeyField(BaseForeignKey):
             terminal.write_warning("Declaring on_delete `SET NULL` but null is False.")
 
     async def _notset_post_delete_callback(self, value: Any) -> None:
+        # FIXME: we are stuck on an old version of field before copy, so replace self
+        self = CURRENT_FIELD_CONTEXT.get()["field"]
         value = self.expand_relationship(value)
-        with_signals = self.target.__deletion_with_signals__
         if value is not None:
             token = CURRENT_INSTANCE.set(value)
-            if with_signals:
-                await self.meta.signals.pre_delete.send_async(self.__class__, instance=value, model_instance=value, row_count=None)
             try:
-                row_count = await value.raw_delete(skip_post_delete_hooks=False, remove_referenced_call=True)
+                await value.raw_delete(skip_post_delete_hooks=False, remove_referenced_call=True)
             finally:
                 CURRENT_INSTANCE.reset(token)
-            if with_signals:
-                await self.meta.signals.post_delete.send_async(self.__class__, instance=value, model_instance=value, row_count=row_count)
 
     async def pre_save_callback(
         self, value: Any, original_value: Any, is_update: bool
@@ -109,6 +106,7 @@ class BaseForeignKeyField(BaseForeignKey):
     def get_relation(self, **kwargs: Any) -> ManyRelationProtocol:
         if self.relation_fn is not None:
             return self.relation_fn(**kwargs)
+        # also set in db.py
         if self.force_cascade_deletion_relation:
             relation: Any = VirtualCascadeDeletionSingleRelation
         else:

--- a/edgy/core/db/fields/mixins.py
+++ b/edgy/core/db/fields/mixins.py
@@ -34,7 +34,7 @@ class IncrementOnSaveBaseField(Field):
         self, value: Any, original_value: Any, is_update: bool
     ) -> dict[str, Any]:
         # FIXME: we are stuck on an old version of field before copy, so replace self
-        self = CURRENT_FIELD_CONTEXT.get()["field"]
+        self = CURRENT_FIELD_CONTEXT.get()["field"]  # type: ignore
         explicit_values = EXPLICIT_SPECIFIED_VALUES.get()
         if explicit_values is not None and self.name in explicit_values:
             return {}

--- a/edgy/core/db/fields/mixins.py
+++ b/edgy/core/db/fields/mixins.py
@@ -2,7 +2,12 @@ import datetime
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from edgy.core.db.context_vars import CURRENT_INSTANCE, CURRENT_PHASE, EXPLICIT_SPECIFIED_VALUES
+from edgy.core.db.context_vars import (
+    CURRENT_FIELD_CONTEXT,
+    CURRENT_INSTANCE,
+    CURRENT_PHASE,
+    EXPLICIT_SPECIFIED_VALUES,
+)
 from edgy.core.db.fields.base import Field
 from edgy.core.db.fields.factories import FieldFactory
 from edgy.core.db.fields.types import BaseFieldType
@@ -28,6 +33,8 @@ class IncrementOnSaveBaseField(Field):
     async def _notset_pre_save_callback(
         self, value: Any, original_value: Any, is_update: bool
     ) -> dict[str, Any]:
+        # FIXME: we are stuck on an old version of field before copy, so replace self
+        self = CURRENT_FIELD_CONTEXT.get()["field"]
         explicit_values = EXPLICIT_SPECIFIED_VALUES.get()
         if explicit_values is not None and self.name in explicit_values:
             return {}

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -57,6 +57,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
             "__show_pk__",
             "__using_schema__",
             "__no_load_trigger_attrs__",
+            "__deletion_with_signals__",
             "database",
             "transaction",
         }
@@ -66,10 +67,12 @@ class EdgyBaseModel(BaseModel, BaseModelType):
     __reflected__: ClassVar[bool] = False
     __show_pk__: ClassVar[bool] = False
     __using_schema__: ClassVar[Union[str, None, Any]] = Undefined
+    __deletion_with_signals__: ClassVar[bool] = False
     __no_load_trigger_attrs__: ClassVar[set[str]] = _empty
     database: ClassVar[Database] = None
-    # private attribute
+    # private attributes
     _loaded_or_deleted: bool = PrivateAttr(default=False)
+    _db_schemas: ClassVar[dict[str, type[BaseModelType]]]
 
     def __init__(
         self,

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -89,6 +89,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
             "__show_pk__": klass.__show_pk__,
             "__no_load_trigger_attrs__": {*klass.__no_load_trigger_attrs__},
             "__using_schema__": klass.__using_schema__,
+            "__deletion_with_signals__": klass.__deletion_with_signals__,
             "database": klass.database,
         }
         if __show_pk__ is not None:

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -596,7 +596,7 @@ class DatabaseMixin:
 
     async def delete(self: Model, skip_post_delete_hooks: bool = False) -> None:
         """Delete operation from the database"""
-        await self.meta.signals.pre_delete.send_async(self.__class__, instance=self)
+        await self.meta.signals.pre_delete.send_async(self.__class__, instance=self, model_instance=self, row_count=None)
         token = CURRENT_INSTANCE.set(self)
         try:
             row_count = await self.raw_delete(
@@ -606,7 +606,7 @@ class DatabaseMixin:
         finally:
             CURRENT_INSTANCE.reset(token)
         await self.meta.signals.post_delete.send_async(
-            self.__class__, instance=self, row_count=row_count
+            self.__class__, instance=self, model_instance=self, row_count=row_count
         )
 
     async def load(self, only_needed: bool = False) -> None:

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -58,9 +58,7 @@ class BaseModelType(ABC):
     __parent__: ClassVar[Union[type[BaseModelType], None]] = None
     __is_proxy_model__: ClassVar[bool] = False
     __require_model_based_deletion__: ClassVar[bool] = False
-    __deletion_with_signals__: ClassVar[bool] = False
     __reflected__: ClassVar[bool] = False
-    _db_schemas: ClassVar[dict[str, type[BaseModelType]]]
 
     @property
     @abstractmethod

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -118,13 +118,25 @@ class BaseModelType(ABC):
 
     @abstractmethod
     async def raw_delete(
-        self, *, skip_post_delete_hooks: bool, remove_referenced_call: bool
+        self, *, skip_post_delete_hooks: bool, remove_referenced_call: Union[bool, str]
     ) -> None:
-        """Delete Model. Raw version called by QuerySet and delete. For customization."""
+        """
+        Delete Model. Raw version called by QuerySet and delete.
+        For customization. Should be called for user and non-user-facing customizations.
+
+        Kwargs:
+            skip_post_delete_hooks: Skip field post deletehooks.
+            remove_referenced_call: Either bool if the originator of the call is the model itself or
+                                    string from which field the delete call originates from
+                                    Should be passed through by customizations.
+        """
+        # Why remove_referenced_call as string?
+        # When traversing a RelatedField for deletions there are stub back references
+        # If not trimmed, they are used for model deletion.
 
     @abstractmethod
     async def delete(self, skip_post_delete_hooks: bool = False) -> None:
-        """Delete Model."""
+        """Delete Model. User-facing, not used by internal methods."""
 
     @abstractmethod
     async def load_recursive(
@@ -186,6 +198,9 @@ class BaseModelType(ABC):
         """
 
     # helpers
+    @classmethod
+    def get_real_class(cls) -> BaseModelType:
+        return cls.__parent__ if cls.__is_proxy_model__ else cls  # type: ignore
 
     def extract_db_fields(self, only: Optional[Sequence[str]] = None) -> dict[str, Any]:
         """

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -58,6 +58,7 @@ class BaseModelType(ABC):
     __parent__: ClassVar[Union[type[BaseModelType], None]] = None
     __is_proxy_model__: ClassVar[bool] = False
     __require_model_based_deletion__: ClassVar[bool] = False
+    __deletion_with_signals__: ClassVar[bool] = False
     __reflected__: ClassVar[bool] = False
     _db_schemas: ClassVar[dict[str, type[BaseModelType]]]
 

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -996,30 +996,38 @@ class BaseQuerySet(
         row_count = 0
         models = await queryset
         token = CURRENT_INSTANCE.set(cast("QuerySet", self))
-        await self.model_class.meta.signals.pre_delete.send_async(self.__class__, instance=self, model_instance=None, row_count=0)
-        trigger_model_signals = self.model_class.__deletion_with_signals__
         try:
             while models:
                 for model in models:
-                    if trigger_model_signals:
-                        await self.model_class.meta.signals.pre_delete.send_async(
-                            self.__class__, instance=self, model_instance=model, row_count=row_count
-                        )
+                    await model.raw_delete(
+                        skip_post_delete_hooks=False, remove_referenced_call=False
+                    )
                     row_count += 1
-                    # delete issues already signals
-                    await model.delete()
-                    if trigger_model_signals:
-                        await self.model_class.meta.signals.post_delete.send_async(
-                            self.__class__, instance=self, model_instance=model, row_count=row_count
-                        )
                 # clear cache and fetch new batch
                 models = await queryset.all(True)
         finally:
             CURRENT_INSTANCE.reset(token)
+        return row_count
+
+    async def raw_delete(self, use_models: bool = False) -> int:
+        if (
+            self.model_class.__require_model_based_deletion__
+            or self.model_class.meta.post_delete_fields
+        ):
+            use_models = True
+        if use_models:
+            row_count = await self._model_based_delete()
+        else:
+            expression = self.table.delete()
+            expression = expression.where(await self.build_where_clause())
+
+            check_db_connection(self.database)
+            async with self.database as database:
+                row_count = cast(int, await database.execute(expression))
+
+        # clear cache before executing post_delete. Fresh results can be retrieved in signals
         self._clear_cache()
-        await self.model_class.meta.signals.post_delete.send_async(
-            self.__class__, instance=self, model_instance=None, row_count=row_count
-        )
+
         return row_count
 
     async def _get_raw(self, **kwargs: Any) -> tuple[BaseModelType, Any]:
@@ -1712,21 +1720,15 @@ class QuerySet(BaseQuerySet):
                 # Models can also issue loads by accessing attrs for building unique_fields
                 # For limiting use something like QuerySet.limit(100).bulk_get_or_create(...)
                 for model in await queryset.filter(**filter_kwargs):
-                    if all(
-                        getattr(model, k) == expected for k, expected in dict_fields.items()
-                    ):
+                    if all(getattr(model, k) == expected for k, expected in dict_fields.items()):
                         lookup_key = _extract_unique_lookup_key(model, unique_fields)
-                        assert lookup_key is not None, (
-                            "invalid fields/attributes in unique_fields"
-                        )
+                        assert lookup_key is not None, "invalid fields/attributes in unique_fields"
                         if lookup_key not in existing_records:
                             existing_records[lookup_key] = model
                         found = True
                         break
                 if found is False:
-                    new_objs.append(
-                        queryset.model_class(**obj) if isinstance(obj, dict) else obj
-                    )
+                    new_objs.append(queryset.model_class(**obj) if isinstance(obj, dict) else obj)
 
             retrieved_objs.extend(existing_records.values())
         else:
@@ -1765,29 +1767,12 @@ class QuerySet(BaseQuerySet):
         return retrieved_objs
 
     async def delete(self, use_models: bool = False) -> int:
-        if (
-            self.model_class.__require_model_based_deletion__
-            or self.model_class.meta.post_delete_fields
-        ):
-            use_models = True
-        if use_models:
-            return await self._model_based_delete()
-
-        # delete of model issues already signals, so don't integrate them
-        await self.model_class.meta.signals.pre_delete.send_async(self.model_class, instance=self, model_instance=None, row_count=0)
-
-        expression = self.table.delete()
-        expression = expression.where(await self.build_where_clause())
-
-        check_db_connection(self.database)
-        async with self.database as database:
-            row_count = cast(int, await database.execute(expression))
-
-        # clear cache before executing post_delete. Fresh results can be retrieved in signals
-        self._clear_cache()
-
+        await self.model_class.meta.signals.pre_delete.send_async(
+            self.model_class, instance=self, model_instance=None
+        )
+        row_count = await self.raw_delete(use_models)
         await self.model_class.meta.signals.post_delete.send_async(
-            self.model_class, instance=self, row_count=row_count, model_instance=None
+            self.model_class, instance=self, model_instance=None, row_count=row_count
         )
         return row_count
 

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -320,4 +320,5 @@ class SingleRelation(ManyRelationProtocol):
 
 class VirtualCascadeDeletionSingleRelation(SingleRelation):
     async def post_delete_callback(self) -> None:
-        await self.delete()
+        # issue a plain deletion, without signals on QuerySet
+        await self.raw_delete()

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -321,4 +321,7 @@ class SingleRelation(ManyRelationProtocol):
 class VirtualCascadeDeletionSingleRelation(SingleRelation):
     async def post_delete_callback(self) -> None:
         # issue a plain deletion, without signals on QuerySet
-        await self.raw_delete()
+        await self.raw_delete(
+            use_models=self.to.meta.fields[self.to_foreign_key].use_model_based_deletion,
+            remove_referenced_call=self.to_foreign_key,
+        )

--- a/tests/signals/test_deletion_signals.py
+++ b/tests/signals/test_deletion_signals.py
@@ -10,8 +10,10 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL, drop_database=True, force_rollback=False)
-models = edgy.Registry(database=database, full_isolation=False)
+database = DatabaseTestClient(
+    DATABASE_URL, drop_database=True, force_rollback=False, full_isolation=False
+)
+models = edgy.Registry(database=database)
 
 
 class User(edgy.StrictModel):
@@ -22,6 +24,7 @@ class User(edgy.StrictModel):
         on_delete=edgy.CASCADE,
         no_constraint=True,
         remove_referenced=True,
+        use_model_based_deletion=True,
     )
 
     class Meta:
@@ -39,10 +42,18 @@ class Profile(edgy.StrictModel):
 class Log(edgy.StrictModel):
     signal = edgy.CharField(max_length=255)
     is_queryset: bool = edgy.BooleanField()
+    model_instance_id = edgy.BigIntegerField(null=True)
+    row_count = edgy.BigIntegerField(null=True)
     class_name: str = edgy.CharField(max_length=255)
 
     class Meta:
         registry = models
+
+    def __str__(self) -> str:
+        return str(self.extract_db_fields())
+
+    def __repr__(self) -> str:
+        return f"Log<{self}>"
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -50,26 +61,46 @@ async def create_test_database():
     async with models:
         await models.create_all()
         yield
-    if not database.drop:
-        await models.drop_all()
 
 
 @pytest.fixture(autouse=True, scope="function")
 async def connect_signals():
-    @pre_delete.connect_via(Profile)
-    @pre_delete.connect_via(User)
+    @pre_delete.connect_via(Profile, weak=True)
+    @pre_delete.connect_via(User, weak=True)
     async def pre_deleting(sender, instance, model_instance, **kwargs):
-        await Log.query.create(signal="pre_delete", is_queryset=model_instance is None, class_name=type(model_instance).__name__)
+        await Log.query.create(
+            signal="pre_delete",
+            is_queryset=model_instance is None,
+            model_instance_id=None if model_instance is None else model_instance.id,
+            class_name=instance.model_class.__name__
+            if model_instance is None
+            else type(model_instance).__name__,
+        )
 
-    @post_delete.connect_via(Profile)
-    @post_delete.connect_via(User)
-    async def post_deleting(sender, instance, model_instance, **kwargs):
-        await Log.query.create(signal="post_delete", is_queryset=model_instance is None, class_name=type(model_instance).__name__)
+    @post_delete.connect_via(Profile, weak=True)
+    @post_delete.connect_via(User, weak=True)
+    async def post_deleting(sender, instance, model_instance, row_count, **kwargs):
+        await Log.query.create(
+            signal="post_delete",
+            is_queryset=model_instance is None,
+            model_instance_id=None if model_instance is None else model_instance.id,
+            class_name=instance.model_class.__name__
+            if model_instance is None
+            else type(model_instance).__name__,
+            row_count=row_count,
+        )
+
     try:
         yield
     finally:
         pre_delete.disconnect(pre_deleting)
         post_delete.disconnect(post_deleting)
+
+
+@pytest.mark.parametrize("klass", [User, Profile])
+async def test_correct_connection(klass):
+    assert pre_delete.has_receivers_for(klass)
+    assert post_delete.has_receivers_for(klass)
 
 
 @pytest.mark.parametrize("klass", [User, Profile])
@@ -85,6 +116,7 @@ async def test_deletion_called_once_model(klass):
     assert logs[1].signal == "post_delete"
     assert logs[1].class_name == klass.__name__
 
+
 async def test_deletion_called_once_query():
     await User.query.create(name="Edgy")
     logs = await Log.query.all()
@@ -93,9 +125,11 @@ async def test_deletion_called_once_query():
     logs = await Log.query.all()
     assert len(logs) == 2
     assert logs[0].signal == "pre_delete"
-    assert logs[0].class_name == type(None).__name__
+    assert logs[0].class_name == "User"
+    assert logs[0].is_queryset
     assert logs[1].signal == "post_delete"
-    assert logs[1].class_name == type(None).__name__
+    assert logs[1].class_name == "User"
+    assert logs[1].is_queryset
 
 
 async def test_deletion_called_referenced():
@@ -116,6 +150,7 @@ async def test_deletion_called_referenced():
 async def test_deletion_called_cascade():
     profile = await Profile.query.create(name="Edgy")
     await User.query.create(name="Edgy", profile=profile)
+    await User.query.create(name="Edgy2", profile=profile)
 
     logs = await Log.query.all()
     assert len(logs) == 0
@@ -123,19 +158,32 @@ async def test_deletion_called_cascade():
     logs = await Log.query.all()
     assert len(logs) == 2
     assert logs[0].signal == "pre_delete"
+    assert logs[0].class_name == "Profile"
     assert logs[1].signal == "post_delete"
+    assert logs[1].class_name == "Profile"
+
 
 async def test_deletion_called_cascade_with_signals():
     profile = await Profile.query.create(name="Edgy")
-    user = await User.query.create(name="Edgy", profile=profile)
+    await User.query.create(name="Edgy", profile=profile)
+    await User.query.create(name="Edgy2", profile=profile)
 
     logs = await Log.query.all()
     assert len(logs) == 0
-    user.__deletion_with_signals__ = True
+    User.__deletion_with_signals__ = True
     await profile.delete()
+    User.__deletion_with_signals__ = False
     logs = await Log.query.all()
-    assert len(logs) == 4
+    assert len(logs) == 6
     assert logs[0].signal == "pre_delete"
+    assert logs[0].class_name == "Profile"
     assert logs[1].signal == "pre_delete"
+    assert logs[1].class_name == "User"
     assert logs[2].signal == "post_delete"
-    assert logs[3].signal == "post_delete"
+    assert logs[2].class_name == "User"
+    assert logs[3].signal == "pre_delete"
+    assert logs[3].class_name == "User"
+    assert logs[4].signal == "post_delete"
+    assert logs[4].class_name == "User"
+    assert logs[5].signal == "post_delete"
+    assert logs[5].class_name == "Profile"

--- a/tests/signals/test_deletion_signals.py
+++ b/tests/signals/test_deletion_signals.py
@@ -1,0 +1,141 @@
+import pytest
+
+import edgy
+from edgy.core.signals import (
+    post_delete,
+    pre_delete,
+)
+from edgy.testclient import DatabaseTestClient
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+
+database = DatabaseTestClient(DATABASE_URL, drop_database=True, force_rollback=False)
+models = edgy.Registry(database=database, full_isolation=False)
+
+
+class User(edgy.StrictModel):
+    name = edgy.CharField(max_length=100)
+    profile = edgy.ForeignKey(
+        "Profile",
+        null=True,
+        on_delete=edgy.CASCADE,
+        no_constraint=True,
+        remove_referenced=True,
+    )
+
+    class Meta:
+        registry = models
+
+
+class Profile(edgy.StrictModel):
+    name = edgy.CharField(max_length=100)
+    __deletion_with_signals__ = True
+
+    class Meta:
+        registry = models
+
+
+class Log(edgy.StrictModel):
+    signal = edgy.CharField(max_length=255)
+    is_queryset: bool = edgy.BooleanField()
+    class_name: str = edgy.CharField(max_length=255)
+
+    class Meta:
+        registry = models
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def create_test_database():
+    async with models:
+        await models.create_all()
+        yield
+    if not database.drop:
+        await models.drop_all()
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def connect_signals():
+    @pre_delete.connect_via(Profile)
+    @pre_delete.connect_via(User)
+    async def pre_deleting(sender, instance, model_instance, **kwargs):
+        await Log.query.create(signal="pre_delete", is_queryset=model_instance is None, class_name=type(model_instance).__name__)
+
+    @post_delete.connect_via(Profile)
+    @post_delete.connect_via(User)
+    async def post_deleting(sender, instance, model_instance, **kwargs):
+        await Log.query.create(signal="post_delete", is_queryset=model_instance is None, class_name=type(model_instance).__name__)
+    try:
+        yield
+    finally:
+        pre_delete.disconnect(pre_deleting)
+        post_delete.disconnect(post_deleting)
+
+
+@pytest.mark.parametrize("klass", [User, Profile])
+async def test_deletion_called_once_model(klass):
+    obj = await klass.query.create(name="Edgy")
+    logs = await Log.query.all()
+    assert len(logs) == 0
+    await obj.delete()
+    logs = await Log.query.all()
+    assert len(logs) == 2
+    assert logs[0].signal == "pre_delete"
+    assert logs[0].class_name == klass.__name__
+    assert logs[1].signal == "post_delete"
+    assert logs[1].class_name == klass.__name__
+
+async def test_deletion_called_once_query():
+    await User.query.create(name="Edgy")
+    logs = await Log.query.all()
+    assert len(logs) == 0
+    await User.query.delete()
+    logs = await Log.query.all()
+    assert len(logs) == 2
+    assert logs[0].signal == "pre_delete"
+    assert logs[0].class_name == type(None).__name__
+    assert logs[1].signal == "post_delete"
+    assert logs[1].class_name == type(None).__name__
+
+
+async def test_deletion_called_referenced():
+    profile = await Profile.query.create(name="Edgy")
+    user = await User.query.create(name="Edgy", profile=profile)
+
+    logs = await Log.query.all()
+    assert len(logs) == 0
+    await user.delete()
+    logs = await Log.query.all()
+    assert len(logs) == 4
+    assert logs[0].signal == "pre_delete"
+    assert logs[1].signal == "pre_delete"
+    assert logs[2].signal == "post_delete"
+    assert logs[3].signal == "post_delete"
+
+
+async def test_deletion_called_cascade():
+    profile = await Profile.query.create(name="Edgy")
+    await User.query.create(name="Edgy", profile=profile)
+
+    logs = await Log.query.all()
+    assert len(logs) == 0
+    await profile.delete()
+    logs = await Log.query.all()
+    assert len(logs) == 2
+    assert logs[0].signal == "pre_delete"
+    assert logs[1].signal == "post_delete"
+
+async def test_deletion_called_cascade_with_signals():
+    profile = await Profile.query.create(name="Edgy")
+    user = await User.query.create(name="Edgy", profile=profile)
+
+    logs = await Log.query.all()
+    assert len(logs) == 0
+    user.__deletion_with_signals__ = True
+    await profile.delete()
+    logs = await Log.query.all()
+    assert len(logs) == 4
+    assert logs[0].signal == "pre_delete"
+    assert logs[1].signal == "pre_delete"
+    assert logs[2].signal == "post_delete"
+    assert logs[3].signal == "post_delete"

--- a/tests/signals/test_signals.py
+++ b/tests/signals/test_signals.py
@@ -1,5 +1,4 @@
 import pytest
-from loguru import logger
 
 import edgy
 from edgy.core.signals import (
@@ -66,38 +65,38 @@ async def test_signals():
         await Log.query.create(
             signal="pre_save", instance=model_instance.model_dump(), params=kwargs
         )
-        logger.info(f"pre_save signal broadcasted for {model_instance.get_instance_name()}")
+        print(f"pre_save signal broadcasted for {model_instance.get_instance_name()}")
 
     @post_save.connect_via(User)
     async def post_saving(sender, instance, model_instance, **kwargs):
         await Log.query.create(
             signal="post_save", instance=model_instance.model_dump(), params=kwargs
         )
-        logger.info(f"post_save signal broadcasted for {model_instance.get_instance_name()}")
+        print(f"post_save signal broadcasted for {model_instance.get_instance_name()}")
 
     @pre_update.connect_via(User)
     async def pre_updating(sender, instance, model_instance, **kwargs):
         await Log.query.create(
             signal="pre_update", instance=model_instance.model_dump(), params=kwargs
         )
-        logger.info(f"pre_update signal broadcasted for {model_instance.get_instance_name()}")
+        print(f"pre_update signal broadcasted for {model_instance.get_instance_name()}")
 
     @post_update.connect_via(User)
     async def post_updating(sender, instance, model_instance, **kwargs):
         await Log.query.create(
             signal="post_update", instance=model_instance.model_dump(), params=kwargs
         )
-        logger.info(f"post_update signal broadcasted for {model_instance.get_instance_name()}")
+        print(f"post_update signal broadcasted for {model_instance.get_instance_name()}")
 
     @pre_delete.connect_via(User)
-    async def pre_deleting(sender, instance, **kwargs):
-        await Log.query.create(signal="pre_delete", instance=instance.model_dump())
-        logger.info(f"pre_delete signal broadcasted for {instance.get_instance_name()}")
+    async def pre_deleting(sender, instance, model_instance, **kwargs):
+        await Log.query.create(signal="pre_delete", instance=model_instance.model_dump())
+        print(f"pre_delete signal broadcasted for {model_instance.get_instance_name()}")
 
     @post_delete.connect_via(User)
-    async def post_deleting(sender, instance, **kwargs):
-        await Log.query.create(signal="post_delete", instance=instance.model_dump())
-        logger.info(f"post_delete signal broadcasted for {instance.get_instance_name()}")
+    async def post_deleting(sender, instance, model_instance, **kwargs):
+        await Log.query.create(signal="post_delete", instance=model_instance.model_dump())
+        print(f"post_delete signal broadcasted for {model_instance.get_instance_name()}")
 
     # Signals for the create
     user = await User.query.create(name="Edgy")


### PR DESCRIPTION
Changes:
- Allow issuing signals during deletion when model based or virtual cascade deletion
- Align the delete signal interface with the save signal interface
- Signal Bugfixes
- Change raw_delete a little
- Remove loguru from tests, there was no reason for logging