### PR TITLE
fix for sqlalchemy change

### DIFF
--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -253,7 +253,12 @@ class BaseField(BaseFieldType, FieldInfo):
                 isnull = column == None  # noqa: E711
                 # is_(None) doesn't work for all fields
                 # column == None is required for IPAddressField, DateField, DateTimeField
-                return isnull if value else sqlalchemy.not_(isnull)
+                if value:
+                    # we use the native way
+                    return isnull
+                else:
+                    # emulation for special fields
+                    return sqlalchemy.not_(isnull)  # type: ignore
 
             # Handle various string containment and prefix/suffix matching operations.
             case (

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -258,6 +258,8 @@ class BaseField(BaseFieldType, FieldInfo):
                     return isnull
                 else:
                     # emulation for special fields
+                    # NOTE: tested by "tests/models/test_model_isnull.py",
+                    #       it is not solvable by just using sqla.true()/false()
                     return sqlalchemy.not_(isnull)  # type: ignore
 
             # Handle various string containment and prefix/suffix matching operations.


### PR DESCRIPTION
Problem:

sqlalchemy.not_  typing disallows bool. It is however the only solution to emulate isnull for some fields

Solution:

expanded and better documented handling. Usage of type: ignore

@tarsil please check carefully.