### PR TITLE
fix 404 status_code and fix json-editor with enums

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,8 @@ hide:
 ### Fixed
 
 - Status code when page in admin was not found.
+- Finally fix issues with json-editor ajax and enums by simply inlining all schemas and disabling ajax.
+- For the json schema view: don't use ref_template, it isn't well supported and leads to problems with enums.
 
 ## 0.32.5
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,12 @@ hide:
 
 # Release Notes
 
+## 0.32.6
+
+### Fixed
+
+- Status code when page in admin was not found.
+
 ## 0.32.5
 
 ### Fixed

--- a/edgy/__init__.py
+++ b/edgy/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.32.5"
+__version__ = "0.32.6"
 from typing import TYPE_CHECKING
 
 from ._monkay import Instance, create_monkay

--- a/edgy/contrib/admin/application.py
+++ b/edgy/contrib/admin/application.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from lilya import status
 from lilya.apps import ChildLilya, Lilya
 from lilya.middleware import DefineMiddleware
 from lilya.middleware.session_context import SessionContextMiddleware
@@ -27,9 +28,7 @@ templates.env.globals["getattr"] = getattr
 
 async def not_found(request: Request, exc: Exception) -> Any:
     return templates.get_template_response(
-        request,
-        "404.html",
-        context={"title": "Not Found"},
+        request, "404.html", context={"title": "Not Found"}, status_code=status.HTTP_404_NOT_FOUND
     )
 
 

--- a/edgy/contrib/admin/templates/admin/model_object_create.html
+++ b/edgy/contrib/admin/templates/admin/model_object_create.html
@@ -21,7 +21,11 @@
   </a>
 </div>
 <script>
-      var schema = JSON.parse('{{schema | safe}}')
+    var schema = JSON.parse('{{schema | safe}}')
+    const submit_form = document.getElementById("submit_form")
+    const submit_button = document.getElementById("submit_button")
+    const editor_data = document.getElementById("editor_data")
+    document.addEventListener("DOMContentLoaded", function() {
       var editor = new JSONEditor(document.getElementById('editor_holder'),{
         required_by_default: false,
         enable_array_copy: true,
@@ -34,9 +38,6 @@
       });
 
 
-      const submit_form = document.getElementById("submit_form")
-      const submit_button = document.getElementById("submit_button")
-      const editor_data = document.getElementById("editor_data")
       editor.on('change',function() {
         if(!editor.validate().length){
           editor_data.value = JSON.stringify(editor.getValue())
@@ -51,5 +52,6 @@
           ev.preventDefault()
         }
       })
+    })
 </script>
 {% endblock %}

--- a/edgy/contrib/admin/templates/admin/model_object_create.html
+++ b/edgy/contrib/admin/templates/admin/model_object_create.html
@@ -21,8 +21,8 @@
   </a>
 </div>
 <script>
+      var schema = JSON.parse('{{schema | safe}}')
       var editor = new JSONEditor(document.getElementById('editor_holder'),{
-        ajax: true,
         required_by_default: false,
         enable_array_copy: true,
         collapsed: true,
@@ -30,9 +30,7 @@
         object_layout: "table",
 
         // The schema for the editor
-        schema: {
-          $ref: "{{ url_prefix }}/models/{{ model_name }}/json?cdefaults=true&phase=create",
-        },
+        schema: schema,
       });
 
 

--- a/edgy/contrib/admin/templates/admin/model_object_edit.html
+++ b/edgy/contrib/admin/templates/admin/model_object_edit.html
@@ -20,8 +20,8 @@
 </div>
 <script>
       var startval = removeNull(JSON.parse('{{values_as_json | safe}}'))
+      var schema = JSON.parse('{{schema | safe}}')
       var editor = new JSONEditor(document.getElementById('editor_holder'),{
-        ajax: true,
         required_by_default: false,
         display_required_only: true,
         enable_array_copy: true,
@@ -30,9 +30,7 @@
         object_layout: "table",
 
         // The schema for the editor
-        schema: {
-          $ref: "{{ url_prefix }}/models/{{ model_name }}/json?cdefaults=true&phase=update",
-        },
+        schema: schema,
         startval: startval
       });
       const submit_form = document.getElementById("submit_form")

--- a/edgy/contrib/admin/templates/admin/model_object_edit.html
+++ b/edgy/contrib/admin/templates/admin/model_object_edit.html
@@ -19,8 +19,13 @@
     </a>
 </div>
 <script>
-      var startval = removeNull(JSON.parse('{{values_as_json | safe}}'))
-      var schema = JSON.parse('{{schema | safe}}')
+    var startval = removeNull(JSON.parse('{{values_as_json | safe}}'))
+    var schema = JSON.parse('{{schema | safe}}')
+    const submit_form = document.getElementById("submit_form")
+    const submit_button = document.getElementById("submit_button")
+    const reset_button = document.getElementById("reset_button")
+    const editor_data = document.getElementById("editor_data")
+    document.addEventListener("DOMContentLoaded", function() {
       var editor = new JSONEditor(document.getElementById('editor_holder'),{
         required_by_default: false,
         display_required_only: true,
@@ -33,10 +38,6 @@
         schema: schema,
         startval: startval
       });
-      const submit_form = document.getElementById("submit_form")
-      const submit_button = document.getElementById("submit_button")
-      const reset_button = document.getElementById("reset_button")
-      const editor_data = document.getElementById("editor_data")
       editor.on('change',function() {
         submit_button.setAttribute("disabled", "disabled")
         reset_button.setAttribute("disabled", "disabled")
@@ -51,14 +52,18 @@
           }
         }
       });
-      reset_button.addEventListener("click", ()=>{
-        editor.setValue(startval);
-      })
 
-      submit_form.addEventListener("submit", async function(ev){
-        if(editor.validate().length){
-          ev.preventDefault()
-        }
+      editor.on('ready', function() {
+        reset_button.addEventListener("click", ()=>{
+          editor.setValue(startval);
+        })
+
+        submit_form.addEventListener("submit", async function(ev){
+          if(editor.validate().length){
+            ev.preventDefault()
+          }
+        })
       })
+    })
 </script>
 {% endblock %}

--- a/edgy/contrib/admin/views.py
+++ b/edgy/contrib/admin/views.py
@@ -43,12 +43,12 @@ def get_registered_model(model: str) -> type[Model]:
 class JSONSchemaView(Controller):
     def get(self, request: Request) -> JSONResponse:
         phase = request.query_params.get("phase", "view")
-        with_defaults = request.query_params.get("cdefaults") == "true"
+        include_callable_defaults = request.query_params.get("cdefaults") == "true"
         model_name = request.path_params.get("name")
         try:
             schema = get_model_json_schema(
                 model_name,
-                include_callable_defaults=with_defaults,
+                include_callable_defaults=include_callable_defaults,
                 no_check_admin_models=True,
                 phase=phase,
             )
@@ -475,7 +475,8 @@ class ModelObjectEditView(BaseObjectView, AdminMixin, TemplateController):
             raise NotFound()
         context["title"] = f"Edit {instance}"
         context["object"] = instance
-        marshall = instance.get_admin_marshall_class(phase="view", for_schema=False)(instance)
+        context["schema"] = self.get_schema(model, phase="edit", include_callable_defaults=True)
+        marshall = instance.get_admin_marshall_class(phase="edit", for_schema=False)(instance)
         json_values = marshall.model_dump_json(exclude_none=True)
         context["values_as_json"] = (
             # replace dangerous chars like in jinja
@@ -622,12 +623,10 @@ class ModelObjectCreateView(BaseObjectView, AdminMixin, TemplateController):
         """
         context = await super().get_context_data(request, **kwargs)
         model_name: str = context["model_name"]
-
-        context.update(
-            {
-                "title": f"Create {model_name.capitalize()}",
-            }
+        context["schema"] = self.get_schema(
+            context["model"], phase="create", include_callable_defaults=True
         )
+        context["title"] = f"Create {model_name.capitalize()}"
         return context
 
     async def get(self, request: Request, **kwargs: Any) -> Any:


### PR DESCRIPTION
Changes
 - Status code when page in admin was not found.
- Finally fix issues with json-editor ajax and enums by simply inlining all schemas and disabling ajax.
- For the json schema view: don't use ref_template, it isn't well supported and leads to problems with enums.
 