### PR TITLE
too early settings import

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,31 @@ hide:
 
 # Release Notes
 
+## 0.31.2
+
+### Added
+
+- Add the method `get_server_default`.
+- Add `get_columns_nullable`, `get_server_default` and `customize_default_for_server_default` to factory
+  overwritable methods.
+
+### Changed
+
+- `server_default` is not extracted anymore by `ColumnDefinitionModel`. Use `get_server_default` instead.
+
+### Removed
+
+- Remove the abstract method `customize_default_for_server_default` from BaseFieldType.
+
+### Fixed
+
+- Fix potential too early import of settings because of the auto computation of server_defaults.
+
+### Breaking
+
+When creating a custom field providing get_columns and
+relying on the extraction of server defaults from field, you may need to update the code to use `get_server_default`.
+
 ## 0.31.1
 
 ### Fixed

--- a/edgy/__init__.py
+++ b/edgy/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.31.1"
+__version__ = "0.31.2"
 from typing import TYPE_CHECKING
 
 from ._monkay import Instance, create_monkay

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -84,7 +84,9 @@ class BaseField(BaseFieldType, FieldInfo):
         # this is required for backward compatibility and pydantic_core uses null=True too
         # for opting out of nullable columns overwrite the get_column(s) method
         if (
-            self.null or self.server_default is not None or self.autoincrement
+            self.null
+            or (self.server_default is not None and self.server_default is not Undefined)
+            or self.autoincrement
         ) and default is Undefined:
             default = None
         if default is not Undefined:
@@ -179,8 +181,9 @@ class BaseField(BaseFieldType, FieldInfo):
             return False
         return not (
             self.null
-            or self.server_default is not None
-            or ((self.default is not None or self.explicit_none) and self.default is not Undefined)
+            # we cannot use get_server_default() here. The test is client side not for migrations.
+            or (self.server_default is not None and self.server_default is not Undefined)
+            or self.has_default()
         )
 
     def has_default(self) -> bool:

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -72,6 +72,7 @@ class BaseField(BaseFieldType, FieldInfo):
         if "__type__" in kwargs:
             kwargs["field_type"] = kwargs.pop("__type__")
         self.explicit_none = default is None
+        self.server_default = server_default
 
         super().__init__(**kwargs)
 
@@ -93,9 +94,10 @@ class BaseField(BaseFieldType, FieldInfo):
         """
         Retrieve the server_default.
         """
+        server_default = getattr(self, "server_default", Undefined)
         # check if there was an explicit defined server_default
-        if self.server_default is not Undefined:
-            return self.server_default
+        if server_default is not Undefined:
+            return server_default
         default = self.default
         if default is Undefined or default is None:
             return None
@@ -109,7 +111,7 @@ class BaseField(BaseFieldType, FieldInfo):
             else:
                 auto_compute_server_default = self.auto_compute_server_default
         else:
-            auto_compute_server_default = bool(self.auto_compute_server_default)
+            auto_compute_server_default = self.auto_compute_server_default is True
 
         if auto_compute_server_default:
             return self.customize_default_for_server_default(default)
@@ -117,11 +119,10 @@ class BaseField(BaseFieldType, FieldInfo):
 
     def customize_default_for_server_default(self, default: Any) -> Any:
         """
-        Modify default for server_default.
+        Modify default for non-null server_default.
 
         Args:
-            field_name: the field name (can be different from name)
-            cleaned_data: currently validated data. Useful to check if the default was already applied.
+            default: The original default.
 
         """
         if callable(default):

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -19,6 +19,9 @@ default_methods_overwritable_by_factory.discard("__init__")
 
 # useful helpers
 default_methods_overwritable_by_factory.add("get_default_value")
+default_methods_overwritable_by_factory.add("get_columns_nullable")
+default_methods_overwritable_by_factory.add("get_server_default")
+default_methods_overwritable_by_factory.add("customize_default_for_server_default")
 
 # extra methods
 default_methods_overwritable_by_factory.add("__set__")

--- a/edgy/core/db/fields/file_field.py
+++ b/edgy/core/db/fields/file_field.py
@@ -175,9 +175,7 @@ class ConcreteFileField(BaseCompositeField):
                 type_=model.column_type,
                 name=column_name,
                 nullable=self.get_columns_nullable(),
-                **model.model_dump(
-                    by_alias=True, exclude_none=True, exclude={"column_name", "server_default"}
-                ),
+                **model.model_dump(by_alias=True, exclude_none=True, exclude={"column_name"}),
             ),
             sqlalchemy.Column(
                 key=f"{field_name}_storage",

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -42,7 +42,7 @@ class ColumnDefinition(_ColumnDefinition):
     column_type: Any = None
     constraints: Sequence[sqlalchemy.Constraint] = ()
     # keep any, so multi-column field authors can set a dict
-    server_default: Optional[Any] = None
+    server_default: Optional[Any] = Undefined
 
 
 class ColumnDefinitionModel(
@@ -71,7 +71,7 @@ class BaseFieldDefinitions:
     owner: Any = None
     default: Any = Undefined
     explicit_none: bool = False
-    server_default: Any = None
+    server_default: Any = Undefined
 
     # column specific
     primary_key: bool = False

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -31,8 +31,7 @@ class _ColumnDefinition:
     index: bool = False
     unique: bool = False
     comment: Optional[str] = None
-    # keep both any, so multi-column field authors can set a dict
-    server_default: Optional[Any] = None
+    # keep any, so multi-column field authors can set a dict
     server_onupdate: Optional[Any] = None
 
 
@@ -42,6 +41,8 @@ class ColumnDefinition(_ColumnDefinition):
     column_name: Optional[str] = None
     column_type: Any = None
     constraints: Sequence[sqlalchemy.Constraint] = ()
+    # keep any, so multi-column field authors can set a dict
+    server_default: Optional[Any] = None
 
 
 class ColumnDefinitionModel(
@@ -167,17 +168,6 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         """
         Define for each field/column a default. Non-private multicolumn fields should
         always check if the default was already applied.
-
-        Args:
-            field_name: the field name (can be different from name)
-            cleaned_data: currently validated data. Useful to check if the default was already applied.
-
-        """
-
-    @abstractmethod
-    def customize_default_for_server_default(self, value: Any) -> Any:
-        """
-        Modify default for server_default.
 
         Args:
             field_name: the field name (can be different from name)

--- a/tests/cli/test_server_default_fields.py
+++ b/tests/cli/test_server_default_fields.py
@@ -7,15 +7,17 @@ from asyncio import run
 from pathlib import Path
 
 import pytest
-import sqlalchemy
-from sqlalchemy.ext.asyncio import create_async_engine
 
+from edgy.testing.client import DatabaseTestClient
 from tests.cli.utils import arun_cmd
-from tests.settings import DATABASE_URL
+from tests.settings import TEST_DATABASE
 
 pytestmark = pytest.mark.anyio
 
 base_path = Path(os.path.abspath(__file__)).absolute().parent
+outer_database = DatabaseTestClient(
+    TEST_DATABASE, use_existing=False, drop_database=True, test_prefix=""
+)
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -33,19 +35,15 @@ def cleanup_folders():
 
 
 async def recreate_db():
-    engine = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
-    try:
-        async with engine.connect() as conn:
-            await conn.execute(sqlalchemy.text("DROP DATABASE test_edgy"))
-    except Exception:
-        pass
-    async with engine.connect() as conn:
-        await conn.execute(sqlalchemy.text("CREATE DATABASE test_edgy"))
+    if await outer_database.is_database_exist():
+        await outer_database.drop_database(outer_database.url)
+    await outer_database.create_database(outer_database.url)
 
 
 @pytest.fixture(scope="function", autouse=True)
 async def cleanup_prepare_db():
-    await recreate_db()
+    async with outer_database:
+        yield
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -6,15 +6,17 @@ from asyncio import run
 from pathlib import Path
 
 import pytest
-import sqlalchemy
-from sqlalchemy.ext.asyncio import create_async_engine
 
+from edgy.testing.client import DatabaseTestClient
 from tests.cli.utils import arun_cmd
-from tests.settings import DATABASE_URL
+from tests.settings import TEST_DATABASE
 
 pytestmark = pytest.mark.anyio
 
 base_path = Path(os.path.abspath(__file__)).absolute().parent
+outer_database = DatabaseTestClient(
+    TEST_DATABASE, use_existing=False, drop_database=True, test_prefix=""
+)
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -31,16 +33,16 @@ def cleanup_folders():
         shutil.rmtree(str(base_path / "migrations2"))
 
 
+async def recreate_db():
+    if await outer_database.is_database_exist():
+        await outer_database.drop_database(outer_database.url)
+    await outer_database.create_database(outer_database.url)
+
+
 @pytest.fixture(scope="function", autouse=True)
 async def cleanup_prepare_db():
-    engine = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
-    try:
-        async with engine.connect() as conn:
-            await conn.execute(sqlalchemy.text("DROP DATABASE test_edgy"))
-    except Exception:
-        pass
-    async with engine.connect() as conn:
-        await conn.execute(sqlalchemy.text("CREATE DATABASE test_edgy"))
+    async with outer_database:
+        yield
 
 
 @pytest.mark.parametrize("app_flag", ["explicit", "explicit_env", "autosearch"])

--- a/tests/fields/test_multi_column_fields.py
+++ b/tests/fields/test_multi_column_fields.py
@@ -35,6 +35,7 @@ class MultiColumnFieldInner(BaseField):
                 model.column_type,
                 *model.constraints,
                 nullable=self.get_columns_nullable(),
+                server_default=self.get_server_default(),
                 **model.model_dump(by_alias=True, exclude_none=True),
             ),
             sqlalchemy.Column(
@@ -42,6 +43,7 @@ class MultiColumnFieldInner(BaseField):
                 model.column_type,
                 *model.constraints,
                 nullable=self.get_columns_nullable(),
+                server_default=self.get_server_default(),
                 **model.model_dump(by_alias=True, exclude_none=True),
             ),
         ]


### PR DESCRIPTION
Currently fields will cause an early settings import.

Despite this is not a big issue, it can be nasty and cause some wrong imports.

fix this by moving the server_default from init to an extra method and have an extra value Undefined for server_default.

cleanup also some tests