### PR TITLE
fix $defs names

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ hide:
 - Admin with foreign keys as primary keys.
 - Revisioning with `auto_now` as primary key.
 - Fix crash with `auto_now_add` as primary key.
+- Fix "$defs" not matching def names. This fixes problems with enums which appear multiple times and reduces requests.
 
 ## 0.32.4
 

--- a/edgy/contrib/admin/views.py
+++ b/edgy/contrib/admin/views.py
@@ -45,22 +45,33 @@ class JSONSchemaView(Controller):
         with_defaults = request.query_params.get("cdefaults") == "true"
         model_name = request.path_params.get("name")
         reftemplate = "../{model}/json"
+        # add phase via f-string
         reftemplate = f"{reftemplate}?phase={phase}"
         if with_defaults:
             reftemplate = f"{reftemplate}&cdefaults=true"
         try:
-            with JSONResponse.with_transform_kwargs({"json_encode_fn": orjson.dumps}):
-                return JSONResponse(
-                    get_model_json_schema(
-                        model_name,
-                        include_callable_defaults=with_defaults,
-                        ref_template=reftemplate,
-                        no_check_admin_models=True,
-                        phase=phase,
-                    )
-                )
+            schema = get_model_json_schema(
+                model_name,
+                include_callable_defaults=with_defaults,
+                ref_template=reftemplate,
+                no_check_admin_models=True,
+                phase=phase,
+            )
         except LookupError:
             raise NotFound() from None
+        # fix defs being plain model/enum names
+        if "$defs" in schema:
+            new_defs = {}
+            for name, model in schema["$defs"].items():
+                # is already a matching definition
+                if "/" in name:
+                    new_defs[name] = model
+                else:
+                    # let's adapt the plain model/enum name
+                    new_defs[reftemplate.format(model=name)] = model
+            schema["$defs"] = new_defs
+        with JSONResponse.with_transform_kwargs({"json_encode_fn": orjson.dumps}):
+            return JSONResponse(schema)
 
 
 class AdminDashboard(AdminMixin, TemplateController):

--- a/tests/cli/main.py
+++ b/tests/cli/main.py
@@ -40,6 +40,15 @@ class User(edgy.StrictModel):
             registry = models
 
 
+class UserPK(edgy.StrictModel):
+    user = edgy.fields.ForeignKey("User", primary_key=True)
+    user2 = edgy.fields.ForeignKey("User", unique=True)
+
+    class Meta:
+        if os.environ.get("TEST_NO_REGISTRY_SET", "false") != "true":
+            registry = models
+
+
 class Group(edgy.StrictModel):
     name = edgy.fields.CharField(max_length=100)
     users = edgy.fields.ManyToMany(


### PR DESCRIPTION
Currently the $def names doesn't match the via ref_template created names. This is problematic because enums which appear multiple times are not found (are injected as $defs entry).

This PR fixes the problem by correcting the $defs entries in the views.