### PR TITLE
DecimalField: unlock free decimal places

### DIFF
--- a/docs/fields/index.md
+++ b/docs/fields/index.md
@@ -464,9 +464,25 @@ class MyModel(edgy.Model):
 * `gt` - An integer indicating the exclusive minimum.
 * `lte` - An integer indicating the maximum.
 * `lt` - An integer indicating the exclusive maximum.
-* `max_digits` - An integer indicating the total maximum digits. Optional.
-* `decimal_places` - An integer indicating the total decimal places.
 * `multiple_of` - An integer, float or decimal indicating the multiple of.
+* `max_digits` - An integer indicating the total maximum digits. Can be `None` for an unconstrained numeric mode if supported (postgres).
+* `decimal_places` - An integer indicating the total decimal places. Can be `None` for an unconstrained numeric mode if supported (postgres).
+                     Negative values are not supported despite some database systems define a logic for negative scales.
+
+**Warning**
+
+If `max_digits` and/or `decimal_places` is set to `None` the behavior differs among databse systems, some will even crash.
+It is basically just postgresql which supports an unconstrained numeric mode.
+However setting `max_digits` to `None` is better supported.
+
+Here a short excerpt about the behavior of different database systems:
+
+- `mysql` - `decimal_places` defaults to 0 when `None`. `max_digits` defaults to 10 when `None`.
+- `oracle` - `decimal_places` defaults to 0 when `None`.
+- `sqlite` - `decimal_places` defaults to 0 when `None`.
+
+Currently a `UserWarning` is issued for backward compatibility if no `max_digits` or no `decimal_places` are provided and as fallback `None` is used.
+This may changes in future depending how the unconstrained numeric mode support develops among database systems.
 
 #### EmailField
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 0.36.0
+
+### Changed
+
+- `DecimalField` supports now also `None` for `decimal_places` and `max_digits`.
+  It emits an `UserWarning` and falls back to `None` for each of both parameters not provided.
+
 ## 0.35.11
 
 ### Fixed

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,9 @@
 
 ## 0.36.0
 
+### Added
+ Support for unconstraint numeric mode of postgresql for `DecimalField`.
+
 ### Changed
 
 - `DecimalField` supports now also `None` for `decimal_places` and `max_digits`.

--- a/docs_src/reflection/autoreflection/datadriven.py
+++ b/docs_src/reflection/autoreflection/datadriven.py
@@ -5,7 +5,7 @@ reflected = edgy.Registry(database="sqlite:///webshopdb.sqlite")
 
 
 class Product(AutoReflectModel):
-    price = edgy.DecimalField(decimal_places=2)
+    price = edgy.DecimalField(decimal_places=2, max_digits=None)
     name = edgy.CharField(max_length=50)
 
     class Meta:

--- a/docs_src/reflection/autoreflection/datadriven_source.py
+++ b/docs_src/reflection/autoreflection/datadriven_source.py
@@ -14,7 +14,7 @@ class Trouser(edgy.Model):
 
 
 class Shoe(edgy.Model):
-    price = edgy.DecimalField(decimal_places=2)
+    price = edgy.DecimalField(decimal_places=2, max_digits=None)
     name = edgy.CharField(max_length=50)
     waterproof = edgy.BooleanField()
     size = edgy.FloatField()

--- a/docs_src/reflection/autoreflection/legacy.py
+++ b/docs_src/reflection/autoreflection/legacy.py
@@ -11,7 +11,7 @@ registry = edgy.Registry(
 
 
 class Product(AutoReflectModel):
-    price = edgy.DecimalField(decimal_places=2)
+    price = edgy.DecimalField(decimal_places=2, max_digits=None)
     name = edgy.CharField(max_length=50)
 
     class Meta:
@@ -21,7 +21,7 @@ class Product(AutoReflectModel):
 
 
 class AncientProduct(edgy.ReflectModel):
-    price = edgy.DecimalField(decimal_places=2)
+    price = edgy.DecimalField(decimal_places=2, max_digits=None)
     name = edgy.CharField(max_length=50)
     __using_schema__ = None
 

--- a/edgy/__init__.py
+++ b/edgy/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.35.11"
+__version__ = "0.36.0"
 from typing import TYPE_CHECKING
 
 from ._monkay import Instance, create_monkay

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -26,6 +26,7 @@ from edgy.core.db.fields.base import Field
 from edgy.core.db.fields.factories import FieldFactory
 from edgy.core.db.fields.types import BaseFieldType
 from edgy.exceptions import FieldDefinitionError
+from edgy.types import Undefined
 
 from .mixins import AutoNowMixin as _AutoNowMixin
 from .mixins import IncrementOnSaveBaseField, TimezonedField
@@ -415,13 +416,13 @@ class DecimalField(FieldFactory, decimal.Decimal):
     def __new__(
         cls,
         *,
+        decimal_places: int | None = cast(Any, Undefined),
+        max_digits: int | None = cast(Any, Undefined),
         ge: int | float | decimal.Decimal | None = None,
         gt: int | float | decimal.Decimal | None = None,
         le: int | float | decimal.Decimal | None = None,
         lt: int | float | decimal.Decimal | None = None,
         multiple_of: int | decimal.Decimal | None = None,
-        max_digits: int | None = None,
-        decimal_places: int | None = None,
         **kwargs: Any,
     ) -> BaseFieldType:
         """
@@ -453,13 +454,36 @@ class DecimalField(FieldFactory, decimal.Decimal):
         """
         Validates the keyword arguments for a DecimalField.
 
-        Ensures that 'decimal_places' is provided and is not negative.
+        Ensures that 'decimal_places' and 'max_digits' are provided and is not negative.
         """
         super().validate(kwargs)
 
         decimal_places = kwargs.get("decimal_places")
-        if decimal_places is None or decimal_places < 0:
-            raise FieldDefinitionError("decimal_places are required for DecimalField")
+        if decimal_places is Undefined:
+            decimal_places = kwargs["decimal_places"] = None
+            warnings.warn(
+                (
+                    "`decimal_places` was not specified, fall back to None (free floating). "
+                    "This is maybe not supported by your db system and/or has an unusual fallback."
+                ),
+                category=UserWarning,
+                stacklevel=4,
+            )
+        if decimal_places is not None and decimal_places < 0:
+            raise FieldDefinitionError("`decimal_places` should not be negative")
+        max_digits = kwargs.get("max_digits")
+        if max_digits is Undefined:
+            max_digits = kwargs["max_digits"] = None
+            warnings.warn(
+                (
+                    "`max_digits` was not specified, fall back to None (free floating). "
+                    "This is maybe not supported by your db system and/or has an unusual fallback."
+                ),
+                category=UserWarning,
+                stacklevel=4,
+            )
+        if max_digits is not None and max_digits < 0:
+            raise FieldDefinitionError("`max_digits` should not be negative")
 
     @classmethod
     def operator_to_clause(

--- a/edgy/core/db/fields/types.py
+++ b/edgy/core/db/fields/types.py
@@ -125,6 +125,8 @@ class BaseFieldType(BaseFieldDefinitions, ABC):
     generating SQLAlchemy columns, cleaning/converting values, and more.
     """
 
+    operator_mapping: dict[str, str]
+
     @abstractmethod
     def is_required(self) -> bool:
         """

--- a/tests/cli/main_server_defaults.py
+++ b/tests/cli/main_server_defaults.py
@@ -27,7 +27,7 @@ class User(edgy.StrictModel):
         active = edgy.fields.BooleanField(default=True)
         is_staff = edgy.fields.BooleanField(default=False)
         age = edgy.fields.IntegerField(default=18)
-        size = edgy.fields.DecimalField(default="1.8", decimal_places=2)
+        size = edgy.fields.DecimalField(default="1.8", decimal_places=2, max_digits=None)
         blob = edgy.fields.BinaryField(default=b"abc")
         # needs special library for alembic enum migrations
         # user_type = edgy.fields.ChoiceField(choices=UserTypeEnum, default=UserTypeEnum.INTERNAL)

--- a/tests/fields/test_decimal_field.py
+++ b/tests/fields/test_decimal_field.py
@@ -7,6 +7,7 @@ import edgy
 from edgy.core.db import fields
 from edgy.exceptions import FieldDefinitionError
 from edgy.testclient import DatabaseTestClient
+from edgy.types import Undefined
 from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
@@ -38,6 +39,9 @@ class Employee(edgy.StrictModel):
     salary: decimal.Decimal = fields.DecimalField(
         max_digits=9, decimal_places=2, null=True, strict=False
     )
+    salary_btc: decimal.Decimal = fields.DecimalField(
+        max_digits=None, decimal_places=None, null=True
+    )
 
     class Meta:
         registry = models
@@ -47,9 +51,12 @@ class Employee(edgy.StrictModel):
 
 
 async def test_can_use_decimal_field():
-    employee = await Employee.query.create(name="Edgy", salary=150000)
+    employee = await Employee.query.create(
+        name="Edgy", salary=150000, salary_btc=decimal.Decimal("10.0002")
+    )
 
     assert employee.salary == 150000
+    assert employee.salary_btc == decimal.Decimal("10.0002")
 
 
 async def test_can_use_decimal_field_raise_exception():
@@ -57,36 +64,29 @@ async def test_can_use_decimal_field_raise_exception():
         await Employee.query.create(name="Another", salary=15000000)
 
 
-async def test_raises_field_definition_error_missing_decimal_places():
-    with pytest.raises(FieldDefinitionError):  # noqa
+@pytest.mark.parametrize(
+    "max_digits,decimal_places", [(1, Undefined), (Undefined, 1), (Undefined, Undefined)]
+)
+async def test_warn_field_definition_missing_decimal_places(max_digits, decimal_places):
+    with pytest.warns(UserWarning):
 
         class AnotherEmployee(edgy.Model):
-            name: str = fields.CharField(max_length=255, null=True)
-            date_of_birth: date = fields.DateField(auto_now=True)
-            salary: decimal.Decimal = fields.DecimalField(max_digits=9, null=True)
+            salary: decimal.Decimal = fields.DecimalField(
+                max_digits=max_digits, decimal_places=decimal_places, null=True
+            )
 
             class Meta:
-                registry = models
-
-            def __str__(self):
-                return f"Employee: {self.name}, Age: {self.date_of_birth}, Salary: {self.salary}"
+                abstract = True
 
 
-@pytest.mark.parametrize(
-    "max_digits,decimal_places", [(-1, None), (None, -2), (None, None), (-1, -2)]
-)
+@pytest.mark.parametrize("max_digits,decimal_places", [(-1, None), (None, -2)])
 async def test_raises_field_definition_error_on_values(max_digits, decimal_places):
     with pytest.raises(FieldDefinitionError):  # noqa
 
         class AnotherEmployee(edgy.Model):
-            name: str = fields.CharField(max_length=255, null=True)
-            date_of_birth: date = fields.DateField(auto_now=True)
             salary: decimal.Decimal = fields.DecimalField(
-                decimal_places=decimal_places, max_digits=max_digits, null=True
+                decimal_places=decimal_places, max_digits=-1, null=True
             )
 
             class Meta:
-                registry = models
-
-            def __str__(self):
-                return f"Employee: {self.name}, Age: {self.date_of_birth}, Salary: {self.salary}"
+                abstract = True

--- a/tests/fields/test_indb_updates.py
+++ b/tests/fields/test_indb_updates.py
@@ -12,7 +12,7 @@ models = edgy.Registry(database=edgy.Database(database, force_rollback=True))
 
 
 class MyModel(edgy.StrictModel):
-    price = edgy.DecimalField(decimal_places=2)
+    price = edgy.DecimalField(decimal_places=2, max_digits=None)
     name: str = edgy.CharField(max_length=255)
 
     class Meta:


### PR DESCRIPTION
Changes:
- Support for unconstraint numeric mode of postgresql for `DecimalField`.
- fixes for preventing negative values in `decimal_places` and `max_digits`
- bump version