### PR TITLE
switch to python >=3.10

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.10", "3.11", "3.12", "3.13"]
     services:
       postgres:
         image: postgres:16

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,12 +19,17 @@ hide:
 - `_loaded_or_deleted` is now `_db_loaded_or_deleted`. The former name is now deprecated.
 - `_loaded_or_deleted` is splitted in `_db_loaded` and `_db_deleted`.
 - Migrations show now tracebacks when manual migration of objects fails.
+- Bump python requirement to python 3.10 to align with (optional) dependencies.
 
 ### Fixed
 
 - Recursive saving.
 - Various json schema fixes.
 - Inherit register_default.
+
+### Breaking
+
+- Python 3.9 is no longer supported.
 
 ## 0.31.3
 

--- a/edgy/_monkay.py
+++ b/edgy/_monkay.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from monkay import Monkay
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 @dataclass
 class Instance:
     registry: Registry
-    app: Optional[Any] = None
+    app: Any | None = None
     storages: StorageHandler = field(default_factory=StorageHandler)
 
 

--- a/edgy/cli/base.py
+++ b/edgy/cli/base.py
@@ -5,7 +5,7 @@ import typing
 import warnings
 from collections.abc import Awaitable, Callable
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from alembic import __version__ as __alembic_version__
 from alembic import command
@@ -42,8 +42,8 @@ class Config(AlembicConfig):
     @classmethod
     def get_instance(
         cls,
-        args: Optional[typing.Sequence] = None,
-        options: Optional[typing.Any] = None,
+        args: typing.Sequence | None = None,
+        options: typing.Any | None = None,
     ) -> Any:
         directory = str(edgy.settings.migration_directory)
         config = cls(os.path.join(directory, "alembic.ini"))
@@ -58,7 +58,7 @@ class Config(AlembicConfig):
         if not hasattr(config.cmd_opts, "x"):
             if args is not None:
                 config.cmd_opts.x = []
-                if isinstance(args, (list, tuple)):
+                if isinstance(args, list | tuple):
                     for arg in args:
                         config.cmd_opts.x.append(arg)
                 else:
@@ -88,7 +88,7 @@ class Migrate:
         self,
         app: typing.Any,
         registry: "Registry",
-        model_apps: Union[dict[str, str], tuple[str], list[str], None] = None,
+        model_apps: dict[str, str] | tuple[str] | list[str] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -97,7 +97,7 @@ class Migrate:
         self.registry = registry
         self.model_apps = model_apps or {}
 
-        assert isinstance(self.model_apps, (dict, tuple, list)), (
+        assert isinstance(self.model_apps, dict | tuple | list), (
             "`model_apps` must be a dict of 'app_name:location' format or a list/tuple of strings."
         )
 
@@ -117,7 +117,7 @@ class Migrate:
         self.set_edgy_extension(app)
 
     def check_db_models(
-        self, model_apps: Union[dict[str, str], tuple[str], list[str]]
+        self, model_apps: dict[str, str] | tuple[str] | list[str]
     ) -> dict[str, Any]:
         """
         Goes through all the model applications declared in the migrate and
@@ -160,7 +160,7 @@ def list_templates() -> None:
 
 @catch_errors
 def init(
-    template: Optional[str] = None,
+    template: str | None = None,
     package: bool = False,
 ) -> None:
     """Creates a new migration folder"""
@@ -182,16 +182,16 @@ def init(
 
 @catch_errors
 def revision(
-    message: Optional[str] = None,
+    message: str | None = None,
     autogenerate: bool = False,
     sql: bool = False,
     head: str = "head",
     splice: bool = False,
-    branch_label: Optional[str] = None,
-    version_path: Optional[str] = None,
-    revision_id: Optional[typing.Any] = None,
-    arg: Optional[typing.Any] = None,
-    null_fields: Union[list[str], tuple[str, ...]] = (),
+    branch_label: str | None = None,
+    version_path: str | None = None,
+    revision_id: typing.Any | None = None,
+    arg: typing.Any | None = None,
+    null_fields: list[str] | tuple[str, ...] = (),
 ) -> None:
     """
     Creates a new revision file
@@ -239,15 +239,15 @@ def revision(
 
 
 def migrate(
-    message: Optional[str] = None,
+    message: str | None = None,
     sql: bool = False,
     head: str = "head",
     splice: bool = False,
-    branch_label: Optional[str] = None,
-    version_path: Optional[str] = None,
-    revision_id: Optional[typing.Any] = None,
-    arg: Optional[typing.Any] = None,
-    null_fields: Union[list[str], tuple[str, ...]] = (),
+    branch_label: str | None = None,
+    version_path: str | None = None,
+    revision_id: typing.Any | None = None,
+    arg: typing.Any | None = None,
+    null_fields: list[str] | tuple[str, ...] = (),
 ) -> None:
     """Alias for 'revision --autogenerate'"""
     return revision(
@@ -277,9 +277,9 @@ def edit(revision: str = "current") -> None:
 @catch_errors
 def merge(
     revisions: str = "",
-    message: Optional[str] = None,
-    branch_label: Optional[str] = None,
-    revision_id: Optional[str] = None,
+    message: str | None = None,
+    branch_label: str | None = None,
+    revision_id: str | None = None,
 ) -> None:
     """Merge two revisions together.  Creates a new migration file"""
     config = Config.get_instance()
@@ -292,8 +292,8 @@ def merge(
 def upgrade(
     revision: str = "head",
     sql: bool = False,
-    tag: Optional[str] = None,
-    arg: Optional[typing.Any] = None,
+    tag: str | None = None,
+    arg: typing.Any | None = None,
 ) -> None:
     """Upgrade to a later version"""
     config = Config.get_instance(args=arg)
@@ -320,8 +320,8 @@ def upgrade(
 def downgrade(
     revision: str = "-1",
     sql: bool = False,
-    tag: Optional[str] = None,
-    arg: Optional[typing.Any] = None,
+    tag: str | None = None,
+    arg: typing.Any | None = None,
 ) -> None:
     """Revert to a previous version"""
     config = Config.get_instance(args=arg)
@@ -357,7 +357,7 @@ def show(
 
 @catch_errors
 def history(
-    rev_range: Optional[typing.Any] = None,
+    rev_range: typing.Any | None = None,
     verbose: bool = False,
     indicate_current: bool = False,
 ) -> None:
@@ -394,7 +394,7 @@ def current(verbose: bool = False) -> None:
 def stamp(
     revision: str = "head",
     sql: bool = False,
-    tag: Optional[typing.Any] = None,
+    tag: typing.Any | None = None,
 ) -> None:
     """'stamp' the revision table with the given revision; don't run any
     migrations"""

--- a/edgy/cli/decorators.py
+++ b/edgy/cli/decorators.py
@@ -3,7 +3,7 @@ from contextlib import suppress
 from functools import wraps
 from importlib import import_module
 from pathlib import Path
-from typing import Any, NoReturn, Optional, TypeVar
+from typing import Any, NoReturn, TypeVar
 
 from alembic.util import CommandError
 from loguru import logger
@@ -28,7 +28,7 @@ def catch_errors(fn: T) -> T:
 def add_migration_directory_option(fn: Any) -> Any:
     import click
 
-    def callback(ctx: Any, param: str, value: Optional[str]) -> None:
+    def callback(ctx: Any, param: str, value: str | None) -> None:
         import edgy
 
         if value is not None:
@@ -60,7 +60,7 @@ def add_force_field_nullable_option(fn: Any) -> Any:
 def add_app_module_option(fn: Any) -> Any:
     import click
 
-    def callback(ctx: click.Context, param: str, value: Optional[str]) -> None:
+    def callback(ctx: click.Context, param: str, value: str | None) -> None:
         import edgy
 
         # before importing anything inject the cwd

--- a/edgy/cli/operations/inspectdb.py
+++ b/edgy/cli/operations/inspectdb.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import click
 
 from edgy.utils.inspect import InspectDB
@@ -18,7 +16,7 @@ from edgy.utils.inspect import InspectDB
 @click.command()
 def inspect_db(
     database: str,
-    schema: Union[str, None] = None,
+    schema: str | None = None,
 ) -> None:
     """
     Inspects an existing database and generates the Edgy reflect models.

--- a/edgy/cli/operations/makemigrations.py
+++ b/edgy/cli/operations/makemigrations.py
@@ -2,7 +2,7 @@
 Client to interact with Edgy models and migrations.
 """
 
-from typing import Any, Union
+from typing import Any
 
 import click
 
@@ -46,7 +46,7 @@ def makemigrations(
     version_path: str,
     rev_id: str,
     arg: Any,
-    null_field: Union[list[str], tuple[str, ...]],
+    null_field: list[str] | tuple[str, ...],
 ) -> None:
     """Autogenerate a new revision file (Alias for 'revision --autogenerate')"""
     _migrate(

--- a/edgy/cli/operations/revision.py
+++ b/edgy/cli/operations/revision.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any
 
 import click
 
@@ -51,7 +51,7 @@ def revision(
     version_path: str,
     rev_id: str,
     arg: Any,
-    null_field: Union[list[str], tuple[str, ...]],
+    null_field: list[str] | tuple[str, ...],
 ) -> None:
     """Create a new revision file."""
     _revision(

--- a/edgy/cli/operations/shell/base.py
+++ b/edgy/cli/operations/shell/base.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import select
 import sys
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -75,9 +75,9 @@ async def run_shell(app: Any, lifespan: Any, registry: Registry, kernel: str) ->
 
 
 def handle_lifespan_events(
-    on_startup: Optional[Sequence[Callable]] = None,
-    on_shutdown: Optional[Sequence[Callable]] = None,
-    lifespan: Optional[Any] = None,
+    on_startup: Sequence[Callable] | None = None,
+    on_shutdown: Sequence[Callable] | None = None,
+    lifespan: Any | None = None,
 ) -> Any:
     """Handles with the lifespan events in the new Starlette format of lifespan.
     This adds a mask that keeps the old `on_startup` and `on_shutdown` events variable

--- a/edgy/cli/templates/default/env.py
+++ b/edgy/cli/templates/default/env.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections.abc import Generator
 from logging.config import fileConfig
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from alembic import context
 from rich.console import Console
@@ -33,8 +33,8 @@ MAIN_DATABASE_NAME: str = " "
 def iter_databases(
     registry: Registry,
 ) -> Generator[tuple[str, Database, "sqlalchemy.MetaData"], None, None]:
-    url: Optional[str] = os.environ.get("EDGY_DATABASE_URL")
-    name: Union[str, Literal[False], None] = os.environ.get("EDGY_DATABASE") or False
+    url: str | None = os.environ.get("EDGY_DATABASE_URL")
+    name: str | Literal[False] | None = os.environ.get("EDGY_DATABASE") or False
     if url and not name:
         try:
             name = registry.metadata_by_url.get_name(url)

--- a/edgy/cli/templates/plain/env.py
+++ b/edgy/cli/templates/plain/env.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections.abc import Generator
 from logging.config import fileConfig
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from alembic import context
 from rich.console import Console
@@ -33,8 +33,8 @@ MAIN_DATABASE_NAME: str = " "
 def iter_databases(
     registry: Registry,
 ) -> Generator[tuple[str, Database, "sqlalchemy.MetaData"], None, None]:
-    url: Optional[str] = os.environ.get("EDGY_DATABASE_URL")
-    name: Union[str, Literal[False], None] = os.environ.get("EDGY_DATABASE") or False
+    url: str | None = os.environ.get("EDGY_DATABASE_URL")
+    name: str | Literal[False] | None = os.environ.get("EDGY_DATABASE") or False
     if url and not name:
         try:
             name = registry.metadata_by_url.get_name(url)

--- a/edgy/cli/templates/sequencial/env.py
+++ b/edgy/cli/templates/sequencial/env.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections.abc import Generator
 from logging.config import fileConfig
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from alembic import context
 from migrations.generator import create_migration_filename  # type: ignore
@@ -34,8 +34,8 @@ MAIN_DATABASE_NAME: str = " "
 def iter_databases(
     registry: Registry,
 ) -> Generator[tuple[str, Database, "sqlalchemy.MetaData"], None, None]:
-    url: Optional[str] = os.environ.get("EDGY_DATABASE_URL")
-    name: Union[str, Literal[False], None] = os.environ.get("EDGY_DATABASE") or False
+    url: str | None = os.environ.get("EDGY_DATABASE_URL")
+    name: str | Literal[False] | None = os.environ.get("EDGY_DATABASE") or False
     if url and not name:
         try:
             name = registry.metadata_by_url.get_name(url)

--- a/edgy/cli/templates/sequencial/generator.py
+++ b/edgy/cli/templates/sequencial/generator.py
@@ -1,6 +1,5 @@
 import os
 import re
-from typing import Union
 
 MIGRATIONS_DIR = "migrations/versions"
 FILENAME_PATTERN = re.compile(r"(\d{4})_(.*)\.py")
@@ -38,7 +37,7 @@ def get_sequencial_revision_number() -> str:
     return f"{next_number:04d}"
 
 
-def create_migration_filename(slug: Union[str, None] = None, with_extension: bool = False) -> str:
+def create_migration_filename(slug: str | None = None, with_extension: bool = False) -> str:
     """
     Generates a migration filename based on the next migration number and a given slug.
     Args:

--- a/edgy/cli/templates/url/env.py
+++ b/edgy/cli/templates/url/env.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections.abc import Generator
 from logging.config import fileConfig
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from alembic import context
 from rich.console import Console
@@ -33,8 +33,8 @@ MAIN_DATABASE_NAME: str = " "
 def iter_databases(
     registry: Registry,
 ) -> Generator[tuple[str, Database, "sqlalchemy.MetaData"], None, None]:
-    url: Optional[str] = os.environ.get("EDGY_DATABASE_URL")
-    name: Union[str, Literal[False], None] = os.environ.get("EDGY_DATABASE") or False
+    url: str | None = os.environ.get("EDGY_DATABASE_URL")
+    name: str | Literal[False] | None = os.environ.get("EDGY_DATABASE") or False
     if url and not name:
         try:
             name = registry.metadata_by_url.get_name(url)

--- a/edgy/conf/global_settings.py
+++ b/edgy/conf/global_settings.py
@@ -4,7 +4,6 @@ import os
 import re
 from functools import cached_property
 from pathlib import Path
-from typing import Union
 
 from monkay import ExtensionProtocol
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -17,12 +16,12 @@ class MediaSettings(BaseSettings):
     All settings related to media and media root.
     """
 
-    file_upload_temp_dir: Union[str, None] = None
-    file_upload_permissions: Union[int, None] = 0o644
-    file_upload_directory_permissions: Union[int, None] = None
+    file_upload_temp_dir: str | None = None
+    file_upload_permissions: int | None = 0o644
+    file_upload_directory_permissions: int | None = None
 
     # Don't allow overwriting the project files by default, set to media
-    media_root: Union[str, os.PathLike] = Path("media/")
+    media_root: str | os.PathLike = Path("media/")
     media_url: str = ""
 
     # Storage defaults
@@ -35,10 +34,10 @@ class MediaSettings(BaseSettings):
 
 class MigrationSettings(BaseSettings):
     allow_automigrations: bool = True
-    multi_schema: Union[bool, re.Pattern, str] = False
-    ignore_schema_pattern: Union[None, re.Pattern, str] = "information_schema"
-    migrate_databases: Union[list[Union[str, None]], tuple[Union[str, None], ...]] = (None,)
-    migration_directory: Union[str, os.PathLike] = Path("migrations/")
+    multi_schema: bool | re.Pattern | str = False
+    ignore_schema_pattern: None | re.Pattern | str = "information_schema"
+    migrate_databases: list[str | None] | tuple[str | None, ...] = (None,)
+    migration_directory: str | os.PathLike = Path("migrations/")
 
     # Extra keyword arguments to pass to alembic
     alembic_ctx_kwargs: dict = {
@@ -50,9 +49,9 @@ class MigrationSettings(BaseSettings):
 class EdgySettings(MediaSettings, MigrationSettings):
     model_config = SettingsConfigDict(extra="allow", ignored_types=(cached_property,))
     allow_auto_compute_server_defaults: bool = True
-    preloads: Union[list[str], tuple[str, ...]] = ()
-    extensions: Union[list[ExtensionProtocol], tuple[ExtensionProtocol, ...]] = ()
-    ipython_args: Union[list[str], tuple[str, ...]] = ("--no-banner",)
+    preloads: list[str] | tuple[str, ...] = ()
+    extensions: list[ExtensionProtocol] | tuple[ExtensionProtocol, ...] = ()
+    ipython_args: list[str] | tuple[str, ...] = ("--no-banner",)
     ptpython_config_file: str = "~/.config/ptpython/config.py"
 
     @cached_property

--- a/edgy/contrib/admin/config.py
+++ b/edgy/contrib/admin/config.py
@@ -1,5 +1,4 @@
 import os
-from typing import Union
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -13,4 +12,4 @@ class AdminConfig(BaseSettings):
     favicon: str = "https://raw.githubusercontent.com/dymmond/edgy/refs/heads/main/docs/statics/images/favicon.ico"
     sidebar_bg_colour: str = "#1C4C74"
     dashboard_title: str = "Edgy Admin Dashboard"
-    SECRET_KEY: Union[str, bytes] = Field(default_factory=lambda: os.urandom(64))
+    SECRET_KEY: str | bytes = Field(default_factory=lambda: os.urandom(64))

--- a/edgy/contrib/admin/views.py
+++ b/edgy/contrib/admin/views.py
@@ -382,7 +382,7 @@ class ModelObjectDetailView(BaseObjectView, AdminMixin, TemplateController):
         m2m_values = {
             name: await getattr(instance, name).all()
             for name in model.meta.relationship_fields
-            if isinstance(model.meta.fields[name], (BaseManyToManyForeignKeyField, RelatedField))
+            if isinstance(model.meta.fields[name], BaseManyToManyForeignKeyField | RelatedField)
         }
 
         for field in model.meta.relationship_fields:

--- a/edgy/contrib/autoreflection/metaclasses.py
+++ b/edgy/contrib/autoreflection/metaclasses.py
@@ -1,10 +1,8 @@
 import re
+from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
-    Optional,
-    Union,
     cast,
 )
 
@@ -17,10 +15,10 @@ if TYPE_CHECKING:
 class AutoReflectionMetaInfo(MetaInfo):
     __slots__ = ("include_pattern", "exclude_pattern", "template", "databases", "schemes")
     include_pattern: re.Pattern
-    exclude_pattern: Optional[re.Pattern]
+    exclude_pattern: re.Pattern | None
     template: Callable[["Table"], str]
-    databases: frozenset[Union[str, None]]
-    schemes: frozenset[Union[str, None]]
+    databases: frozenset[str | None]
+    schemes: frozenset[str | None]
 
     def __init__(self, meta: Any = None, **kwargs: Any) -> None:
         self.include_pattern = getattr(meta, "include_pattern", None)

--- a/edgy/contrib/contenttypes/fields.py
+++ b/edgy/contrib/contenttypes/fields.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic.json_schema import WithJsonSchema
 
@@ -33,7 +33,7 @@ class BaseContentTypeField(BaseForeignKeyField):
         if value is None or (isinstance(value, dict) and not value):
             value = original_value
         # e.g. default was a Model
-        if isinstance(value, (target, target.proxy_model)):
+        if isinstance(value, target | target.proxy_model):
             value.name = self.owner.__name__
             value.schema_name = instance.get_active_instance_schema()
         return await super().pre_save_callback(value, original_value, is_update=is_update)
@@ -68,7 +68,7 @@ class ContentTypeField(ForeignKey):
 
     def __new__(  # type: ignore
         cls,
-        to: Union[type["BaseModelType"], str] = "ContentType",
+        to: type["BaseModelType"] | str = "ContentType",
         on_delete: str = CASCADE,
         no_constraint: bool = False,
         remove_referenced: bool = True,

--- a/edgy/contrib/contenttypes/models.py
+++ b/edgy/contrib/contenttypes/models.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, Union, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 import edgy
 
@@ -32,7 +32,7 @@ class ContentType(edgy.Model, metaclass=ContentTypeMeta):
         )
 
     async def raw_delete(
-        self, *, skip_post_delete_hooks: bool, remove_referenced_call: Union[bool, str]
+        self, *, skip_post_delete_hooks: bool, remove_referenced_call: bool | str
     ) -> None:
         await super().raw_delete(
             skip_post_delete_hooks=skip_post_delete_hooks,

--- a/edgy/contrib/multi_tenancy/metaclasses.py
+++ b/edgy/contrib/multi_tenancy/metaclasses.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from edgy.core.db.models.metaclasses import BaseModelMeta, MetaInfo, get_model_meta_attr
 
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 def _check_model_inherited_tenancy(bases: tuple[type, ...]) -> bool:
     for base in bases:
-        meta: Optional[MetaInfo] = getattr(base, "meta", None)
+        meta: MetaInfo | None = getattr(base, "meta", None)
         if meta is None:
             continue
         if hasattr(meta, "is_tenant"):
@@ -19,7 +19,7 @@ def _check_model_inherited_tenancy(bases: tuple[type, ...]) -> bool:
 
 class TenantMeta(MetaInfo):
     __slots__ = ("is_tenant", "register_default")
-    register_default: Optional[bool]
+    register_default: bool | None
 
     def __init__(self, meta: Any = None, **kwargs: Any) -> None:
         self.is_tenant = getattr(meta, "is_tenant", None)
@@ -48,11 +48,11 @@ class BaseTenantMeta(BaseModelMeta):
         bases: tuple[type, ...],
         attrs: Any,
         on_conflict: Literal["error", "replace", "keep"] = "error",
-        skip_registry: Union[bool, Literal["allow_search"]] = False,
+        skip_registry: bool | Literal["allow_search"] = False,
         meta_info_class: type[TenantMeta] = TenantMeta,
         **kwargs: Any,
     ) -> Any:
-        database: Union[Literal["keep"], None, Database, bool] = attrs.get("database", "keep")
+        database: Literal["keep"] | None | Database | bool = attrs.get("database", "keep")
         new_model = super().__new__(
             cls,
             name,

--- a/edgy/contrib/multi_tenancy/models.py
+++ b/edgy/contrib/multi_tenancy/models.py
@@ -1,7 +1,7 @@
 import uuid
 import warnings
 from datetime import date
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 from uuid import UUID
 
 from loguru import logger
@@ -49,8 +49,8 @@ class TenantMixin(edgy.Model):
     async def real_save(
         self,
         force_insert: bool = False,
-        values: Union[dict[str, Any], set[str], None] = None,
-        force_save: Optional[bool] = None,
+        values: dict[str, Any] | set[str] | None = None,
+        force_save: bool | None = None,
     ) -> Model:
         """
         Creates a tenant record and generates a schema in the database.
@@ -129,8 +129,8 @@ class DomainMixin(edgy.Model):
     async def real_save(
         self: Any,
         force_insert: bool = False,
-        values: Union[dict[str, Any], set[str], None] = None,
-        force_save: Optional[bool] = None,
+        values: dict[str, Any] | set[str] | None = None,
+        force_save: bool | None = None,
     ) -> Model:
         if force_save is not None:
             force_insert = force_save
@@ -180,7 +180,7 @@ class TenantUserMixin(edgy.Model):
         abstract = True
 
     @classmethod
-    async def get_active_user_tenant(cls, user: edgy.Model) -> Union[edgy.Model, None]:
+    async def get_active_user_tenant(cls, user: edgy.Model) -> edgy.Model | None:
         """
         Obtains the active user tenant.
         """

--- a/edgy/contrib/multi_tenancy/settings.py
+++ b/edgy/contrib/multi_tenancy/settings.py
@@ -1,6 +1,6 @@
 import os
 from functools import cached_property
-from typing import Any, Optional
+from typing import Any
 
 from pydantic_settings import SettingsConfigDict
 
@@ -16,7 +16,7 @@ class TenancySettings(EdgySettings):
     auto_create_schema: bool = True
     auto_drop_schema: bool = False
     tenant_schema_default: str = "public"
-    tenant_model: Optional[str] = None
+    tenant_model: str | None = None
     domain: Any = os.getenv("DOMAIN")
     domain_name: str = "localhost"
-    auth_user_model: Optional[str] = None
+    auth_user_model: str | None = None

--- a/edgy/contrib/pagination/base.py
+++ b/edgy/contrib/pagination/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import AsyncGenerator, Hashable, Iterable
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -23,8 +23,8 @@ class BasePage(BaseModel):
 
 class Page(BasePage):
     current_page: int = 1
-    next_page: Optional[int]
-    previous_page: Optional[int]
+    next_page: int | None
+    previous_page: int | None
 
 
 PageType = TypeVar("PageType", bound=BasePage)
@@ -40,7 +40,7 @@ class BasePaginator(Generic[PageType]):
         next_item_attr: str = "",
         previous_item_attr: str = "",
     ) -> None:
-        self._reverse_paginator: Optional[Self] = None
+        self._reverse_paginator: Self | None = None
         self.page_size = int(page_size)
         if page_size < 0:
             raise ValueError("page_size must be at least 0")

--- a/edgy/contrib/permissions/models.py
+++ b/edgy/contrib/permissions/models.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 import edgy
 
@@ -8,7 +8,7 @@ from .managers import PermissionManager
 class BasePermission(edgy.Model):
     users_field_group: ClassVar[str] = "users"
     name: str = edgy.fields.CharField(max_length=100, null=False)
-    description: Optional[str] = edgy.fields.ComputedField(  # type: ignore
+    description: str | None = edgy.fields.ComputedField(  # type: ignore
         getter="get_description",
         setter="set_description",
         fallback_getter=lambda field, instance, owner: instance.name,

--- a/edgy/core/connection/asgi.py
+++ b/edgy/core/connection/asgi.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from edgy.core.connection.registry import Registry

--- a/edgy/core/connection/schemas.py
+++ b/edgy/core/connection/schemas.py
@@ -1,7 +1,7 @@
 import asyncio
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import sqlalchemy
 from sqlalchemy.exc import DBAPIError, ProgrammingError
@@ -21,7 +21,7 @@ class Schema:
     All the operations regarding a schema are placed in one object
     """
 
-    _default_schema: Optional[str]
+    _default_schema: str | None
 
     def __init__(self, registry: "Registry") -> None:
         self.registry = registry
@@ -30,7 +30,7 @@ class Schema:
     def database(self) -> "Database":
         return self.registry.database
 
-    def get_default_schema(self) -> Optional[str]:
+    def get_default_schema(self) -> str | None:
         """
         Returns the default schema which is usually None
         """
@@ -63,7 +63,7 @@ class Schema:
         init_models: bool = False,
         init_tenant_models: bool = False,
         update_cache: bool = True,
-        databases: Sequence[Union[str, None]] = (None,),
+        databases: Sequence[str | None] = (None,),
     ) -> None:
         """
         Creates a model schema if it does not exist.
@@ -83,7 +83,7 @@ class Schema:
             for model_class in self.registry.tenant_models.values():
                 model_class.add_global_field_constraints(schema=schema)
 
-        def execute_create(connection: sqlalchemy.Connection, name: Optional[str]) -> None:
+        def execute_create(connection: sqlalchemy.Connection, name: str | None) -> None:
             try:
                 connection.execute(
                     sqlalchemy.schema.CreateSchema(name=schema, if_not_exists=if_not_exists)
@@ -117,7 +117,7 @@ class Schema:
         schema: str,
         cascade: bool = False,
         if_exists: bool = False,
-        databases: Sequence[Union[str, None]] = (None,),
+        databases: Sequence[str | None] = (None,),
     ) -> None:
         """
         Drops an existing model schema.
@@ -174,8 +174,8 @@ class Schema:
 
     async def get_schemes_tree(
         self, *, no_reflect: bool = False
-    ) -> dict[Union[str, None], tuple[str, sqlalchemy.MetaData, list[str]]]:
-        schemes_tree: dict[Union[str, None], tuple[str, sqlalchemy.MetaData, list[str]]] = {
+    ) -> dict[str | None, tuple[str, sqlalchemy.MetaData, list[str]]]:
+        schemes_tree: dict[str | None, tuple[str, sqlalchemy.MetaData, list[str]]] = {
             None: (
                 str(self.database.url),
                 *(

--- a/edgy/core/datastructures.py
+++ b/edgy/core/datastructures.py
@@ -18,7 +18,7 @@ class HashableBaseModel(BaseModel):
         values: Any = {}
         for key, value in self.__dict__.items():
             values[key] = None
-            if isinstance(value, (list, set)):
+            if isinstance(value, list | set):
                 values[key] = tuple(value)
             else:
                 values[key] = value

--- a/edgy/core/db/context_vars.py
+++ b/edgy/core/db/context_vars.py
@@ -14,7 +14,7 @@ FORCE_FIELDS_NULLABLE: ContextVar[set[tuple[str, str]]] = ContextVar(
     "FORCE_FIELDS_NULLABLE", default=_empty
 )
 CURRENT_FIELD_CONTEXT: ContextVar["FIELD_CONTEXT_TYPE"] = ContextVar("CURRENT_FIELD_CONTEXT")
-CURRENT_INSTANCE: ContextVar[Optional[Union["BaseModelType", "QuerySet"]]] = ContextVar(
+CURRENT_INSTANCE: ContextVar[Union["BaseModelType", "QuerySet"] | None] = ContextVar(
     "CURRENT_INSTANCE", default=None
 )
 CURRENT_MODEL_INSTANCE: ContextVar[Optional["BaseModelType"]] = ContextVar(
@@ -24,7 +24,7 @@ CURRENT_PHASE: ContextVar[str] = ContextVar("CURRENT_PHASE", default="")
 NO_GLOBAL_FIELD_CONSTRAINTS: ContextVar[bool] = ContextVar(
     "NO_GLOBAL_FIELD_CONSTRAINTS", default=False
 )
-EXPLICIT_SPECIFIED_VALUES: ContextVar[Optional[set[str]]] = ContextVar(
+EXPLICIT_SPECIFIED_VALUES: ContextVar[set[str] | None] = ContextVar(
     "EXPLICIT_SPECIFIED_VALUES", default=None
 )
 MODEL_GETATTR_BEHAVIOR: ContextVar[Literal["passdown", "load", "coro"]] = ContextVar(
@@ -36,14 +36,14 @@ SCHEMA: ContextVar[str] = ContextVar("SCHEMA", default=None)
 SHEMA = SCHEMA
 
 
-def get_tenant() -> Union[str, None]:
+def get_tenant() -> str | None:
     """
     Gets the current active tenant in the context.
     """
     return TENANT.get()
 
 
-def set_tenant(value: Union[str, None]) -> Token:
+def set_tenant(value: str | None) -> Token:
     """
     Sets the global tenant for the context of the queries.
     When a global tenant is set the `get_schema` -> `SCHEMA` is ignored.
@@ -59,7 +59,7 @@ def set_tenant(value: Union[str, None]) -> Token:
 
 
 @contextmanager
-def with_tenant(tenant: Union[str, None]) -> Generator[None, None, None]:
+def with_tenant(tenant: str | None) -> Generator[None, None, None]:
     """
     Sets the global tenant for the context of the queries.
     When a global tenant is set the `get_schema` -> `SCHEMA` is ignored.
@@ -75,7 +75,7 @@ def with_tenant(tenant: Union[str, None]) -> Generator[None, None, None]:
         TENANT.reset(token)
 
 
-def _process_force_field_nullable(item: Union[str, tuple[str, str]]) -> tuple[str, str]:
+def _process_force_field_nullable(item: str | tuple[str, str]) -> tuple[str, str]:
     result = item if isinstance(item, tuple) else tuple(item.split(":"))
     assert isinstance(result, tuple) and len(result) == 2
     assert isinstance(result[0], str)
@@ -85,7 +85,7 @@ def _process_force_field_nullable(item: Union[str, tuple[str, str]]) -> tuple[st
 
 @contextmanager
 def with_force_fields_nullable(
-    inp: Iterable[Union[str, tuple[str, str]]],
+    inp: Iterable[str | tuple[str, str]],
 ) -> Generator[None, None, None]:
     token = FORCE_FIELDS_NULLABLE.set({_process_force_field_nullable(item) for item in inp})
     try:
@@ -94,7 +94,7 @@ def with_force_fields_nullable(
         FORCE_FIELDS_NULLABLE.reset(token)
 
 
-def get_schema(check_tenant: bool = True) -> Union[str, None]:
+def get_schema(check_tenant: bool = True) -> str | None:
     if check_tenant:
         tenant = get_tenant()
         if tenant is not None:
@@ -102,14 +102,14 @@ def get_schema(check_tenant: bool = True) -> Union[str, None]:
     return SCHEMA.get()
 
 
-def set_schema(value: Union[str, None]) -> Token:
+def set_schema(value: str | None) -> Token:
     """Set the schema and return the token for resetting. Manual way of with_schema."""
 
     return SCHEMA.set(value)
 
 
 @contextmanager
-def with_schema(schema: Union[str, None]) -> Generator[None, None, None]:
+def with_schema(schema: str | None) -> Generator[None, None, None]:
     token = SCHEMA.set(schema)
     try:
         yield

--- a/edgy/core/db/fields/_internal.py
+++ b/edgy/core/db/fields/_internal.py
@@ -21,6 +21,6 @@ class IPAddress(sqlalchemy.TypeDecorator):
     def process_result_value(self, value: Any, dialect: Any) -> Any:
         if value is None:
             return value
-        if not isinstance(value, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+        if not isinstance(value, ipaddress.IPv4Address | ipaddress.IPv6Address):
             value = ipaddress.ip_address(value)
         return value

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -8,7 +8,6 @@ from typing import (
     Any,
     Literal,
     Optional,
-    Union,
     cast,
 )
 
@@ -53,7 +52,7 @@ class BaseField(BaseFieldType, FieldInfo):
         "lte": "__le__",
         "le": "__le__",
     }
-    auto_compute_server_default: Union[bool, None, Literal["ignore_null"]] = False
+    auto_compute_server_default: bool | None | Literal["ignore_null"] = False
 
     def __init__(
         self,
@@ -195,7 +194,7 @@ class BaseField(BaseFieldType, FieldInfo):
         self,
         prefix: str,
         new_fieldname: str,
-        owner: Optional[type["BaseModelType"]] = None,
+        owner: type["BaseModelType"] | None = None,
         parent: Optional["BaseFieldType"] = None,
     ) -> Optional["BaseField"]:
         """
@@ -238,7 +237,7 @@ class Field(BaseField):
     """
 
     # safe here as we have only one column
-    auto_compute_server_default: Union[bool, None, Literal["ignore_null"]] = None
+    auto_compute_server_default: bool | None | Literal["ignore_null"] = None
 
     def check(self, value: Any) -> Any:
         """
@@ -252,7 +251,7 @@ class Field(BaseField):
         """
         return {name: self.check(value)}
 
-    def get_column(self, name: str) -> Optional[sqlalchemy.Column]:
+    def get_column(self, name: str) -> sqlalchemy.Column | None:
         """
         Return a single column for the field declared. Return None for meta fields.
         """
@@ -370,7 +369,7 @@ class PKField(BaseCompositeField):
         self.metadata.append(SkipValidation())
         self.metadata.append(WithJsonSchema(mode="validation", json_schema=None))
 
-    def __get__(self, instance: "BaseModelType", owner: Any = None) -> Union[dict[str, Any], Any]:
+    def __get__(self, instance: "BaseModelType", owner: Any = None) -> dict[str, Any] | Any:
         pkcolumns = self.owner.pkcolumns
         pknames = self.owner.pknames
         assert len(pkcolumns) >= 1
@@ -406,9 +405,9 @@ class PKField(BaseCompositeField):
         self,
         prefix: str,
         new_fieldname: str,
-        owner: Optional[type["BaseModelType"]] = None,
-        parent: Optional[BaseFieldType] = None,
-    ) -> Optional[BaseFieldType]:
+        owner: type["BaseModelType"] | None = None,
+        parent: BaseFieldType | None = None,
+    ) -> BaseFieldType | None:
         return None
 
     def clean(self, field_name: str, value: Any, for_query: bool = False) -> dict[str, Any]:
@@ -419,7 +418,7 @@ class PKField(BaseCompositeField):
         if (
             len(pknames) == 1
             and not self.is_incomplete
-            and not isinstance(value, (dict, BaseModel))
+            and not isinstance(value, dict | BaseModel)
         ):
             pkname = pknames[0]
             field = self.owner.meta.fields[pkname]
@@ -457,7 +456,7 @@ class PKField(BaseCompositeField):
         if (
             len(pknames) == 1
             # we first only redirect both
-            and not isinstance(value, (dict, BaseModel))
+            and not isinstance(value, dict | BaseModel)
         ):
             field = self.owner.meta.fields[pknames[0]]
             return field.to_model(pknames[0], value)
@@ -484,7 +483,7 @@ class PKField(BaseCompositeField):
 
 class BaseForeignKey(RelationshipField):
     is_m2m: bool = False
-    related_name: Union[str, Literal[False]] = ""
+    related_name: str | Literal[False] = ""
     # name used for backward relations
     # only useful if related_name = False because otherwise it gets overwritten
     reverse_name: str = ""
@@ -536,7 +535,7 @@ class BaseForeignKey(RelationshipField):
             owner_database = self.owner.database
         return str(owner_database.url) != str(self.target.database.url)
 
-    def get_related_model_for_admin(self) -> Optional[type["BaseModelType"]]:
+    def get_related_model_for_admin(self) -> type["BaseModelType"] | None:
         if self.target.__name__ in self.target_registry.admin_models:
             return cast("type[BaseModelType]", self.target)
         return None

--- a/edgy/core/db/fields/computed_field.py
+++ b/edgy/core/db/fields/computed_field.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from edgy.core.db.fields.base import BaseField
 from edgy.core.db.fields.types import BaseFieldType
@@ -12,13 +12,13 @@ if TYPE_CHECKING:
 class ComputedField(BaseField):
     def __init__(
         self,
-        getter: Union[
-            Callable[[BaseFieldType, "BaseModelType", Optional[type["BaseModelType"]]], Any], str
-        ],
-        setter: Union[Callable[[BaseFieldType, "BaseModelType", Any], None], str, None] = None,
-        fallback_getter: Optional[
-            Callable[[BaseFieldType, "BaseModelType", Optional[type["BaseModelType"]]], Any]
-        ] = None,
+        getter: Callable[[BaseFieldType, "BaseModelType", type["BaseModelType"] | None], Any]
+        | str,
+        setter: Callable[[BaseFieldType, "BaseModelType", Any], None] | str | None = None,
+        fallback_getter: Callable[
+            [BaseFieldType, "BaseModelType", type["BaseModelType"] | None], Any
+        ]
+        | None = None,
         **kwargs: Any,
     ) -> None:
         kwargs.setdefault("exclude", True)
@@ -35,14 +35,11 @@ class ComputedField(BaseField):
     @cached_property
     def compute_getter(
         self,
-    ) -> Callable[[BaseFieldType, "BaseModelType", Optional[type["BaseModelType"]]], Any]:
+    ) -> Callable[[BaseFieldType, "BaseModelType", type["BaseModelType"] | None], Any]:
         if isinstance(self.getter, str):
             fn = cast(
-                Optional[
-                    Callable[
-                        [BaseFieldType, "BaseModelType", Optional[type["BaseModelType"]]], Any
-                    ]
-                ],
+                Callable[[BaseFieldType, "BaseModelType", type["BaseModelType"] | None], Any]
+                | None,
                 getattr(self.owner, self.getter, None),
             )
         else:
@@ -57,7 +54,7 @@ class ComputedField(BaseField):
     def compute_setter(self) -> Callable[[BaseFieldType, "BaseModelType", Any], None]:
         if isinstance(self.setter, str):
             fn = cast(
-                Optional[Callable[[BaseFieldType, "BaseModelType", Any], None]],
+                Callable[[BaseFieldType, "BaseModelType", Any], None] | None,
                 getattr(self.owner, self.setter, None),
             )
         else:

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from enum import Enum, EnumMeta
 from re import Pattern
 from secrets import compare_digest
-from typing import TYPE_CHECKING, Annotated, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Annotated, Any, Optional, cast
 
 import orjson
 import pydantic
@@ -44,9 +44,9 @@ class CharField(FieldFactory, str):
     def __new__(  # type: ignore
         cls,
         *,
-        min_length: Optional[int] = None,
-        regex: Union[str, Pattern] = None,
-        pattern: Union[str, Pattern] = None,
+        min_length: int | None = None,
+        regex: str | Pattern = None,
+        pattern: str | Pattern = None,
         **kwargs: Any,
     ) -> BaseFieldType:
         if pattern is None:
@@ -70,11 +70,11 @@ class CharField(FieldFactory, str):
 
         assert min_length is None or isinstance(min_length, int)
         assert max_length is None or isinstance(max_length, int)
-        assert pattern is None or isinstance(pattern, (str, Pattern))
+        assert pattern is None or isinstance(pattern, str | Pattern)
 
     @classmethod
     def get_column_type(cls, kwargs: dict[str, Any]) -> Any:
-        max_length: Optional[int] = kwargs.get("max_length")
+        max_length: int | None = kwargs.get("max_length")
         return (
             sqlalchemy.Text(collation=kwargs.get("collation"))
             if max_length is None
@@ -102,11 +102,11 @@ class IntegerField(FieldFactory, int):
     def __new__(  # type: ignore
         cls,
         *,
-        ge: Union[int, float, decimal.Decimal, None] = None,
-        gt: Union[int, float, decimal.Decimal, None] = None,
-        le: Union[int, float, decimal.Decimal, None] = None,
-        lt: Union[int, float, decimal.Decimal, None] = None,
-        multiple_of: Optional[int] = None,
+        ge: int | float | decimal.Decimal | None = None,
+        gt: int | float | decimal.Decimal | None = None,
+        le: int | float | decimal.Decimal | None = None,
+        lt: int | float | decimal.Decimal | None = None,
+        multiple_of: int | None = None,
         increment_on_save: int = 0,
         **kwargs: Any,
     ) -> BaseFieldType:
@@ -158,11 +158,11 @@ class FloatField(FieldFactory, float):
     def __new__(  # type: ignore
         cls,
         *,
-        max_digits: Optional[int] = None,
-        ge: Union[int, float, decimal.Decimal, None] = None,
-        gt: Union[int, float, decimal.Decimal, None] = None,
-        le: Union[int, float, decimal.Decimal, None] = None,
-        lt: Union[int, float, decimal.Decimal, None] = None,
+        max_digits: int | None = None,
+        ge: int | float | decimal.Decimal | None = None,
+        gt: int | float | decimal.Decimal | None = None,
+        le: int | float | decimal.Decimal | None = None,
+        lt: int | float | decimal.Decimal | None = None,
         **kwargs: Any,
     ) -> BaseFieldType:
         # pydantic doesn't support max_digits for float, so rename it
@@ -177,7 +177,7 @@ class FloatField(FieldFactory, float):
 
     @classmethod
     def get_column_type(cls, kwargs: dict[str, Any]) -> Any:
-        precision: Optional[int] = kwargs.get("precision")
+        precision: int | None = kwargs.get("precision")
         if precision is None:
             return sqlalchemy.Float(asdecimal=False)
         return sqlalchemy.Float(precision=precision, asdecimal=False).with_variant(
@@ -217,13 +217,13 @@ class DecimalField(FieldFactory, decimal.Decimal):
     def __new__(  # type: ignore
         cls,
         *,
-        ge: Union[int, float, decimal.Decimal, None] = None,
-        gt: Union[int, float, decimal.Decimal, None] = None,
-        le: Union[int, float, decimal.Decimal, None] = None,
-        lt: Union[int, float, decimal.Decimal, None] = None,
-        multiple_of: Union[int, decimal.Decimal, None] = None,
-        max_digits: Optional[int] = None,
-        decimal_places: Optional[int] = None,
+        ge: int | float | decimal.Decimal | None = None,
+        gt: int | float | decimal.Decimal | None = None,
+        le: int | float | decimal.Decimal | None = None,
+        lt: int | float | decimal.Decimal | None = None,
+        multiple_of: int | decimal.Decimal | None = None,
+        max_digits: int | None = None,
+        decimal_places: int | None = None,
         **kwargs: Any,
     ) -> BaseFieldType:
         kwargs = {
@@ -267,8 +267,8 @@ class DateTimeField(_AutoNowMixin, datetime.datetime):
     def __new__(  # type: ignore
         cls,
         *,
-        auto_now: Optional[bool] = False,
-        auto_now_add: Optional[bool] = False,
+        auto_now: bool | None = False,
+        auto_now_add: bool | None = False,
         default_timezone: Optional["zoneinfo.ZoneInfo"] = None,
         force_timezone: Optional["zoneinfo.ZoneInfo"] = None,
         remove_timezone: bool = False,
@@ -309,8 +309,8 @@ class DateField(_AutoNowMixin, datetime.date):
     def __new__(  # type: ignore
         cls,
         *,
-        auto_now: Optional[bool] = False,
-        auto_now_add: Optional[bool] = False,
+        auto_now: bool | None = False,
+        auto_now_add: bool | None = False,
         default_timezone: Optional["zoneinfo.ZoneInfo"] = None,
         force_timezone: Optional["zoneinfo.ZoneInfo"] = None,
         **kwargs: Any,
@@ -369,7 +369,7 @@ class JSONField(FieldFactory, pydantic.Json):  # type: ignore
     def get_default_value(cls, field_obj: BaseFieldType, original_fn: Any = None) -> Any:
         default = original_fn()
         # copy mutable structures
-        if isinstance(default, (list, dict)):
+        if isinstance(default, list | dict):
             default = copy.deepcopy(default)
         return default
 
@@ -389,7 +389,7 @@ class BinaryField(FieldFactory, bytes):
 
     field_type = bytes
 
-    def __new__(cls, *, max_length: Optional[int] = None, **kwargs: Any) -> BaseFieldType:  # type: ignore
+    def __new__(cls, *, max_length: int | None = None, **kwargs: Any) -> BaseFieldType:  # type: ignore
         kwargs = {
             **kwargs,
             **{k: v for k, v in locals().items() if k not in CLASS_DEFAULTS},
@@ -473,7 +473,7 @@ class CharChoiceField(ChoiceField):
 
     @classmethod
     def get_column_type(cls, kwargs: dict[str, Any]) -> Any:
-        max_length: Optional[int] = kwargs.get("key_max_length")
+        max_length: int | None = kwargs.get("key_max_length")
         return (
             sqlalchemy.Text(collation=kwargs.get("collation"))
             if max_length is None
@@ -521,7 +521,7 @@ class PasswordField(CharField):
 
     def __new__(  # type: ignore
         cls,
-        derive_fn: Optional[Callable[[str], str]] = None,
+        derive_fn: Callable[[str], str] | None = None,
         **kwargs: Any,
     ) -> BaseFieldType:
         kwargs.setdefault("keep_original", derive_fn is not None)
@@ -558,7 +558,7 @@ class PasswordField(CharField):
     def to_model(
         cls, field_obj: BaseFieldType, field_name: str, value: Any, original_fn: Any = None
     ) -> dict[str, Any]:
-        if isinstance(value, (tuple, list)):
+        if isinstance(value, tuple | list):
             # despite an != should not be a problem here, make sure that strange logics
             # doesn't leak timings of the password
             if not compare_digest(value[0], value[1]):
@@ -567,7 +567,7 @@ class PasswordField(CharField):
                 value = value[0]
         retval: dict[str, Any] = {}
         phase = CURRENT_PHASE.get()
-        derive_fn = cast(Optional[Callable[[str], str]], field_obj.derive_fn)
+        derive_fn = cast(Callable[[str], str] | None, field_obj.derive_fn)
         if phase in {"set", "init"} and derive_fn is not None:
             retval[field_name] = derive_fn(value)
             if getattr(field_obj, "keep_original", False):
@@ -630,7 +630,7 @@ class IPAddressField(FieldFactory, str):
 
     @staticmethod
     def is_native_type(value: str) -> bool:
-        return isinstance(value, (ipaddress.IPv4Address, ipaddress.IPv6Address))
+        return isinstance(value, ipaddress.IPv4Address | ipaddress.IPv6Address)
 
     # overwrite
     @classmethod

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from functools import lru_cache, partial
-from typing import Any, Literal, Union, cast
+from typing import Any, Literal, cast
 
 from edgy.core.db.constants import CASCADE, RESTRICT, SET_NULL
 from edgy.core.db.fields.base import Field
@@ -172,7 +172,7 @@ class ForeignKeyFieldFactory(FieldFactory):
         to: Any = None,
         on_update: str = CASCADE,
         on_delete: str = RESTRICT,
-        related_name: Union[str, Literal[False]] = "",
+        related_name: str | Literal[False] = "",
         **kwargs: Any,
     ) -> BaseFieldType:
         kwargs = {

--- a/edgy/core/db/fields/image_field.py
+++ b/edgy/core/db/fields/image_field.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from edgy.core.db.fields.file_field import FileField
 from edgy.core.files import ImageFieldFile
@@ -13,9 +13,9 @@ class ImageField(FileField):
     def __new__(  # type: ignore
         cls,
         # image formats without approval
-        image_formats: Optional[Sequence[str]] = (),
+        image_formats: Sequence[str] | None = (),
         # extra image formats after approval
-        approved_image_formats: Optional[Sequence[str]] = None,
+        approved_image_formats: Sequence[str] | None = None,
         field_file_class: type[ImageFieldFile] = ImageFieldFile,
         **kwargs: Any,
     ) -> "BaseFieldType":

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -36,9 +36,9 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         to_foreign_key: str = "",
         from_fields: Sequence[str] = (),
         from_foreign_key: str = "",
-        through: Union[str, type["BaseModelType"]] = "",
-        through_tablename: Union[str, type[OLD_M2M_NAMING], type[NEW_M2M_NAMING]],
-        embed_through: Union[str, Literal[False]] = False,
+        through: str | type["BaseModelType"] = "",
+        through_tablename: str | type[OLD_M2M_NAMING] | type[NEW_M2M_NAMING],
+        embed_through: str | Literal[False] = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -163,12 +163,10 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
     def create_through_model(
         self,
         *,
-        replace_related_field: Union[
-            bool,
-            type["BaseModelType"],
-            tuple[type["BaseModelType"], ...],
-            list[type["BaseModelType"]],
-        ] = False,
+        replace_related_field: bool
+        | type["BaseModelType"]
+        | tuple[type["BaseModelType"], ...]
+        | list[type["BaseModelType"]] = False,
     ) -> None:
         """
         Creates the default empty through model.
@@ -283,7 +281,7 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
             **meta_args,
         )
 
-        to_related_name: Union[str, Literal[False]]
+        to_related_name: str | Literal[False]
         if self.related_name is False:
             to_related_name = False
         elif self.related_name:
@@ -396,9 +394,9 @@ class ManyToManyField(ForeignKeyFieldFactory, list):
         to_foreign_key: str = "",
         from_fields: Sequence[str] = (),
         from_foreign_key: str = "",
-        through: Union[str, type["BaseModelType"], type["Model"]] = "",
-        through_tablename: Union[str, type[OLD_M2M_NAMING], type[NEW_M2M_NAMING]] = "",
-        embed_through: Union[str, Literal[False]] = False,
+        through: str | type["BaseModelType"] | type["Model"] = "",
+        through_tablename: str | type[OLD_M2M_NAMING] | type[NEW_M2M_NAMING] = "",
+        embed_through: str | Literal[False] = False,
         **kwargs: Any,
     ) -> "BaseFieldType":
         kwargs = {
@@ -434,7 +432,7 @@ class ManyToManyField(ForeignKeyFieldFactory, list):
         kwargs["exclude"] = True
         kwargs["on_delete"] = CASCADE
         kwargs["on_update"] = CASCADE
-        through_tablename: Union[str, type[OLD_M2M_NAMING], type[NEW_M2M_NAMING]] = kwargs.get(
+        through_tablename: str | type[OLD_M2M_NAMING] | type[NEW_M2M_NAMING] = kwargs.get(
             "through_tablename"
         )
         if not through_tablename or (

--- a/edgy/core/db/fields/mixins.py
+++ b/edgy/core/db/fields/mixins.py
@@ -1,6 +1,6 @@
 import datetime
 from functools import partial
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from edgy.core.db.context_vars import (
     CURRENT_FIELD_CONTEXT,
@@ -83,9 +83,7 @@ class TimezonedField:
     force_timezone: Optional["zoneinfo.ZoneInfo"]
     remove_timezone: bool
 
-    def _convert_datetime(
-        self, value: datetime.datetime
-    ) -> Union[datetime.datetime, datetime.date]:
+    def _convert_datetime(self, value: datetime.datetime) -> datetime.datetime | datetime.date:
         if value.tzinfo is None and self.default_timezone is not None:
             value = value.replace(tzinfo=self.default_timezone)
         if self.force_timezone is not None and value.tzinfo != self.force_timezone:
@@ -99,12 +97,12 @@ class TimezonedField:
             return value.date()
         return value
 
-    def check(self, value: Any) -> Optional[Union[datetime.datetime, datetime.date]]:
+    def check(self, value: Any) -> datetime.datetime | datetime.date | None:
         if value is None:
             return None
         elif isinstance(value, datetime.datetime):
             return self._convert_datetime(value)
-        elif isinstance(value, (int, float)):
+        elif isinstance(value, int | float):
             return self._convert_datetime(
                 datetime.datetime.fromtimestamp(value, self.default_timezone)
             )
@@ -126,7 +124,7 @@ class TimezonedField:
         self,
         field_name: str,
         value: Any,
-    ) -> dict[str, Optional[Union[datetime.datetime, datetime.date]]]:
+    ) -> dict[str, datetime.datetime | datetime.date | None]:
         """
         Convert input object to datetime
         """
@@ -140,8 +138,8 @@ class AutoNowMixin(FieldFactory):
     def __new__(  # type: ignore
         cls,
         *,
-        auto_now: Optional[bool] = False,
-        auto_now_add: Optional[bool] = False,
+        auto_now: bool | None = False,
+        auto_now_add: bool | None = False,
         default_timezone: Optional["zoneinfo.ZoneInfo"] = None,
         **kwargs: Any,
     ) -> BaseFieldType:

--- a/edgy/core/db/fields/one_to_one_keys.py
+++ b/edgy/core/db/fields/one_to_one_keys.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from edgy.core.db.fields.foreign_keys import ForeignKey
 from edgy.core.terminal import Print
@@ -20,7 +20,7 @@ class OneToOneField(ForeignKey):
 
     def __new__(  # type: ignore
         cls,
-        to: Union[type[BaseModelType], str],
+        to: type[BaseModelType] | str,
         **kwargs: Any,
     ) -> BaseFieldType:
         for argument in ["index", "unique"]:

--- a/edgy/core/db/fields/ref_foreign_key.py
+++ b/edgy/core/db/fields/ref_foreign_key.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import edgy
 from edgy.core.db.context_vars import CURRENT_MODEL_INSTANCE, CURRENT_PHASE
@@ -37,7 +37,7 @@ class RefForeignKey(ForeignKeyFieldFactory, list):
         self,
         prefix: str,
         new_fieldname: str,
-        owner: Optional[type["BaseModelType"]] = None,
+        owner: type["BaseModelType"] | None = None,
         parent: Optional["BaseFieldType"] = None,
     ) -> Optional["BaseFieldType"]:
         return None
@@ -58,7 +58,7 @@ class RefForeignKey(ForeignKeyFieldFactory, list):
     async def post_save_callback(
         cls,
         field_obj: "BaseFieldType",
-        value: Optional[list],
+        value: list | None,
         is_update: bool,
         original_fn: Any = None,
     ) -> None:
@@ -80,7 +80,7 @@ class RefForeignKey(ForeignKeyFieldFactory, list):
             extra_params[relation_field.foreign_key.name] = instance
         relation = getattr(instance, model_ref.__related_name__)
         while value:
-            instance_or_dict: Union[dict, ModelRef] = value.pop()
+            instance_or_dict: dict | ModelRef = value.pop()
             if isinstance(instance_or_dict, dict):
                 instance_or_dict = model_ref(**instance_or_dict)
             model = target_model_class(

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import sqlalchemy
 from pydantic import BaseModel, Field
@@ -30,26 +30,26 @@ class _ColumnDefinition:
     autoincrement: bool = False
     index: bool = False
     unique: bool = False
-    comment: Optional[str] = None
+    comment: str | None = None
     # keep any, so multi-column field authors can set a dict
-    server_onupdate: Optional[Any] = None
+    server_onupdate: Any | None = None
 
 
 # for preventing shadowing warnings
 class ColumnDefinition(_ColumnDefinition):
     null: bool = False
-    column_name: Optional[str] = None
+    column_name: str | None = None
     column_type: Any = None
     constraints: Sequence[sqlalchemy.Constraint] = ()
     # keep any, so multi-column field authors can set a dict
-    server_default: Optional[Any] = Undefined
+    server_default: Any | None = Undefined
 
 
 class ColumnDefinitionModel(
     _ColumnDefinition, BaseModel, extra="ignore", arbitrary_types_allowed=True
 ):
     # no default and null extraction, edgy uses a custom logic
-    column_name: Optional[str] = Field(exclude=True, default=None)
+    column_name: str | None = Field(exclude=True, default=None)
     column_type: Any = Field(exclude=True, default=None)
     constraints: Sequence[sqlalchemy.Constraint] = Field(exclude=True, default=())
 
@@ -62,7 +62,7 @@ class BaseFieldDefinitions:
     skip_absorption_check: bool = False
     skip_reflection_type_check: bool = False
     field_type: Any = Any
-    factory: Optional[FieldFactory] = None
+    factory: FieldFactory | None = None
 
     __original_type__: Any = None
     name: str = ""
@@ -142,7 +142,7 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         name: str,
         columns: Sequence[sqlalchemy.Column],
         schemes: Sequence[str] = (),
-    ) -> Sequence[Union[sqlalchemy.Constraint, sqlalchemy.Index]]:
+    ) -> Sequence[sqlalchemy.Constraint | sqlalchemy.Index]:
         """Return global constraints and indexes.
         Useful for multicolumn fields
         """
@@ -180,9 +180,9 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
         self,
         prefix: str,
         new_fieldname: str,
-        owner: Optional[BaseModelType] = None,
-        parent: Optional[BaseFieldType] = None,
-    ) -> Optional[BaseFieldType]:
+        owner: BaseModelType | None = None,
+        parent: BaseFieldType | None = None,
+    ) -> BaseFieldType | None:
         """
         Embed this field or return None to prevent embedding.
         Must return a copy with name and owner set when not returning None.

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -10,8 +10,6 @@ from typing import (
     Any,
     ClassVar,
     Literal,
-    Optional,
-    Union,
     cast,
 )
 
@@ -67,10 +65,10 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         }
     )
     _edgy_namespace: dict = PrivateAttr()
-    __proxy_model__: ClassVar[Union[type[Model], None]] = None
+    __proxy_model__: ClassVar[type[Model] | None] = None
     __reflected__: ClassVar[bool] = False
     __show_pk__: ClassVar[bool] = False
-    __using_schema__: ClassVar[Union[str, None, Any]] = Undefined
+    __using_schema__: ClassVar[str | None | Any] = Undefined
     __deletion_with_signals__: ClassVar[bool] = False
     __no_load_trigger_attrs__: ClassVar[set[str]] = _empty
     database: ClassVar[Database] = None
@@ -83,7 +81,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
     def __init__(
         self,
         *args: Any,
-        __show_pk__: Optional[bool] = None,
+        __show_pk__: bool | None = None,
         __phase__: str = "init",
         __drop_extra_kwargs__: bool = False,
         **kwargs: Any,
@@ -172,7 +170,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         cls,
         kwargs: dict[str, Any],
         phase: str = "",
-        instance: Optional[BaseModelType] = None,
+        instance: BaseModelType | None = None,
         drop_extra_kwargs: bool = False,
     ) -> Any:
         """
@@ -245,7 +243,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         self,
         only_needed: bool = False,
         only_needed_nest: bool = False,
-        _seen: Optional[set[Any]] = None,
+        _seen: set[Any] | None = None,
     ) -> None:
         if _seen is None:
             _seen = {self.create_model_key()}
@@ -286,7 +284,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         )
         return self.meta.fields
 
-    def model_dump(self, show_pk: Union[bool, None] = None, **kwargs: Any) -> dict[str, Any]:
+    def model_dump(self, show_pk: bool | None = None, **kwargs: Any) -> dict[str, Any]:
         """
         An updated version of the model dump.
         It can show the pk always and handles the exclude attribute on fields correctly and
@@ -296,7 +294,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
             show_pk: bool - Enforces showing the primary key in the model_dump.
         """
         # we want a copy
-        _exclude: Union[set[str], dict[str, Any], None] = kwargs.pop("exclude", None)
+        _exclude: set[str] | dict[str, Any] | None = kwargs.pop("exclude", None)
         if _exclude is None:
             initial_full_field_exclude: set[str] = _empty
             # must be a writable dict
@@ -328,8 +326,8 @@ class EdgyBaseModel(BaseModel, BaseModelType):
             if field.target.meta.needs_special_serialization:
                 exclude_passed[field_name] = True
                 need_second_pass.add(field_name)
-        include: Union[set[str], dict[str, Any], None] = kwargs.pop("include", None)
-        mode: Union[Literal["json", "python"], str] = kwargs.pop("mode", "python")
+        include: set[str] | dict[str, Any] | None = kwargs.pop("include", None)
+        mode: Literal["json", "python"] | str = kwargs.pop("mode", "python")
 
         should_show_pk = self.__show_pk__ if show_pk is None else show_pk
         model = super().model_dump(exclude=exclude_passed, include=include, mode=mode, **kwargs)
@@ -444,8 +442,8 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         is_update: bool = False,
         is_partial: bool = False,
         phase: str = "",
-        instance: Optional[Union[BaseModelType, QuerySet]] = None,
-        model_instance: Optional[BaseModelType] = None,
+        instance: BaseModelType | QuerySet | None = None,
+        model_instance: BaseModelType | None = None,
         evaluate_values: bool = False,
     ) -> dict[str, Any]:
         validated: dict[str, Any] = {}

--- a/edgy/core/db/models/managers.py
+++ b/edgy/core/db/models/managers.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from edgy.core.db.querysets.base import QuerySet
 
@@ -10,10 +10,10 @@ class BaseManager:
     def __init__(
         self,
         *,
-        owner: Optional[Union[type["BaseModelType"]]] = None,
+        owner: type["BaseModelType"] | None = None,
         inherit: bool = True,
         name: str = "",
-        instance: Optional[Union["BaseModelType"]] = None,
+        instance: Union["BaseModelType"] | None = None,
     ):
         self.owner = owner
         self.inherit = inherit

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -13,8 +13,6 @@ from typing import (
     Any,
     ClassVar,
     Literal,
-    Optional,
-    Union,
     cast,
     get_origin,
 )
@@ -52,7 +50,7 @@ _seen_table_names: ContextVar[set[str]] = ContextVar("_seen_table_names", defaul
 class Fields(UserDict, dict[str, BaseFieldType]):
     """Smart wrapper which tries to prevent invalidation as far as possible"""
 
-    def __init__(self, meta: MetaInfo, data: Optional[dict[str, BaseFieldType]] = None):
+    def __init__(self, meta: MetaInfo, data: dict[str, BaseFieldType] | None = None):
         self.meta = meta
         super().__init__(data)
 
@@ -274,25 +272,25 @@ class MetaInfo:
     field_to_column_names: FieldToColumnNames
     columns_to_field: ColumnsToField
 
-    unique_together: list[Union[str, tuple, UniqueConstraint]]
+    unique_together: list[str | tuple | UniqueConstraint]
     indexes: list[Index]
     constraints: list[sqlalchemy.Constraint]
 
     def __init__(self, meta: Any = None, **kwargs: Any) -> None:
         self._fields_are_initialized = False
         self._field_stats_are_initialized = False
-        self.model: Optional[type[BaseModelType]] = None
+        self.model: type[BaseModelType] | None = None
         #  Difference between meta extraction and kwargs: meta attributes are copied
         self.abstract: bool = getattr(meta, "abstract", False)
         self.no_copy: bool = getattr(meta, "no_copy", False)
         # for embedding
         self.inherit: bool = getattr(meta, "inherit", True)
-        self.in_admin: Optional[bool] = getattr(meta, "in_admin", None)
-        self.registry: Union[Registry, Literal[False], None] = getattr(meta, "registry", None)
-        self.tablename: Optional[str] = getattr(meta, "tablename", None)
+        self.in_admin: bool | None = getattr(meta, "in_admin", None)
+        self.registry: Registry | Literal[False] | None = getattr(meta, "registry", None)
+        self.tablename: str | None = getattr(meta, "tablename", None)
         for attr in ["unique_together", "indexes", "constraints"]:
             attr_val: Any = getattr(meta, attr, [])
-            if not isinstance(attr_val, (list, tuple)):
+            if not isinstance(attr_val, list | tuple):
                 raise ImproperlyConfigured(
                     f"{attr} must be a tuple or list. Got {type(attr_val).__name__} instead."
                 )
@@ -307,8 +305,8 @@ class MetaInfo:
         self.load_dict(kwargs)
 
     @property
-    def pk(self) -> Optional[PKField]:
-        return cast(Optional[PKField], self.fields.get("pk"))
+    def pk(self) -> PKField | None:
+        return cast(PKField | None, self.fields.get("pk"))
 
     @property
     def needs_special_serialization(self) -> bool:
@@ -473,8 +471,8 @@ class MetaInfo:
 
 
 def get_model_meta_attr(
-    attr: str, bases: tuple[type, ...], meta_class: Optional[Union[object, MetaInfo]] = None
-) -> Optional[Any]:
+    attr: str, bases: tuple[type, ...], meta_class: object | MetaInfo | None = None
+) -> Any | None:
     """
     When an enabled attr is missing or None from the Meta class, it should look up for the bases
     and obtain the first found attr.
@@ -497,14 +495,14 @@ def get_model_meta_attr(
 
 
 def get_model_registry(
-    bases: tuple[type, ...], meta_class: Optional[Union[object, MetaInfo]] = None
-) -> Union[Registry, None, Literal[False]]:
+    bases: tuple[type, ...], meta_class: object | MetaInfo | None = None
+) -> Registry | None | Literal[False]:
     """
     When a registry is missing from the Meta class, it should look up for the bases
     and obtain the first found registry.
     """
     return cast(
-        "Union[Registry, None, Literal[False]]",
+        "Registry | None | Literal[False]",
         get_model_meta_attr("registry", bases=bases, meta_class=meta_class),
     )
 
@@ -544,7 +542,7 @@ _occluded_sentinel = object()
 def _extract_fields_and_managers(base: type, attrs: dict[str, Any]) -> None:
     from edgy.core.db.fields.composite_field import CompositeField
 
-    meta: Union[MetaInfo, None] = getattr(base, "meta", None)
+    meta: MetaInfo | None = getattr(base, "meta", None)
     if not meta:
         # Mixins and other classes
         # Note: from mixins BaseFields and BaseManagers are imported despite inherit=False until a model in the
@@ -610,7 +608,7 @@ def _extract_fields_and_managers(base: type, attrs: dict[str, Any]) -> None:
 
 
 def extract_fields_and_managers(
-    bases: Sequence[type], attrs: Optional[dict[str, Any]] = None
+    bases: Sequence[type], attrs: dict[str, Any] | None = None
 ) -> dict[str, Any]:
     """
     Search for fields and managers and return them.
@@ -653,7 +651,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
         bases: tuple[type, ...],
         attrs: dict[str, Any],
         meta_info_class: type[MetaInfo] = MetaInfo,
-        skip_registry: Union[bool, Literal["allow_search"]] = False,
+        skip_registry: bool | Literal["allow_search"] = False,
         on_conflict: Literal["error", "replace", "keep"] = "error",
         **kwargs: Any,
     ) -> Any:
@@ -671,7 +669,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
         attrs.pop("_pkcolumns", None)
         attrs.pop("_pknames", None)
         attrs.pop("_table", None)
-        database: Union[Literal["keep"], None, Database, bool] = attrs.pop("database", "keep")
+        database: Literal["keep"] | None | Database | bool = attrs.pop("database", "keep")
 
         # Extract fields and managers and include them in attrs
         attrs = extract_fields_and_managers(bases, attrs)
@@ -827,7 +825,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
         if meta.unique_together:
             unique_together = meta.unique_together
             for value in unique_together:
-                if not isinstance(value, (str, tuple, UniqueConstraint)):
+                if not isinstance(value, str | tuple | UniqueConstraint):
                     raise ValueError(
                         "The values inside the unique_together must be a string, a tuple of strings or an instance of UniqueConstraint."
                     )
@@ -866,7 +864,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
 
         # Now find a registry and add it to the meta.
         if meta.registry is None and skip_registry is not True:
-            registry: Union[Registry, None, Literal[False]] = get_model_registry(bases, meta_class)
+            registry: Registry | None | Literal[False] = get_model_registry(bases, meta_class)
             meta.registry = registry or None
         # don't add automatically to registry. Useful for subclasses which modify the registry itself.
         # `skip_registry="allow_search"` is trueish so it works.
@@ -877,7 +875,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
         new_class.add_to_registry(meta.registry, database=database, on_conflict=on_conflict)
         return new_class
 
-    def get_db_schema(cls) -> Union[str, None]:
+    def get_db_schema(cls) -> str | None:
         """
         Returns a db_schema from registry if any is passed.
         """
@@ -885,7 +883,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
             return cls.meta.registry.db_schema  # type: ignore
         return None
 
-    def get_db_shema(cls) -> Union[str, None]:
+    def get_db_shema(cls) -> str | None:
         warnings.warn(
             "'get_db_shema' has been deprecated, use 'get_db_schema' instead.",
             DeprecationWarning,
@@ -893,7 +891,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
         )
         return cls.get_db_schema()
 
-    def _build_table(cls, metadata: Optional[sqlalchemy.MetaData] = None) -> None:
+    def _build_table(cls, metadata: sqlalchemy.MetaData | None = None) -> None:
         try:
             cls._table = cls.build(cls.get_db_schema(), metadata=metadata)
         except AttributeError as exc:
@@ -968,9 +966,9 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
 
     def table_schema(
         cls,
-        schema: Union[str, None] = None,
+        schema: str | None = None,
         *,
-        metadata: Optional[sqlalchemy.MetaData] = None,
+        metadata: sqlalchemy.MetaData | None = None,
         update_cache: bool = False,
     ) -> sqlalchemy.Table:
         """

--- a/edgy/core/db/models/mixins/reflection.py
+++ b/edgy/core/db/models/mixins/reflection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Union, cast
 
 import sqlalchemy
 from pydantic_core._pydantic_core import SchemaValidator as SchemaValidator
@@ -28,8 +28,8 @@ class ReflectedModelMixin:
     @classmethod
     def build(
         cls,
-        schema: Optional[str] = None,
-        metadata: Optional[sqlalchemy.MetaData] = None,
+        schema: str | None = None,
+        metadata: sqlalchemy.MetaData | None = None,
     ) -> Any:
         """
         The inspect is done in an async manner and reflects the objects from the database.
@@ -71,7 +71,7 @@ class ReflectedModelMixin:
         registry: Union["Registry", "Database"],
         tablename: str,
         metadata: sqlalchemy.MetaData,
-        schema: Union[str, None] = None,
+        schema: str | None = None,
     ) -> sqlalchemy.Table:
         """
         Reflect a table from the database and return its SQLAlchemy Table object.

--- a/edgy/core/db/models/mixins/row.py
+++ b/edgy/core/db/models/mixins/row.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from edgy.core.db.fields.base import RelationshipField
 from edgy.core.db.models.utils import apply_instance_extras
@@ -41,17 +41,17 @@ class ModelRowMixin:
         row: Row,
         # contain the mappings used for select
         tables_and_models: dict[str, tuple[Table, type[BaseModelType]]],
-        select_related: Optional[Sequence[Any]] = None,
-        prefetch_related: Optional[Sequence[Prefetch]] = None,
+        select_related: Sequence[Any] | None = None,
+        prefetch_related: Sequence[Prefetch] | None = None,
         only_fields: Sequence[str] = None,
         is_defer_fields: bool = False,
         exclude_secrets: bool = False,
-        using_schema: Optional[str] = None,
-        database: Optional[Database] = None,
+        using_schema: str | None = None,
+        database: Database | None = None,
         prefix: str = "",
-        old_select_related_value: Optional[Model] = None,
-        reference_select: Optional[reference_select_type] = None,
-    ) -> Optional[Model]:
+        old_select_related_value: Model | None = None,
+        reference_select: reference_select_type | None = None,
+    ) -> Model | None:
         """
         Class method to convert a SQLAlchemy Row result into a EdgyModel row type.
 

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
     import sqlalchemy
@@ -55,7 +55,7 @@ class BaseModelType(ABC):
     Meta: ClassVar[DescriptiveMeta] = DescriptiveMeta()
     transaction: ClassVar[TransactionCallProtocol]
 
-    __parent__: ClassVar[Union[type[BaseModelType], None]] = None
+    __parent__: ClassVar[type[BaseModelType] | None] = None
     __is_proxy_model__: ClassVar[bool] = False
     __require_model_based_deletion__: ClassVar[bool] = False
     __reflected__: ClassVar[bool] = False
@@ -104,7 +104,7 @@ class BaseModelType(ABC):
     async def real_save(
         self,
         force_insert: bool = False,
-        values: Union[dict[str, Any], set[str], list[str], None] = None,
+        values: dict[str, Any] | set[str] | list[str] | None = None,
     ) -> BaseModelType:
         """Save model. For customizations used by querysets and direct calls."""
 
@@ -112,13 +112,13 @@ class BaseModelType(ABC):
     async def save(
         self,
         force_insert: bool = False,
-        values: Union[dict[str, Any], set[str], list[str], None] = None,
+        values: dict[str, Any] | set[str] | list[str] | None = None,
     ) -> BaseModelType:
         """Save model. For customizations only by direct calls."""
 
     @abstractmethod
     async def raw_delete(
-        self, *, skip_post_delete_hooks: bool, remove_referenced_call: Union[bool, str]
+        self, *, skip_post_delete_hooks: bool, remove_referenced_call: bool | str
     ) -> None:
         """
         Delete Model. Raw version called by QuerySet and delete.
@@ -145,7 +145,7 @@ class BaseModelType(ABC):
         """Load model and all models referenced by foreign keys."""
 
     @abstractmethod
-    def model_dump(self, show_pk: Union[bool, None] = None, **kwargs: Any) -> dict[str, Any]:
+    def model_dump(self, show_pk: bool | None = None, **kwargs: Any) -> dict[str, Any]:
         """
         An updated version of the model dump.
         It can show the pk always and handles the exclude attribute on fields correctly and
@@ -159,8 +159,8 @@ class BaseModelType(ABC):
     @abstractmethod
     def build(
         cls,
-        schema: Optional[str] = None,
-        metadata: Optional[sqlalchemy.MetaData] = None,
+        schema: str | None = None,
+        metadata: sqlalchemy.MetaData | None = None,
     ) -> sqlalchemy.Table:
         """
         Builds the SQLAlchemy table representation from the loaded fields.
@@ -188,8 +188,8 @@ class BaseModelType(ABC):
         extracted_values: dict[str, Any],
         is_update: bool = False,
         is_partial: bool = False,
-        instance: Optional[Union[BaseModelType, QuerySet]] = None,
-        model_instance: Optional[BaseModelType] = None,
+        instance: BaseModelType | QuerySet | None = None,
+        model_instance: BaseModelType | None = None,
         evaluate_kwarg_values: bool = False,
     ) -> dict[str, Any]:
         """
@@ -202,7 +202,7 @@ class BaseModelType(ABC):
     def get_real_class(cls) -> BaseModelType:
         return cls.__parent__ if cls.__is_proxy_model__ else cls  # type: ignore
 
-    def extract_db_fields(self, only: Optional[Sequence[str]] = None) -> dict[str, Any]:
+    def extract_db_fields(self, only: Sequence[str] | None = None) -> dict[str, Any]:
         """
         Extracts all the db fields, model references and fields.
         Related fields are not included because they are disjoint.

--- a/edgy/core/db/models/utils.py
+++ b/edgy/core/db/models/utils.py
@@ -55,7 +55,7 @@ _model_type = TypeVar("_model_type", bound="BaseModelType")
 def apply_instance_extras(
     model: _model_type,
     model_class: type["BaseModelType"],
-    schema: Optional[str] = None,
+    schema: str | None = None,
     database: Optional["Database"] = None,
     table: Optional["Table"] = None,
 ) -> _model_type:

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Generator, Iterable, Sequence
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Generator,
+    Iterable,
+    Sequence,
+)
 from contextvars import ContextVar
 from functools import cached_property
 from inspect import isawaitable
@@ -9,10 +17,7 @@ from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Literal,
-    Optional,
-    Union,
     cast,
 )
 
@@ -52,12 +57,12 @@ if TYPE_CHECKING:  # pragma: no cover
 
 _empty_set = cast(Sequence[Any], frozenset())
 # get current row during iteration. Used for prefetching.
-_current_row_holder: ContextVar[Optional[list[Optional[sqlalchemy.Row]]]] = ContextVar(
+_current_row_holder: ContextVar[list[sqlalchemy.Row | None] | None] = ContextVar(
     "_current_row_holder", default=None
 )
 
 
-def get_table_key_or_name(table: Union[sqlalchemy.Table, sqlalchemy.Alias]) -> str:
+def get_table_key_or_name(table: sqlalchemy.Table | sqlalchemy.Alias) -> str:
     try:
         return table.key  # type: ignore
     except AttributeError:
@@ -65,7 +70,7 @@ def get_table_key_or_name(table: Union[sqlalchemy.Table, sqlalchemy.Alias]) -> s
         return table.name
 
 
-def _extract_unique_lookup_key(obj: Any, unique_fields: Sequence[str]) -> Union[tuple, None]:
+def _extract_unique_lookup_key(obj: Any, unique_fields: Sequence[str]) -> tuple | None:
     lookup_key = []
     if isinstance(obj, dict):
         for field in unique_fields:
@@ -74,7 +79,7 @@ def _extract_unique_lookup_key(obj: Any, unique_fields: Sequence[str]) -> Union[
             value = obj[field]
             lookup_key.append(
                 orjson.dumps(value, option=orjson.OPT_SORT_KEYS)
-                if isinstance(value, (dict, list))
+                if isinstance(value, dict | list)
                 else value
             )
     else:
@@ -84,7 +89,7 @@ def _extract_unique_lookup_key(obj: Any, unique_fields: Sequence[str]) -> Union[
             value = getattr(obj, field)
             lookup_key.append(
                 orjson.dumps(value, option=orjson.OPT_SORT_KEYS)
-                if isinstance(value, (dict, list))
+                if isinstance(value, dict | list)
                 else value
             )
     return tuple(lookup_key)
@@ -100,32 +105,32 @@ class BaseQuerySet(
 
     def __init__(
         self,
-        model_class: Union[type[BaseModelType], None] = None,
+        model_class: type[BaseModelType] | None = None,
         *,
-        database: Union[Database, None] = None,
+        database: Database | None = None,
         filter_clauses: Iterable[Any] = _empty_set,
         select_related: Iterable[str] = _empty_set,
         prefetch_related: Iterable[Prefetch] = _empty_set,
-        limit_count: Optional[int] = None,
-        limit: Optional[int] = None,
-        limit_offset: Optional[int] = None,
-        offset: Optional[int] = None,
-        batch_size: Optional[int] = None,
+        limit_count: int | None = None,
+        limit: int | None = None,
+        limit_offset: int | None = None,
+        offset: int | None = None,
+        batch_size: int | None = None,
         order_by: Iterable[str] = _empty_set,
         group_by: Iterable[str] = _empty_set,
-        distinct_on: Union[None, Literal[True], Iterable[str]] = None,
-        distinct: Union[None, Literal[True], Iterable[str]] = None,
-        only_fields: Optional[Iterable[str]] = None,
+        distinct_on: None | Literal[True] | Iterable[str] = None,
+        distinct: None | Literal[True] | Iterable[str] = None,
+        only_fields: Iterable[str] | None = None,
         only: Iterable[str] = _empty_set,
-        defer_fields: Optional[Sequence[str]] = None,
+        defer_fields: Sequence[str] | None = None,
         defer: Iterable[str] = _empty_set,
-        embed_parent: Optional[tuple[str, Union[str, str]]] = None,
-        embed_parent_filters: Optional[tuple[str, str]] = None,
-        using_schema: Union[str, None, Any] = Undefined,
-        table: Optional[sqlalchemy.Table] = None,
+        embed_parent: tuple[str, str | str] | None = None,
+        embed_parent_filters: tuple[str, str] | None = None,
+        using_schema: str | None | Any = Undefined,
+        table: sqlalchemy.Table | None = None,
         exclude_secrets: bool = False,
-        extra_select: Optional[Iterable[sqlalchemy.ClauseElement]] = None,
-        reference_select: Optional[reference_select_type] = None,
+        extra_select: Iterable[sqlalchemy.ClauseElement] | None = None,
+        reference_select: reference_select_type | None = None,
     ) -> None:
         # Making sure for queries we use the main class and not the proxy
         # And enable the parent
@@ -188,12 +193,9 @@ class BaseQuerySet(
         # is empty
         self._clear_cache(keep_result_cache=False)
         # this is not cleared, because the expression is immutable
-        self._cached_select_related_expression: Optional[
-            tuple[
-                Any,
-                dict[str, tuple[sqlalchemy.Table, type[BaseModelType]]],
-            ]
-        ] = None
+        self._cached_select_related_expression: (
+            tuple[Any, dict[str, tuple[sqlalchemy.Table, type[BaseModelType]]]] | None
+        ) = None
         # initialize
         self.active_schema = self.get_schema()
 
@@ -245,12 +247,12 @@ class BaseQuerySet(
         if not keep_result_cache:
             self._cache.clear()
         if not keep_cached_selected:
-            self._cached_select_with_tables: Optional[
-                tuple[Any, dict[str, tuple[sqlalchemy.Table, type[BaseModelType]]]]
-            ] = None
-        self._cache_count: Optional[int] = None
-        self._cache_first: Optional[tuple[BaseModelType, Any]] = None
-        self._cache_last: Optional[tuple[BaseModelType, Any]] = None
+            self._cached_select_with_tables: (
+                tuple[Any, dict[str, tuple[sqlalchemy.Table, type[BaseModelType]]]] | None
+            ) = None
+        self._cache_count: int | None = None
+        self._cache_first: tuple[BaseModelType, Any] | None = None
+        self._cache_last: tuple[BaseModelType, Any] | None = None
         # fetch all is in cache
         self._cache_fetch_all: bool = False
 
@@ -265,10 +267,10 @@ class BaseQuerySet(
         return expression
 
     async def build_where_clause(
-        self, _: Any = None, tables_and_models: Optional[tables_and_models_type] = None
+        self, _: Any = None, tables_and_models: tables_and_models_type | None = None
     ) -> Any:
         """Build a where clause from the filters which can be passed in a where function."""
-        joins: Optional[Any] = None
+        joins: Any | None = None
         if tables_and_models is None:
             joins, tables_and_models = self._build_tables_join_from_relationship()
         # ignored args for passing build_where_clause in filter_clauses
@@ -309,7 +311,7 @@ class BaseQuerySet(
             )
         )
 
-    def _build_select_distinct(self, distinct_on: Optional[Sequence[str]], expression: Any) -> Any:
+    def _build_select_distinct(self, distinct_on: Sequence[str] | None, expression: Any) -> Any:
         """Filters selects only specific fields. Leave empty to use simple distinct"""
         # using with columns is not supported by all databases
         if distinct_on:
@@ -323,7 +325,7 @@ class BaseQuerySet(
         join_clause: Any,
         current_transition: tuple[str, str, str],
         *,
-        transitions: dict[tuple[str, str, str], tuple[Any, Optional[tuple[str, str, str]], str]],
+        transitions: dict[tuple[str, str, str], tuple[Any, tuple[str, str, str] | None, str]],
         tables_and_models: dict[str, tuple[sqlalchemy.Table, type[BaseModelType]]],
     ) -> Any:
         if current_transition not in transitions:
@@ -371,7 +373,7 @@ class BaseQuerySet(
                 "": (select_from, self.model_class)
             }
             transitions: dict[
-                tuple[str, str, str], tuple[Any, Optional[tuple[str, str, str]], str]
+                tuple[str, str, str], tuple[Any, tuple[str, str, str] | None, str]
             ] = {}
 
             # Select related
@@ -389,8 +391,8 @@ class BaseQuerySet(
                 # string: add a custom prefix instead of the calculated one and skip adding the next field to the
                 #         public prefix.
 
-                injected_prefix: Union[bool, str] = False
-                model_database: Optional[Database] = self.database
+                injected_prefix: bool | str = False
+                model_database: Database | None = self.database
                 while select_path:
                     field_name = select_path.split("__", 1)[0]
                     try:
@@ -655,7 +657,7 @@ class BaseQuerySet(
                     *,
                     _field: BaseFieldType = field,
                     _value: Any = value,
-                    _op: Optional[str] = op,
+                    _op: str | None = op,
                     _prefix: str = related_str,
                     # generic field has no field name
                     _field_name: str = field_name,
@@ -681,7 +683,7 @@ class BaseQuerySet(
         return self.table.columns[distinct_on]
 
     async def _embed_parent_in_result(
-        self, result: Union[EdgyModel, Awaitable[EdgyModel]]
+        self, result: EdgyModel | Awaitable[EdgyModel]
     ) -> tuple[EdgyModel, Any]:
         if isawaitable(result):
             result = await result
@@ -732,7 +734,7 @@ class BaseQuerySet(
                 setattr(self, attr, result_tuple)
         return result_tuple
 
-    def get_schema(self) -> Optional[str]:
+    def get_schema(self) -> str | None:
         # Differs from get_schema global
         schema = self.using_schema
         if schema is Undefined:
@@ -766,7 +768,7 @@ class BaseQuerySet(
                 QuerySetError(
                     detail=("Creating a reverse path is not possible, unidirectional fields used.")
                 )
-            prefetch_queryset: Optional[QuerySet] = prefetch.queryset
+            prefetch_queryset: QuerySet | None = prefetch.queryset
 
             clauses = [
                 {
@@ -822,7 +824,7 @@ class BaseQuerySet(
         )
 
     @property
-    def _current_row(self) -> Optional[sqlalchemy.Row]:
+    def _current_row(self) -> sqlalchemy.Row | None:
         """Get async safe the current row when in _execute_iterate"""
         row_holder = _current_row_holder.get()
         if not row_holder:
@@ -864,9 +866,9 @@ class BaseQuerySet(
                 fetch_all_at_once = True
 
         counter = 0
-        last_element: Optional[tuple[BaseModelType, BaseModelType]] = None
+        last_element: tuple[BaseModelType, BaseModelType] | None = None
         check_db_connection(queryset.database, stacklevel=4)
-        current_row: list[Optional[sqlalchemy.Row]] = [None]
+        current_row: list[sqlalchemy.Row | None] = [None]
         token = _current_row_holder.set(current_row)
         try:
             if fetch_all_at_once:
@@ -925,18 +927,14 @@ class BaseQuerySet(
         self,
         kwargs: Any,
         clauses: Sequence[
-            Union[
-                sqlalchemy.sql.expression.BinaryExpression,
-                Callable[
-                    [QuerySetType],
-                    Union[
-                        sqlalchemy.sql.expression.BinaryExpression,
-                        Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                    ],
-                ],
-                dict[str, Any],
-                QuerySet,
+            sqlalchemy.sql.expression.BinaryExpression
+            | Callable[
+                [QuerySetType],
+                sqlalchemy.sql.expression.BinaryExpression
+                | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
             ]
+            | dict[str, Any]
+            | QuerySet
         ],
         exclude: bool = False,
         or_: bool = False,
@@ -949,15 +947,11 @@ class BaseQuerySet(
         if kwargs:
             clauses = [*clauses, kwargs]
         converted_clauses: Sequence[
-            Union[
-                sqlalchemy.sql.expression.BinaryExpression,
-                Callable[
-                    [QuerySetType],
-                    Union[
-                        sqlalchemy.sql.expression.BinaryExpression,
-                        Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                    ],
-                ],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Callable[
+                [QuerySetType],
+                sqlalchemy.sql.expression.BinaryExpression
+                | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
             ]
         ] = []
         for raw_clause in clauses:
@@ -1011,7 +1005,7 @@ class BaseQuerySet(
             queryset.filter_clauses.extend(converted_clauses)
         return queryset
 
-    async def _model_based_delete(self, remove_referenced_call: Union[str, bool]) -> int:
+    async def _model_based_delete(self, remove_referenced_call: str | bool) -> int:
         queryset = self.limit(self._batch_size) if not self._cache_fetch_all else self
         # we set embed_parent on the copy to None to get raw instances
         # embed_parent_filters is not affected
@@ -1033,7 +1027,7 @@ class BaseQuerySet(
         return row_count
 
     async def raw_delete(
-        self, use_models: bool = False, remove_referenced_call: Union[str, bool] = False
+        self, use_models: bool = False, remove_referenced_call: str | bool = False
     ) -> int:
         if (
             self.model_class.__require_model_based_deletion__
@@ -1064,7 +1058,7 @@ class BaseQuerySet(
 
         if kwargs:
             cached = cast(
-                Optional[tuple[BaseModelType, Any]], self._cache.get(self.model_class, kwargs)
+                tuple[BaseModelType, Any] | None, self._cache.get(self.model_class, kwargs)
             )
             if cached is not None:
                 return cached
@@ -1115,18 +1109,14 @@ class QuerySet(BaseQuerySet):
 
     def filter(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-            QuerySet,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any]
+        | QuerySet,
         **kwargs: Any,
     ) -> QuerySet:
         """
@@ -1145,18 +1135,14 @@ class QuerySet(BaseQuerySet):
 
     def or_(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-            QuerySet,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any]
+        | QuerySet,
         **kwargs: Any,
     ) -> QuerySet:
         """
@@ -1166,18 +1152,14 @@ class QuerySet(BaseQuerySet):
 
     def local_or(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-            QuerySet,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any]
+        | QuerySet,
         **kwargs: Any,
     ) -> QuerySet:
         """
@@ -1189,17 +1171,13 @@ class QuerySet(BaseQuerySet):
 
     def and_(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any],
         **kwargs: Any,
     ) -> QuerySet:
         """
@@ -1209,18 +1187,14 @@ class QuerySet(BaseQuerySet):
 
     def not_(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-            QuerySet,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any]
+        | QuerySet,
         **kwargs: Any,
     ) -> QuerySet:
         """
@@ -1230,18 +1204,14 @@ class QuerySet(BaseQuerySet):
 
     def exclude(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-            QuerySet,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any]
+        | QuerySet,
         **kwargs: Any,
     ) -> QuerySet:
         """
@@ -1275,7 +1245,7 @@ class QuerySet(BaseQuerySet):
 
     def batch_size(
         self,
-        batch_size: Optional[int] = None,
+        batch_size: int | None = None,
     ) -> QuerySet:
         """
         Set batch/chunk size. Used for iterate
@@ -1298,7 +1268,7 @@ class QuerySet(BaseQuerySet):
         search_fields = [
             name
             for name, field in queryset.model_class.meta.fields.items()
-            if isinstance(field, (CharField, TextField))
+            if isinstance(field, CharField | TextField)
         ]
         search_clauses = [queryset.table.columns[name].ilike(value) for name in search_fields]
 
@@ -1363,7 +1333,7 @@ class QuerySet(BaseQuerySet):
         queryset._group_by = group_by
         return queryset
 
-    def distinct(self, first: Union[bool, str] = True, *distinct_on: str) -> QuerySet:
+    def distinct(self, first: bool | str = True, *distinct_on: str) -> QuerySet:
         """
         Returns a queryset with distinct results.
         """
@@ -1428,8 +1398,8 @@ class QuerySet(BaseQuerySet):
 
     async def values(
         self,
-        fields: Union[Sequence[str], str, None] = None,
-        exclude: Union[Sequence[str], set[str]] = None,
+        fields: Sequence[str] | str | None = None,
+        exclude: Sequence[str] | set[str] = None,
         exclude_none: bool = False,
     ) -> list[Any]:
         """
@@ -1455,8 +1425,8 @@ class QuerySet(BaseQuerySet):
 
     async def values_list(
         self,
-        fields: Union[Sequence[str], str, None] = None,
-        exclude: Union[Sequence[str], set[str]] = None,
+        fields: Sequence[str] | str | None = None,
+        exclude: Sequence[str] | set[str] = None,
         exclude_none: bool = False,
         flat: bool = False,
     ) -> list[Any]:
@@ -1509,7 +1479,7 @@ class QuerySet(BaseQuerySet):
             self._cache_count = count = cast("int", await database.fetch_val(expression))
         return count
 
-    async def get_or_none(self, **kwargs: Any) -> Union[EdgyEmbedTarget, None]:
+    async def get_or_none(self, **kwargs: Any) -> EdgyEmbedTarget | None:
         """
         Fetch one object matching the parameters or returns None.
         """
@@ -1524,7 +1494,7 @@ class QuerySet(BaseQuerySet):
         """
         return cast(EdgyEmbedTarget, (await self._get_raw(**kwargs))[1])
 
-    async def first(self) -> Union[EdgyEmbedTarget, None]:
+    async def first(self) -> EdgyEmbedTarget | None:
         """
         Returns the first record of a given queryset.
         """
@@ -1546,7 +1516,7 @@ class QuerySet(BaseQuerySet):
             )[1]
         return None
 
-    async def last(self) -> Union[EdgyEmbedTarget, None]:
+    async def last(self) -> EdgyEmbedTarget | None:
         """
         Returns the last record of a given queryset.
         """
@@ -1603,7 +1573,7 @@ class QuerySet(BaseQuerySet):
         finally:
             CHECK_DB_CONNECTION_SILENCED.reset(token)
 
-    async def bulk_create(self, objs: Iterable[Union[dict[str, Any], EdgyModel]]) -> None:
+    async def bulk_create(self, objs: Iterable[dict[str, Any] | EdgyModel]) -> None:
         """
         Bulk creates records in a table
         """
@@ -1611,7 +1581,7 @@ class QuerySet(BaseQuerySet):
 
         new_objs: list[EdgyModel] = []
 
-        async def _iterate(obj_or_dict: Union[EdgyModel, dict[str, Any]]) -> dict[str, Any]:
+        async def _iterate(obj_or_dict: EdgyModel | dict[str, Any]) -> dict[str, Any]:
             if isinstance(obj_or_dict, dict):
                 obj: EdgyModel = queryset.model_class(**obj_or_dict)
                 if (
@@ -1710,8 +1680,8 @@ class QuerySet(BaseQuerySet):
 
     async def bulk_get_or_create(
         self,
-        objs: list[Union[dict[str, Any], EdgyModel]],
-        unique_fields: Union[list[str], None] = None,
+        objs: list[dict[str, Any] | EdgyModel],
+        unique_fields: list[str] | None = None,
     ) -> list[EdgyModel]:
         """
         Bulk gets or creates records in a table.
@@ -1859,7 +1829,7 @@ class QuerySet(BaseQuerySet):
         self._clear_cache()
 
     async def get_or_create(
-        self, defaults: Union[dict[str, Any], Any, None] = None, *args: Any, **kwargs: Any
+        self, defaults: dict[str, Any] | Any | None = None, *args: Any, **kwargs: Any
     ) -> tuple[EdgyEmbedTarget, bool]:
         """
         Creates a record in a specific table or updates if already exists.
@@ -1897,7 +1867,7 @@ class QuerySet(BaseQuerySet):
         return cast(EdgyEmbedTarget, get_instance), False
 
     async def update_or_create(
-        self, defaults: Union[dict[str, Any], Any, None] = None, *args: Any, **kwargs: Any
+        self, defaults: dict[str, Any] | Any | None = None, *args: Any, **kwargs: Any
     ) -> tuple[EdgyEmbedTarget, bool]:
         """
         Updates a record in a specific table or creates a new one.

--- a/edgy/core/db/querysets/clauses.py
+++ b/edgy/core/db/querysets/clauses.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from functools import partial
 from inspect import Parameter, Signature, isawaitable
 from itertools import islice
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import sqlalchemy
 
@@ -65,8 +65,8 @@ async def parse_clause_args(
 def clean_query_kwargs(
     model_class: type[BaseModelType],
     kwargs: dict[str, Any],
-    embed_parent: Optional[tuple[str, str]] = None,
-    model_database: Optional[Database] = None,
+    embed_parent: tuple[str, str] | None = None,
+    model_database: Database | None = None,
 ) -> dict[str, Any]:
     new_kwargs: dict[str, Any] = {}
     for key, val in kwargs.items():

--- a/edgy/core/db/querysets/mixins.py
+++ b/edgy/core/db/querysets/mixins.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import sqlalchemy
 
@@ -20,8 +20,8 @@ class QuerySetPropsMixin:
     for clean access and maintainance.
     """
 
-    _table: Optional[sqlalchemy.Table] = None
-    _database: Optional[Database] = None
+    _table: sqlalchemy.Table | None = None
+    _database: Database | None = None
 
     @property
     def database(self) -> Database:
@@ -41,7 +41,7 @@ class QuerySetPropsMixin:
         return self._table
 
     @table.setter
-    def table(self: QuerySet, value: Optional[sqlalchemy.Table]) -> None:
+    def table(self: QuerySet, value: sqlalchemy.Table | None) -> None:
         self._table = value
         self._clear_cache()
 
@@ -66,8 +66,8 @@ class TenancyMixin:
         self,
         _positional: Any = _sentinel,
         *,
-        database: Union[str, Any, None, Database] = Undefined,
-        schema: Union[str, Any, None, Literal[False]] = Undefined,
+        database: str | Any | None | Database = Undefined,
+        schema: str | Any | None | Literal[False] = Undefined,
     ) -> QuerySet:
         """
         Enables and switches the db schema and/or db.
@@ -111,7 +111,7 @@ class TenancyMixin:
         return queryset
 
     def using_with_db(
-        self, connection_name: str, schema: Union[str, Any, None, Literal[False]] = Undefined
+        self, connection_name: str, schema: str | Any | None | Literal[False] = Undefined
     ) -> QuerySet:
         """
         Switches the database connection and schema

--- a/edgy/core/db/querysets/prefetch.py
+++ b/edgy/core/db/querysets/prefetch.py
@@ -22,7 +22,7 @@ class Prefetch:
     ) -> None:
         self.related_name = related_name
         self.to_attr = to_attr
-        self.queryset: Optional[QuerySet] = queryset
+        self.queryset: QuerySet | None = queryset
         self._is_finished = False
         self._bake_prefix: str = ""
         self._baked_results: dict[tuple[str, ...], list[Any]] = defaultdict(list)

--- a/edgy/core/db/querysets/types.py
+++ b/edgy/core/db/querysets/types.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Awaitable, Generator, Iterable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Generic,
     Literal,
-    Optional,
     TypeVar,
     Union,
 )
@@ -41,24 +39,20 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
 
     @abstractmethod
     async def build_where_clause(
-        self, _: Any = None, tables_and_models: Optional[tables_and_models_type] = None
+        self, _: Any = None, tables_and_models: tables_and_models_type | None = None
     ) -> Any: ...
 
     @abstractmethod
     def filter(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-            QuerySetType,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any]
+        | QuerySetType,
         **kwargs: Any,
     ) -> QuerySetType: ...
 
@@ -68,17 +62,13 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     @abstractmethod
     def or_(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            QuerySetType,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | QuerySetType,
         **kwargs: Any,
     ) -> QuerySetType:
         """
@@ -88,17 +78,13 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     @abstractmethod
     def local_or(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            QuerySetType,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | QuerySetType,
         **kwargs: Any,
     ) -> QuerySetType:
         """
@@ -108,18 +94,14 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     @abstractmethod
     def and_(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-            QuerySetType,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any]
+        | QuerySetType,
         **kwargs: Any,
     ) -> QuerySetType:
         """
@@ -129,18 +111,14 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     @abstractmethod
     def not_(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-            QuerySetType,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any]
+        | QuerySetType,
         **kwargs: Any,
     ) -> QuerySetType:
         """
@@ -151,18 +129,14 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     @abstractmethod
     def exclude(
         self,
-        *clauses: Union[
-            sqlalchemy.sql.expression.BinaryExpression,
-            Callable[
-                [QuerySetType],
-                Union[
-                    sqlalchemy.sql.expression.BinaryExpression,
-                    Awaitable[sqlalchemy.sql.expression.BinaryExpression],
-                ],
-            ],
-            dict[str, Any],
-            QuerySetType,
-        ],
+        *clauses: sqlalchemy.sql.expression.BinaryExpression
+        | Callable[
+            [QuerySetType],
+            sqlalchemy.sql.expression.BinaryExpression
+            | Awaitable[sqlalchemy.sql.expression.BinaryExpression],
+        ]
+        | dict[str, Any]
+        | QuerySetType,
         **kwargs: Any,
     ) -> QuerySetType: ...
 
@@ -203,22 +177,22 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     async def count(self) -> int: ...
 
     @abstractmethod
-    async def get_or_none(self, **kwargs: Any) -> Union[EdgyEmbedTarget, None]: ...
+    async def get_or_none(self, **kwargs: Any) -> EdgyEmbedTarget | None: ...
 
     @abstractmethod
     async def get(self, **kwargs: Any) -> EdgyEmbedTarget: ...
 
     @abstractmethod
-    async def first(self) -> Union[EdgyEmbedTarget, None]: ...
+    async def first(self) -> EdgyEmbedTarget | None: ...
 
     @abstractmethod
-    async def last(self) -> Union[EdgyEmbedTarget, None]: ...
+    async def last(self) -> EdgyEmbedTarget | None: ...
 
     @abstractmethod
     async def create(self, *args: Any, **kwargs: Any) -> EdgyEmbedTarget: ...
 
     @abstractmethod
-    async def bulk_create(self, objs: Iterable[Union[dict[str, Any], EdgyModel]]) -> None: ...
+    async def bulk_create(self, objs: Iterable[dict[str, Any] | EdgyModel]) -> None: ...
 
     @abstractmethod
     async def bulk_update(self, objs: Sequence[EdgyModel], fields: list[str]) -> None: ...
@@ -232,8 +206,8 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     @abstractmethod
     async def values(
         self,
-        fields: Union[Sequence[str], str, None],
-        exclude: Union[Sequence[str], set[str]],
+        fields: Sequence[str] | str | None,
+        exclude: Sequence[str] | set[str],
         exclude_none: bool,
         **kwargs: Any,
     ) -> list[Any]: ...
@@ -241,8 +215,8 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     @abstractmethod
     async def values_list(
         self,
-        fields: Union[Sequence[str], str, None],
-        exclude: Union[Sequence[str], set[str]],
+        fields: Sequence[str] | str | None,
+        exclude: Sequence[str] | set[str],
         exclude_none: bool,
         flat: bool,
     ) -> list[Any]: ...
@@ -250,14 +224,14 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     @abstractmethod
     async def get_or_create(
         self,
-        defaults: Union[dict[str, Any], Any, None] = None,
+        defaults: dict[str, Any] | Any | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> tuple[EdgyEmbedTarget, bool]: ...
 
     @abstractmethod
     async def update_or_create(
-        self, defaults: Union[dict[str, Any], Any, None] = None, *args: Any, **kwargs: Any
+        self, defaults: dict[str, Any] | Any | None = None, *args: Any, **kwargs: Any
     ) -> tuple[EdgyEmbedTarget, bool]: ...
 
     @abstractmethod
@@ -271,8 +245,8 @@ class QuerySetType(ABC, Generic[EdgyEmbedTarget, EdgyModel]):
     def using(
         self,
         *,
-        database: Union[str, Any, None, Database] = Undefined,
-        schema: Union[str, Any, None, Literal[False]] = Undefined,
+        database: str | Any | None | Database = Undefined,
+        schema: str | Any | None | Literal[False] = Undefined,
     ) -> QuerySetType: ...
 
     @abstractmethod

--- a/edgy/core/db/relationships/related_field.py
+++ b/edgy/core/db/relationships/related_field.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import SkipValidation
 from pydantic.json_schema import SkipJsonSchema
@@ -97,12 +97,12 @@ class RelatedField(RelationshipField):
     def get_relation(self, **kwargs: Any) -> ManyRelationProtocol:
         return self.foreign_key.get_relation(**kwargs)
 
-    def is_cross_db(self, owner_database: Optional[Database] = None) -> bool:
+    def is_cross_db(self, owner_database: Database | None = None) -> bool:
         if owner_database is None:
             owner_database = self.owner.database
         return str(owner_database.url) != str(self.foreign_key.owner.database.url)
 
-    def get_related_model_for_admin(self) -> Optional[type[BaseModelType]]:
+    def get_related_model_for_admin(self) -> type[BaseModelType] | None:
         related_from_registry = self.related_from.meta.registry
         assert related_from_registry is not None and related_from_registry is not False
         if self.related_from.__name__ in related_from_registry.admin_models:

--- a/edgy/core/db/relationships/utils.py
+++ b/edgy/core/db/relationships/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional
 
 from edgy.core.db.fields.base import BaseForeignKey, RelationshipField
 
@@ -10,9 +10,9 @@ if TYPE_CHECKING:  # pragma: no cover
 class RelationshipCrawlResult(NamedTuple):
     model_class: type["BaseModelType"]
     field_name: str
-    operator: Optional[str]
+    operator: str | None
     forward_path: str
-    reverse_path: Union[str, Literal[False]]
+    reverse_path: str | Literal[False]
     cross_db_remainder: str
 
 
@@ -26,8 +26,8 @@ def crawl_relationship(
 ) -> RelationshipCrawlResult:
     field = None
     forward_prefix_path = ""
-    reverse_path: Union[str, Literal[False]] = ""
-    operator: Optional[str] = "exact"
+    reverse_path: str | Literal[False] = ""
+    operator: str | None = "exact"
     field_name: str = path
     cross_db_remainder: str = ""
     while path:

--- a/edgy/core/events.py
+++ b/edgy/core/events.py
@@ -1,7 +1,7 @@
 import inspect
 import typing
-from collections.abc import Sequence
-from typing import Any, Callable, Optional, TypeVar
+from collections.abc import Callable, Sequence
+from typing import Any, TypeVar
 
 Scope = typing.MutableMapping[str, typing.Any]
 Message = typing.MutableMapping[str, typing.Any]
@@ -28,8 +28,8 @@ class AyncLifespanContextManager:
 
     def __init__(
         self,
-        on_shutdown: Optional[Sequence[Callable[..., Any]]] = None,
-        on_startup: Optional[Sequence[Callable[..., Any]]] = None,
+        on_shutdown: Sequence[Callable[..., Any]] | None = None,
+        on_startup: Sequence[Callable[..., Any]] | None = None,
     ) -> None:
         self.on_startup = [] if on_startup is None else list(on_startup)
         self.on_shutdown = [] if on_shutdown is None else list(on_shutdown)
@@ -53,9 +53,9 @@ class AyncLifespanContextManager:
 
 
 def handle_lifespan_events(
-    on_startup: Optional[Sequence[Callable]] = None,
-    on_shutdown: Optional[Sequence[Callable]] = None,
-    lifespan: Optional[Any] = None,
+    on_startup: Sequence[Callable] | None = None,
+    on_shutdown: Sequence[Callable] | None = None,
+    lifespan: Any | None = None,
 ) -> Any:
     """Handles with the lifespan events in the new Starlette format of lifespan.
     This adds a mask that keeps the old `on_startup` and `on_shutdown` events variable

--- a/edgy/core/files/storage/base.py
+++ b/edgy/core/files/storage/base.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar
 
 from edgy.core.files.base import ContentFile, File
 from edgy.exceptions import SuspiciousFileOperation
@@ -24,13 +24,13 @@ class Storage(ABC):
 
     # private helper
     @staticmethod
-    def value_or_setting(value: _arg_val, setting: _arg_setting) -> Union[_arg_val, _arg_setting]:
+    def value_or_setting(value: _arg_val, setting: _arg_setting) -> _arg_val | _arg_setting:
         return setting if value is None else value
 
     @abstractmethod
     def _open(self, name: str, mode: str) -> Any: ...
 
-    def open(self, name: str, mode: Union[str, None] = None) -> Any:
+    def open(self, name: str, mode: str | None = None) -> Any:
         if mode is None:
             mode = "rb"
         return self._open(name, mode)
@@ -83,9 +83,9 @@ class Storage(ABC):
     def get_available_name(
         self,
         name: str,
-        max_length: Union[int, None] = None,
+        max_length: int | None = None,
         overwrite: bool = False,
-        multi_process_safe: Union[bool] = None,
+        multi_process_safe: bool = None,
     ) -> str:
         """
         Return a filename that's free on the target storage system and

--- a/edgy/core/files/storage/filesystem.py
+++ b/edgy/core/files/storage/filesystem.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime, timezone
 from functools import cached_property
 from threading import Lock
-from typing import Any, BinaryIO, Union, cast
+from typing import Any, BinaryIO, cast
 from urllib.parse import urljoin
 
 from edgy.conf import settings
@@ -19,10 +19,10 @@ class FileSystemStorage(Storage):
 
     def __init__(
         self,
-        location: Union[str, os.PathLike, None] = None,
-        base_url: Union[str, None] = None,
-        file_permissions_mode: Union[int, None] = None,
-        directory_permissions_mode: Union[int, None] = None,
+        location: str | os.PathLike | None = None,
+        base_url: str | None = None,
+        file_permissions_mode: int | None = None,
+        directory_permissions_mode: int | None = None,
     ) -> None:
         self._location = location
         self._base_url = base_url

--- a/edgy/core/files/storage/handler.py
+++ b/edgy/core/files/storage/handler.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from monkay import load
 
@@ -15,7 +15,7 @@ class StorageHandler:
     of the system.
     """
 
-    def __init__(self, backends: Union[dict[str, Any], None] = None) -> None:
+    def __init__(self, backends: dict[str, Any] | None = None) -> None:
         self._backends = backends
         self._storages: dict[str, Storage] = {}
 

--- a/edgy/core/marshalls/base.py
+++ b/edgy/core/marshalls/base.py
@@ -1,7 +1,7 @@
 import inspect
 from asyncio import gather
 from collections.abc import Awaitable
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -30,7 +30,7 @@ class BaseMarshall(BaseModel, metaclass=MarshallMeta):
     def __init__(self, /, **kwargs: Any) -> None:
         _instance = kwargs.pop("instance", None)
         super().__init__(**kwargs)
-        self._instance: Optional[Model] = None
+        self._instance: Model | None = None
         if _instance is not None:
             self.instance = _instance
         elif not type(self).__incomplete_fields__:

--- a/edgy/core/marshalls/config.py
+++ b/edgy/core/marshalls/config.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from typing_extensions import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     from edgy.core.db.models import Model

--- a/edgy/core/marshalls/config.py
+++ b/edgy/core/marshalls/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from typing_extensions import TypedDict
 
@@ -11,11 +11,11 @@ if TYPE_CHECKING:
 class ConfigMarshall(TypedDict, total=False):
     """A TypedDict for configuring Marshall behaviour."""
 
-    model: Union[type[Model], str]
+    model: type[Model] | str
     """The model from there the marshall will read from."""
 
-    fields: Union[list[str], None] = None
+    fields: list[str] | None = None
     """A list of fields to be serialized"""
 
-    exclude: Union[list[str], None] = None
+    exclude: list[str] | None = None
     """A list of fields to be excluded from the serialization."""

--- a/edgy/core/marshalls/fields.py
+++ b/edgy/core/marshalls/fields.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Union
+from typing import Any, ClassVar
 
 from pydantic.fields import FieldInfo
 
@@ -11,7 +11,7 @@ class BaseMarshallField(FieldInfo):
     def __init__(
         self,
         field_type: type,
-        source: Union[str, None] = None,
+        source: str | None = None,
         allow_null: bool = False,
         default: Any = Undefined,
         **kwargs: Any,
@@ -57,7 +57,7 @@ class MarshallField(BaseMarshallField):
     def __init__(
         self,
         field_type: type,
-        source: Union[str, None] = None,
+        source: str | None = None,
         **kwargs: dict[str, Any],
     ) -> None:
         kwargs.pop("default", None)

--- a/edgy/core/marshalls/metaclasses.py
+++ b/edgy/core/marshalls/metaclasses.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from monkay import load
 from pydantic._internal._model_construction import ModelMetaclass
@@ -43,7 +43,7 @@ class MarshallMeta(ModelMetaclass):
             )
 
         # The declared model
-        _model: Union[type[Model], str, None] = marshall_config.get("model", None)
+        _model: type[Model] | str | None = marshall_config.get("model", None)
         assert _model is not None, "'model' must be declared in the 'ConfigMarshall'."
 
         if isinstance(_model, str):

--- a/edgy/core/tenancy/utils.py
+++ b/edgy/core/tenancy/utils.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import sqlalchemy
 from loguru import logger
@@ -47,7 +47,7 @@ async def create_tables(
 async def create_schema(
     registry: "Registry",
     schema_name: str,
-    models: Union[dict[str, type["BaseModelType"]], None] = None,
+    models: dict[str, type["BaseModelType"]] | None = None,
     if_not_exists: bool = False,
     should_create_tables: bool = False,
 ) -> None:

--- a/edgy/core/terminal/base.py
+++ b/edgy/core/terminal/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Union
+from typing import Any
 
 from rich.console import Console
 
@@ -259,24 +259,24 @@ class Base(ABC, Console):
     """Base output class for the terminal"""
 
     @abstractmethod
-    def write_success(self, message: str, colour: str = OutputColour.SUCCESS) -> Union[str, None]:
+    def write_success(self, message: str, colour: str = OutputColour.SUCCESS) -> str | None:
         raise NotImplementedError()
 
     @abstractmethod
-    def write_info(self, message: str, colour: str = OutputColour.INFO) -> Union[str, None]:
+    def write_info(self, message: str, colour: str = OutputColour.INFO) -> str | None:
         """Outputs the info to the console"""
         raise NotImplementedError()
 
     @abstractmethod
-    def write_warning(self, message: str, colour: str = OutputColour.WARNING) -> Union[str, None]:
+    def write_warning(self, message: str, colour: str = OutputColour.WARNING) -> str | None:
         """Outputs the warnings to the console"""
 
     @abstractmethod
-    def write_error(self, message: str, colour: str = OutputColour.ERROR) -> Union[str, None]:
+    def write_error(self, message: str, colour: str = OutputColour.ERROR) -> str | None:
         """Outputs the errors to the console"""
         raise NotImplementedError()
 
-    def write_plain(self, message: str, colour: str = OutputColour.WHITE) -> Union[str, None]:
+    def write_plain(self, message: str, colour: str = OutputColour.WHITE) -> str | None:
         """Outputs the custom plain"""
         raise NotImplementedError()
 

--- a/edgy/core/utils/functional.py
+++ b/edgy/core/utils/functional.py
@@ -2,7 +2,7 @@
 All functional common to Edgy
 """
 
-from typing import Any, Union
+from typing import Any
 
 from pydantic.fields import FieldInfo
 
@@ -14,7 +14,7 @@ edgy_setattr = object.__setattr__
 
 
 def extract_field_annotations_and_defaults(
-    attrs: dict[Any, Any], base_type: Union[type[FieldInfo], type[BaseFieldType]] = BaseFieldType
+    attrs: dict[Any, Any], base_type: type[FieldInfo] | type[BaseFieldType] = BaseFieldType
 ) -> tuple[dict[Any, Any], dict[Any, Any]]:
     """
     Extracts annotations from class namespace dict and triggers
@@ -27,7 +27,7 @@ def extract_field_annotations_and_defaults(
 
 
 def get_model_fields(
-    attrs: Union[dict, Any], base_type: Union[type[FieldInfo], type[BaseFieldType]] = BaseFieldType
+    attrs: dict | Any, base_type: type[FieldInfo] | type[BaseFieldType] = BaseFieldType
 ) -> dict:
     """
     Gets all the fields in current model class that are Edgy Fields.
@@ -36,7 +36,7 @@ def get_model_fields(
 
 
 def populate_pydantic_default_values(
-    attrs: dict, base_type: Union[type[FieldInfo], type[BaseFieldType]] = BaseFieldType
+    attrs: dict, base_type: type[FieldInfo] | type[BaseFieldType] = BaseFieldType
 ) -> tuple[dict, dict]:
     """
     Making sure the fields from Edgy are the ones being validated by Edgy models
@@ -50,7 +50,7 @@ def populate_pydantic_default_values(
         field.name = field_name
         original_type = getattr(field, "__original_type__", None)
 
-        default_type = field.field_type if not field.null else Union[field.field_type, None]
+        default_type = field.field_type if not field.null else None | field.field_type
         overwrite_type = original_type if field.field_type != original_type else None
         field.annotation = overwrite_type or default_type
         model_fields[field_name] = field

--- a/edgy/core/utils/models.py
+++ b/edgy/core/utils/models.py
@@ -14,14 +14,14 @@ if TYPE_CHECKING:
 def create_edgy_model(
     __name__: str,
     __module__: str,
-    __definitions__: Optional[dict[str, Any]] = None,
+    __definitions__: dict[str, Any] | None = None,
     __metadata__: Optional["MetaInfo"] = None,
-    __qualname__: Optional[str] = None,
+    __qualname__: str | None = None,
     __config__: Optional["ConfigDict"] = None,
-    __bases__: Optional[tuple[type["BaseModelType"], ...]] = None,
+    __bases__: tuple[type["BaseModelType"], ...] | None = None,
     __proxy__: bool = False,
     __pydantic_extra__: Any = None,
-    __type_kwargs__: Optional[dict] = None,
+    __type_kwargs__: dict | None = None,
 ) -> type["Model"]:
     """
     Generates an `edgy.Model` with all the required definitions to generate the pydantic

--- a/edgy/core/utils/sync.py
+++ b/edgy/core/utils/sync.py
@@ -3,15 +3,15 @@ import weakref
 from collections.abc import Awaitable
 from contextvars import ContextVar, copy_context
 from threading import Event, Thread
-from typing import Any, Optional
+from typing import Any
 
 # for registry with
-current_eventloop: ContextVar[Optional[asyncio.AbstractEventLoop]] = ContextVar(
+current_eventloop: ContextVar[asyncio.AbstractEventLoop | None] = ContextVar(
     "current_eventloop", default=None
 )
 
 
-async def _coro_helper(awaitable: Awaitable, timeout: Optional[float]) -> Any:
+async def _coro_helper(awaitable: Awaitable, timeout: float | None) -> Any:
     if timeout is not None and timeout > 0:
         return await asyncio.wait_for(awaitable, timeout)
     return await awaitable
@@ -70,9 +70,9 @@ def get_subloop(loop: asyncio.AbstractEventLoop) -> asyncio.AbstractEventLoop:
 
 def run_sync(
     awaitable: Awaitable,
-    timeout: Optional[float] = None,
+    timeout: float | None = None,
     *,
-    loop: Optional[asyncio.AbstractEventLoop] = None,
+    loop: asyncio.AbstractEventLoop | None = None,
 ) -> Any:
     """
     Runs the queries in sync mode

--- a/edgy/testing/factory/types.py
+++ b/edgy/testing/factory/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Protocol, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict
 
 if TYPE_CHECKING:
     from faker import Faker
@@ -34,7 +34,7 @@ FactoryParameterCallback = Callable[
     ],
     Any,
 ]
-FactoryParameters = dict[str, Union[Any, FactoryParameterCallback]]
+FactoryParameters = dict[str, Any | FactoryParameterCallback]
 FactoryCallback = Callable[["FactoryField", ModelFactoryContext, dict[str, Any]], Any]
-FieldFactoryCallback = Union[FactoryCallback, str]
-FactoryFieldType = Union[str, "BaseFieldType", type["BaseFieldType"]]
+FieldFactoryCallback = str | FactoryCallback
+FactoryFieldType = str | "BaseFieldType" | type["BaseFieldType"]

--- a/edgy/testing/factory/types.py
+++ b/edgy/testing/factory/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Protocol, TypedDict
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, TypedDict
 
 if TYPE_CHECKING:
     from faker import Faker
@@ -34,7 +34,7 @@ FactoryParameterCallback = Callable[
     ],
     Any,
 ]
-FactoryParameters = dict[str, Any | FactoryParameterCallback]
-FactoryCallback = Callable[["FactoryField", ModelFactoryContext, dict[str, Any]], Any]
-FieldFactoryCallback = str | FactoryCallback
-FactoryFieldType = str | "BaseFieldType" | type["BaseFieldType"]
+FactoryParameters: TypeAlias = dict[str, Any | FactoryParameterCallback]
+FactoryCallback: TypeAlias = Callable[["FactoryField", ModelFactoryContext, dict[str, Any]], Any]
+FieldFactoryCallback: TypeAlias = str | FactoryCallback
+FactoryFieldType: TypeAlias = str | "BaseFieldType" | type["BaseFieldType"]

--- a/edgy/utils/compat.py
+++ b/edgy/utils/compat.py
@@ -1,7 +1,5 @@
 from inspect import isclass
-from typing import Any
-
-from typing_extensions import get_origin
+from typing import Any, get_origin
 
 
 def is_class_and_subclass(value: Any, _type: Any) -> bool:

--- a/edgy/utils/inspect.py
+++ b/edgy/utils/inspect.py
@@ -1,6 +1,7 @@
 import inspect
 import sys
-from typing import Any, Callable, NoReturn, Optional, Union
+from collections.abc import Callable
+from typing import Any, NoReturn
 
 import sqlalchemy
 from loguru import logger
@@ -59,7 +60,7 @@ class InspectDB:
     Class that builds the inspection of a database.
     """
 
-    def __init__(self, database: str, schema: Optional[str] = None) -> None:
+    def __init__(self, database: str, schema: str | None = None) -> None:
         """
         Creates an instance of an InspectDB and triggers the proccess.
         """
@@ -135,7 +136,7 @@ class InspectDB:
 
     @classmethod
     def get_foreign_keys(
-        cls, table_or_column: Union[sqlalchemy.Table, sqlalchemy.Column]
+        cls, table_or_column: sqlalchemy.Table | sqlalchemy.Column
     ) -> list[dict[str, Any]]:
         """
         Extracts all the information needed of the foreign keys.
@@ -271,7 +272,7 @@ class InspectDB:
 
     @classmethod
     def write_output(
-        cls, table_details: list[Any], connection_string: str, schema: Union[str, None] = None
+        cls, table_details: list[Any], connection_string: str, schema: str | None = None
     ) -> NoReturn:
         """
         Writes to stdout and runs some internal validations.

--- a/edgy/utils/path.py
+++ b/edgy/utils/path.py
@@ -4,7 +4,7 @@ import re
 import secrets
 import string
 from os.path import abspath, dirname, join, normcase, sep
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import quote
 
 from edgy.exceptions import SuspiciousFileOperation
@@ -122,7 +122,7 @@ def validate_file_name(name: str, allow_relative_path: bool = False) -> str:
     return name
 
 
-def filepath_to_uri(path: Optional[str]) -> str:
+def filepath_to_uri(path: str | None) -> str:
     """
     Convert a file system path to a URI portion suitable for inclusion in a URL.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "edgy"
 description = "🔥 The perfect ORM to work with complex databases 🔥"
 long_description = "🔥 The perfect ORM to work with complex databases 🔥"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ['version']
 authors = [{ name = "Tiago Silva", email = "tiago.arasilva@gmail.com" }]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "pydantic-settings>=2.0.0,<3.0.0",
     "rich>=14.0.0",
     "blinker>=1.8,<2.0",
+    'typing_extensions>=4.0; python_version<"3.11"'
+
 ]
 keywords = [
     "api",

--- a/tests/cli/custom_multidb/env.py
+++ b/tests/cli/custom_multidb/env.py
@@ -4,7 +4,7 @@ import logging
 import os
 from collections.abc import Generator
 from logging.config import fileConfig
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from alembic import context
 from rich.console import Console
@@ -30,8 +30,8 @@ MAIN_DATABASE_NAME: str = " "
 
 
 def iter_databases(registry: Registry) -> Generator[tuple[str, Database, "sqlalchemy.MetaData"]]:
-    url: Optional[str] = os.environ.get("EDGY_DATABASE_URL")
-    name: Union[str, Literal[False], None] = os.environ.get("EDGY_DATABASE") or False
+    url: str | None = os.environ.get("EDGY_DATABASE_URL")
+    name: str | Literal[False] | None = os.environ.get("EDGY_DATABASE") or False
     if url and not name:
         try:
             name = registry.metadata_by_url.get_name(url)

--- a/tests/cli/custom_multidb_copied_registry/env.py
+++ b/tests/cli/custom_multidb_copied_registry/env.py
@@ -4,7 +4,7 @@ import logging
 import os
 from collections.abc import Generator
 from logging.config import fileConfig
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from alembic import context
 from rich.console import Console
@@ -30,8 +30,8 @@ MAIN_DATABASE_NAME: str = " "
 
 
 def iter_databases(registry: Registry) -> Generator[tuple[str, Database, "sqlalchemy.MetaData"]]:
-    url: Optional[str] = os.environ.get("EDGY_DATABASE_URL")
-    name: Union[str, Literal[False], None] = os.environ.get("EDGY_DATABASE") or False
+    url: str | None = os.environ.get("EDGY_DATABASE_URL")
+    name: str | Literal[False] | None = os.environ.get("EDGY_DATABASE") or False
     if url and not name:
         try:
             name = registry.metadata_by_url.get_name(url)

--- a/tests/contrib/pagination/test_esmerald_integration_cursor.py
+++ b/tests/contrib/pagination/test_esmerald_integration_cursor.py
@@ -59,12 +59,12 @@ class BlogPage(BaseModel):
     content: list[BlogEntry]
     is_first: bool
     is_last: bool
-    current_cursor: Optional[int]
-    next_cursor: Optional[int]
+    current_cursor: int | None
+    next_cursor: int | None
     pages: int
 
 
-async def _get_blogpost(item: int) -> Optional[BlogEntry]:
+async def _get_blogpost(item: int) -> BlogEntry | None:
     # order by is required for paginators
     paginator = CursorPaginator(
         BlogEntry.query.order_by("-id"),
@@ -80,7 +80,7 @@ async def _get_blogpost(item: int) -> Optional[BlogEntry]:
 
 
 @get("/blog/item/{item}")
-async def get_blogpost(item: int) -> Optional[BlogEntry]:
+async def get_blogpost(item: int) -> BlogEntry | None:
     return await _get_blogpost(item)
 
 
@@ -127,7 +127,7 @@ async def get_last_blogpost_page(reverse_cursor: int) -> BlogPage:
 
 
 @post("/search")
-async def search_blogpost(string: str, cursor: Optional[int] = None) -> BlogPage:
+async def search_blogpost(string: str, cursor: int | None = None) -> BlogPage:
     # order by is required for paginators
     paginator = CursorPaginator(
         BlogEntry.query.or_({"title__icontains": string}, {"content__icontains": string}).order_by(

--- a/tests/contrib/pagination/test_pagination.py
+++ b/tests/contrib/pagination/test_pagination.py
@@ -97,7 +97,10 @@ async def test_pagination_int_count_no_leak():
     assert all(hasattr(entry, "next") for entry in entries_paginator)
     assert all(hasattr(entry, "prev") for entry in entries_paginator)
     assert len(entries_ordered) == len(entries_paginator)
-    assert all(entry1 == entry2 for entry1, entry2 in zip(entries_ordered, entries_paginator))
+    assert all(
+        entry1 == entry2
+        for entry1, entry2 in zip(entries_ordered, entries_paginator, strict=False)
+    )
 
 
 async def test_pagination_int_count_no_copy():

--- a/tests/models/test_inner_select.py
+++ b/tests/models/test_inner_select.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 import edgy
@@ -52,8 +50,8 @@ class AppModule(EdgyTenantBaseModel):
 
 
 class Permission(EdgyTenantBaseModel):
-    module: Optional[AppModule] = edgy.ForeignKey(AppModule)
-    designation: Optional[Designation] = edgy.ForeignKey("Designation")
+    module: AppModule | None = edgy.ForeignKey(AppModule)
+    designation: Designation | None = edgy.ForeignKey("Designation")
     can_read: bool = edgy.BooleanField(default=False)
     can_write: bool = edgy.BooleanField(default=False)
     can_update: bool = edgy.BooleanField(default=False)

--- a/tests/models/test_select_related_mul.py
+++ b/tests/models/test_select_related_mul.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 import edgy
@@ -36,8 +34,8 @@ class AppModule(EdgyTenantBaseModel):
 
 
 class Permission(EdgyTenantBaseModel):
-    module: Optional[AppModule] = edgy.ForeignKey(AppModule, null=True)
-    designation: Optional[Designation] = edgy.ForeignKey("Designation", null=True)
+    module: AppModule | None = edgy.ForeignKey(AppModule, null=True)
+    designation: Designation | None = edgy.ForeignKey("Designation", null=True)
     can_read: bool = edgy.BooleanField(default=False)
     can_write: bool = edgy.BooleanField(default=False)
     can_update: bool = edgy.BooleanField(default=False)

--- a/tests/models/test_select_related_single.py
+++ b/tests/models/test_select_related_single.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 import edgy
@@ -36,8 +34,8 @@ class AppModule(EdgyTenantBaseModel):
 
 
 class Permission(EdgyTenantBaseModel):
-    module: Optional[AppModule] = edgy.ForeignKey(AppModule, null=True)
-    designation: Optional[Designation] = edgy.ForeignKey("Designation", null=True)
+    module: AppModule | None = edgy.ForeignKey(AppModule, null=True)
+    designation: Designation | None = edgy.ForeignKey("Designation", null=True)
     can_read: bool = edgy.BooleanField(default=False)
     can_write: bool = edgy.BooleanField(default=False)
     can_update: bool = edgy.BooleanField(default=False)

--- a/tests/settings/default.py
+++ b/tests/settings/default.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Union
 
 from edgy.contrib.multi_tenancy.settings import TenancySettings
 
@@ -8,4 +7,4 @@ from edgy.contrib.multi_tenancy.settings import TenancySettings
 class TestSettings(TenancySettings):
     tenant_model: str = "Tenant"
     auth_user_model: str = "User"
-    media_root: Union[str, os.PathLike] = Path(__file__).parent.parent / "test_media/"
+    media_root: str | os.PathLike = Path(__file__).parent.parent / "test_media/"

--- a/tests/settings/disabled_auto_server_defaults.py
+++ b/tests/settings/disabled_auto_server_defaults.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Union
 
 from edgy.contrib.multi_tenancy.settings import TenancySettings
 
@@ -8,5 +7,5 @@ from edgy.contrib.multi_tenancy.settings import TenancySettings
 class TestSettings(TenancySettings):
     tenant_model: str = "Tenant"
     auth_user_model: str = "User"
-    media_root: Union[str, os.PathLike] = Path(__file__).parent.parent / "test_media/"
+    media_root: str | os.PathLike = Path(__file__).parent.parent / "test_media/"
     allow_auto_compute_server_defaults: bool = False

--- a/tests/settings/multidb.py
+++ b/tests/settings/multidb.py
@@ -1,7 +1,5 @@
-from typing import Union
-
 from edgy import EdgySettings
 
 
 class TestSettings(EdgySettings):
-    migrate_databases: list[Union[str, None]] = [None, "another"]
+    migrate_databases: list[str | None] = [None, "another"]

--- a/tests/settings/multidb_nonidentifier.py
+++ b/tests/settings/multidb_nonidentifier.py
@@ -1,7 +1,5 @@
-from typing import Union
-
 from edgy import EdgySettings
 
 
 class TestSettings(EdgySettings):
-    migrate_databases: list[Union[str, None]] = [None, "ano ther "]
+    migrate_databases: list[str | None] = [None, "ano ther "]

--- a/tests/tenancy/test_activate_tenant.py
+++ b/tests/tenancy/test_activate_tenant.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 import edgy
@@ -45,8 +43,8 @@ class AppModule(EdgyTenantBaseModel):
 
 
 class Permission(EdgyTenantBaseModel):
-    module: Optional[AppModule] = edgy.ForeignKey(AppModule)
-    designation: Optional[Designation] = edgy.ForeignKey("Designation")
+    module: AppModule | None = edgy.ForeignKey(AppModule)
+    designation: Designation | None = edgy.ForeignKey("Designation")
     can_read: bool = edgy.BooleanField(default=False)
     can_write: bool = edgy.BooleanField(default=False)
     can_update: bool = edgy.BooleanField(default=False)

--- a/tests/tenancy/test_activate_tenant_precedent.py
+++ b/tests/tenancy/test_activate_tenant_precedent.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 import edgy
@@ -45,8 +43,8 @@ class AppModule(EdgyTenantBaseModel):
 
 
 class Permission(EdgyTenantBaseModel):
-    module: Optional[AppModule] = edgy.ForeignKey(AppModule)
-    designation: Optional[Designation] = edgy.ForeignKey("Designation")
+    module: AppModule | None = edgy.ForeignKey(AppModule)
+    designation: Designation | None = edgy.ForeignKey("Designation")
     can_read: bool = edgy.BooleanField(default=False)
     can_write: bool = edgy.BooleanField(default=False)
     can_update: bool = edgy.BooleanField(default=False)

--- a/tests/tenancy/test_load.py
+++ b/tests/tenancy/test_load.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 import edgy
@@ -44,8 +42,8 @@ class AppModule(EdgyTenantBaseModel):
 
 
 class Permission(EdgyTenantBaseModel):
-    module: Optional[AppModule] = edgy.ForeignKey(AppModule)
-    designation: Optional[Designation] = edgy.ForeignKey("Designation")
+    module: AppModule | None = edgy.ForeignKey(AppModule)
+    designation: Designation | None = edgy.ForeignKey("Designation")
     can_read: bool = edgy.BooleanField(default=False)
     can_write: bool = edgy.BooleanField(default=False)
     can_update: bool = edgy.BooleanField(default=False)

--- a/tests/tenancy/test_select_related_multiple.py
+++ b/tests/tenancy/test_select_related_multiple.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 import edgy
@@ -44,8 +42,8 @@ class AppModule(EdgyTenantBaseModel):
 
 
 class Permission(EdgyTenantBaseModel):
-    module: Optional[AppModule] = edgy.ForeignKey(AppModule)
-    designation: Optional[Designation] = edgy.ForeignKey("Designation")
+    module: AppModule | None = edgy.ForeignKey(AppModule)
+    designation: Designation | None = edgy.ForeignKey("Designation")
     can_read: bool = edgy.BooleanField(default=False)
     can_write: bool = edgy.BooleanField(default=False)
     can_update: bool = edgy.BooleanField(default=False)

--- a/tests/tenancy/test_select_related_two.py
+++ b/tests/tenancy/test_select_related_two.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 import edgy
@@ -44,8 +42,8 @@ class AppModule(EdgyTenantBaseModel):
 
 
 class Permission(EdgyTenantBaseModel):
-    module: Optional[AppModule] = edgy.ForeignKey(AppModule)
-    designation: Optional[Designation] = edgy.ForeignKey("Designation")
+    module: AppModule | None = edgy.ForeignKey(AppModule)
+    designation: Designation | None = edgy.ForeignKey("Designation")
     can_read: bool = edgy.BooleanField(default=False)
     can_write: bool = edgy.BooleanField(default=False)
     can_update: bool = edgy.BooleanField(default=False)

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -224,7 +224,7 @@ async def test_model_crud():
     )
 
     user = await User.query.get()
-    assert isinstance(user.ipaddress, (ipaddress.IPv4Address, ipaddress.IPv6Address))
+    assert isinstance(user.ipaddress, ipaddress.IPv4Address | ipaddress.IPv6Address)
     assert user.password == "12345"
 
     assert user.url == "https://edgy.com/"


### PR DESCRIPTION
Due to dependencies (and test dependencies) switching to python >=3.10 we switch too.
Not switching would break tests.

Changes:
- Switch to python >=3.10
- Apply ruff formatting and use python 3.10 typing features
- Add missing typing_extensions dependency