### PR TITLE
speedup relation operations, expose ignore_conflicts for bulk_create and resolve cubic.ai pointed issues

### DIFF
--- a/docs/queries/bulk.md
+++ b/docs/queries/bulk.md
@@ -32,6 +32,27 @@ assert not returned_objs[0].can_load  # the pks are incomplete
 assert returned_objs[1].can_load  # the pks are complete
 ```
 
+#### `ignore_conflicts`
+
+When the database is compatible and we don't need the returned values, we can use `ignore_conflicts=True` instead `bulk_get_or_create`.
+Assuming email is the primary key, we can do something like this:
+
+```python
+await User.query.bulk_create([
+    {"email": "bar@foo.com", "first_name": "Bar", "last_name": "Foo", "is_active": True},
+    ...
+], ignore_conflicts=True)
+
+# is ignored
+await User.query.bulk_create([
+    {"email": "bar@foo.com", "first_name": "Bar", "last_name": "Foo", "is_active": False},
+    ...
+], ignore_conflicts=True)
+```
+
+What does it do? Simply skipping rows which would cause a conflict. It is maybe not as performant because single inserts are issued.
+Deduped objects are returned as `None` for `ignore_conflicts=True`.
+
 ### Bulk update
 
 When you need to update many instances in one go, or **in bulk**. With `update_fields` you can define the fields updated.
@@ -73,7 +94,6 @@ await User.query.bulk_get_or_create([
     {"email": "bar@foo.com", "first_name": "Bar", "last_name": "Foo", "is_active": True},
 ], unique_fields=["email"])
 
-
 users = await User.query.all() # 2 as total
 ```
 
@@ -109,9 +129,22 @@ assert not results[1][1]  # updated
 users = await User.query.all() # 2 as total
 ```
 
-By default `unique_fields` are the primary keys or columns and `update_fields` are all the fields defined in the model class.
+By default `unique_fields` are the primary keys and columns and `update_fields` are all the fields defined in the model class.
+Note that `None` can be returned in case of input that doesn't contain enough information to generate an update (notably: the instance must be loadable).
+
+#### What is the difference to `bulk_update`?
+
+- It is possible to define `unique_fields`.
+- It can create instances on the fly, not just update them.
+- It can return `None` for instances which couldn't be inserted but have not enough information to generate an update.
 
 ## Advanced Topics
+
+### `unique_fields`
+
+`unique_fields` are explicit provided fields or database columns for deduplication. They are also used for the retrieval of instances.
+Caching and deduplication only work if an input object has all `unique_fields` defined.
+When left on `None` the primary keys and columns are used for `unique_fields`.
 
 ### `resolve_embed`
 
@@ -119,5 +152,15 @@ By default `embed_parent` isn't honored for bulk operations. If you need to reso
 `embed_target=True`.
 This mode has two effects:
 
-- It is ensured that all returned instances `can_load` when `embed_parent` is active. If necessary, it will issue an `real_save`.
+- It is ensured that all returned instances `can_load` when `embed_parent` is active. If necessary, it will issue serialized single inserts.
 - The embedding is resolved if `embed_parent` is set. You get the child with the embedded parent.
+
+### loadable
+
+An instances is loadable if its `can_load` property signals it is loadable. For dictionaries the on the fly generated instance is used.
+But if you provide a correct instance you can do some tricks:
+
+You can set the `identifying_db_fields` so a provided instance becomes suddenly loadable and for `bulk_update_or_create` the update succeeds instead returning `None`.
+Other effects are that `resolve_embed` succeeds for such crafted instances.
+
+It is planned to add signals so you will be able to manipulate the immediate instances via signals so you can do this trick also for dict inputs.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -3,9 +3,11 @@
 ## 0.36.0
 
 ### Added
+
 - Support for unconstraint numeric mode of postgresql for `DecimalField`.
-- Add `bulk_update_or_create` operation to the queryset.
-- Add `update_embed_parent` operation to the queryset.
+- Add the `bulk_update_or_create` operation to querysets.
+- Add the `update_embed_parent` operation to querysets.
+- Add the `ignore_conflicts` parameter to `bulk_create`.
 
 ### Changed
 
@@ -14,8 +16,20 @@
 - `bulk_get_or_create` mirrors now `get_or_create` and returns a list with `(instance, created)` tuples. The returned instances are not always complete.
 - `CombinedQuerySet` is moved from `edgy.core.db.queryset.mixins.combined` to `edgy.core.db.queryset.combined`. It is not a mixin.
 - The bulk operations are moved to a mixin.
-- The typings changed for QuerySet: it is now Generic.
+- The typings changed for QuerySet: it is now a `Generic`.
 - The typings changed for QuerySetType: `EdgyEmbedTarget` and `EdgyModel` (the queryset model) are switched in the `Generic` definition.
+- Bulk operations are now keywords only (except the first `objs` parameter).
+- Dedupe `bulk_create`, `bulk_get_or_create`, and `bulk_update_or_create` inputs.
+
+### Fixed
+
+- Relations did not use the tenancy/used schema properly when querying.
+- Bulk operations with reflected fields did not always work properly.
+- `run_concurrently` now properly cleans up not executed coroutines in case of an error.
+
+### Removed
+
+- Private `batched` implementation for `run_concurrently`.
 
 ### Breaking
 

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from edgy.core.connection.database import Database
     from edgy.core.db.fields.types import FIELD_CONTEXT_TYPE, BaseFieldType
     from edgy.core.db.models.model import Model
-    from edgy.core.db.querysets.queryset import QuerySet
+    from edgy.core.db.querysets.types import QuerySetType
 
 
 _empty = cast(set[str], frozenset())
@@ -142,6 +142,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
             kwargs,
             phase=__phase__,
             instance=self,
+            model_instance=self,
             drop_extra_kwargs=__drop_extra_kwargs__,
         )
         # Remove temporary _db_loaded and _db_deleted from __dict__ before super().__init__.
@@ -194,7 +195,8 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         cls,
         kwargs: dict[str, Any],
         phase: str = "",
-        instance: BaseModelType | None = None,
+        instance: BaseModelType | QuerySetType | None = None,
+        model_instance: BaseModelType | None = None,
         drop_extra_kwargs: bool = False,
     ) -> Any:
         """
@@ -203,7 +205,8 @@ class EdgyBaseModel(BaseModel, BaseModelType):
 
         :param kwargs: The input keyword arguments to transform.
         :param phase: The current phase of transformation.
-        :param instance: The model instance being transformed.
+        :param instance: The instance being transformed.
+        :param model_instance: The model instance being transformed.
         :param drop_extra_kwargs: If True, extra kwargs not defined in model fields
                                    will be dropped.
         :return: The transformed keyword arguments.
@@ -216,7 +219,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         fields = cls.meta.fields
         # Set context variables for the current instance, model instance, and phase.
         token = CURRENT_INSTANCE.set(instance)
-        token2 = CURRENT_MODEL_INSTANCE.set(instance)
+        token2 = CURRENT_MODEL_INSTANCE.set(model_instance)
         token3 = CURRENT_PHASE.set(phase)
         try:
             # Phase 1: Apply input modifying fields.
@@ -460,7 +463,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         is_update: bool = False,
         is_partial: bool = False,
         phase: str = "",
-        instance: BaseModelType | QuerySet | None = None,
+        instance: BaseModelType | QuerySetType | None = None,
         model_instance: BaseModelType | None = None,
         evaluate_values: bool = False,
     ) -> dict[str, Any]:

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -262,7 +262,7 @@ class FieldToColumns(UserDict, dict[str, Sequence[sqlalchemy.Column]]):
 
 class FieldToColumnNames(FieldToColumns, dict[str, frozenset[str]]):
     """
-    Manages the mapping from field names to their corresponding SQLAlchemy column names.
+    Manages the mapping from field names to their corresponding SQLAlchemy column key names.
     """
 
     def __getitem__(self, name: str) -> frozenset[str]:
@@ -277,8 +277,8 @@ class FieldToColumnNames(FieldToColumns, dict[str, frozenset[str]]):
         """
         if name in self.data:
             return cast(frozenset[str], self.data[name])
-        column_names = frozenset(column.key for column in self.meta.field_to_columns[name])
-        result = self.data[name] = column_names
+        column_keys = frozenset(column.key for column in self.meta.field_to_columns[name])
+        result = self.data[name] = column_keys
         return result
 
 
@@ -367,10 +367,55 @@ class ColumnsToField(UserDict, dict[str, str]):
         return super().__iter__()
 
 
+class ColumnsRemapping(UserDict, dict[str, str]):
+    """
+    Renames column.name to column.key
+    """
+
+    meta: MetaInfo
+    _init: bool
+
+    def __init__(self, meta: MetaInfo):
+        """
+        Initializes the ColumnsToField object.
+
+        Args:
+            meta: The MetaInfo object associated with these mappings.
+        """
+        self.meta = meta
+        self._init = False
+        super().__init__()
+
+    def init(self) -> None:
+        """
+        Initializes the mapping from column names to field names.
+        This method ensures that the mapping is built only once.
+
+        Raises:
+            ValueError: If a column name collision is detected.
+        """
+        if not self._init:
+            self._init = True
+            _columns_remapping: dict[str, str] = {}
+            for field_name in self.meta.fields:
+                # init structure
+                columns = self.meta.field_to_columns[field_name]
+                for column in columns:
+                    if column.key != column.name:
+                        _columns_remapping[column.name] = column.key
+            self.data.update(_columns_remapping)
+
+    def __getattribute__(self, name: str) -> Any:
+        if name not in {"init", "_init", "data"}:
+            self.init()
+        return object.__getattribute__(self, name)
+
+
 _trigger_attributes_fields_MetaInfo: set[str] = {
     "field_to_columns",
     "field_to_column_names",
     "columns_to_field",
+    "columns_remapping",
 }
 
 _trigger_attributes_field_stats_MetaInfo: set[str] = {
@@ -420,6 +465,7 @@ class MetaInfo:
         "field_to_columns",
         "field_to_column_names",
         "columns_to_field",
+        "columns_remapping",
         "special_getter_fields",
         "excluded_fields",
         "secret_fields",
@@ -449,6 +495,7 @@ class MetaInfo:
     field_to_columns: FieldToColumns
     field_to_column_names: FieldToColumnNames
     columns_to_field: ColumnsToField
+    columns_remapping: ColumnsRemapping
     unique_together: list[str | tuple | UniqueConstraint]
     indexes: list[Index]
     constraints: list[sqlalchemy.Constraint]
@@ -661,6 +708,7 @@ class MetaInfo:
         self.field_to_columns = FieldToColumns(self)
         self.field_to_column_names = FieldToColumnNames(self)
         self.columns_to_field = ColumnsToField(self)
+        self.columns_remapping = ColumnsRemapping(self)
         if self.model is not None:
             self.model.model_rebuild(force=True)
         self._fields_are_initialized = True
@@ -706,6 +754,7 @@ class MetaInfo:
                 "field_to_columns",
                 "field_to_column_names",
                 "columns_to_field",
+                "columns_remapping",
             ):
                 with contextlib.suppress(AttributeError):
                     delattr(self, attr)

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -775,7 +775,7 @@ class DatabaseMixin:
             is_partial=is_partial,
             is_update=True,
             phase="prepare_update",
-            instance=self,
+            instance=instance,
             model_instance=self,
             evaluate_values=True,
         )
@@ -800,7 +800,9 @@ class DatabaseMixin:
                 row_count = cast(int, await database.execute(expression))
 
             # Update the model instance.
-            new_kwargs = self.transform_input(column_values, phase="post_update", instance=self)
+            new_kwargs = self.transform_input(
+                column_values, phase="post_update", instance=instance, model_instance=self
+            )
             self.__dict__.update(new_kwargs)
 
         # updates aren't required to change the db, they can also just affect the meta fields
@@ -809,6 +811,7 @@ class DatabaseMixin:
         if column_values or kwargs:
             # Ensure on access refresh the results is active
             self._db_deleted = False if row_count is None else row_count == 0
+            # TODO: maybe can be unchanged in case of not self._db_deleted
             self._db_loaded = False
         await post_fn(
             real_class,
@@ -997,7 +1000,11 @@ class DatabaseMixin:
             self._db_loaded = True
             raise ObjectNotFound("row does not exist anymore")
         # Update the instance.
-        self.__dict__.update(self.transform_input(dict(row._mapping), phase="load", instance=self))
+        self.__dict__.update(
+            self.transform_input(
+                dict(row._mapping), phase="load", instance=self, model_instance=self
+            )
+        )
         self._db_deleted = False
         self._db_loaded = True
 
@@ -1071,23 +1078,47 @@ class DatabaseMixin:
             values=kwargs,
         )
         check_db_connection(self.database, stacklevel=4)
-        async with self.database as database, database.transaction():
+        table: sqlalchemy.Table = self.table
+        async with (
+            self.database as database,
+            database.connection() as connection,
+            connection.transaction(),
+        ):
+            insert_returning = database.engine.dialect.insert_returning
             # can update column_values
             column_values.update(
                 await self.execute_pre_save_hooks(column_values, kwargs, is_update=False)
             )
-            expression = self.table.insert().values(**column_values)
-            autoincrement_value = await database.execute(expression)
-        # sqlalchemy supports only one autoincrement column
-        if autoincrement_value:
-            column = self.table.autoincrement_column
-            if column is not None and hasattr(autoincrement_value, "_mapping"):
-                autoincrement_value = autoincrement_value._mapping[column.key]
-            # can be explicit set, which causes an invalid value returned
-            if column is not None and column.key not in column_values:
-                column_values[column.key] = autoincrement_value
+            # we can't just use label. If the column.key has an invalid name for the db
+            # we would cause an foo AS invalid clause
+            returning = (
+                [
+                    col
+                    for col in table.columns.values()
+                    if col.key not in column_values
+                    and (col.server_default is not None or col.autoincrement)
+                ]
+                if insert_returning
+                else []
+            )
 
-        new_kwargs = self.transform_input(column_values, phase="post_insert", instance=self)
+            if returning:
+                expression: Any = table.insert().values(**column_values).returning(*returning)
+                returned_mapping = dict((await connection.fetch_one(expression))._mapping)
+            else:
+                expression = table.insert().values(**column_values)
+                pk_values = await connection.execute(expression)
+                returned_mapping = (
+                    dict(pk_values._mapping) if hasattr(pk_values, "_mapping") else {}
+                )
+        for col_name, col_key in self.meta.columns_remapping.items():
+            if col_name in returned_mapping:
+                returned_mapping[col_key] = returned_mapping.pop(col_name)
+        column_values.update(returned_mapping)
+
+        new_kwargs = self.transform_input(
+            column_values, phase="post_insert", instance=instance, model_instance=self
+        )
         self.__dict__.update(new_kwargs)
 
         if self.meta.post_save_fields:

--- a/edgy/core/db/models/mixins/row.py
+++ b/edgy/core/db/models/mixins/row.py
@@ -221,10 +221,10 @@ class ModelRowMixin:
 
             # Collect foreign key column values from the row mapping.
             for column_name in columns_to_check:
-                column = getattr(table_columns, column_name, None)
-                if column_name is None:
+                if (column := table_columns.get(column_name)) is None:
                     continue
-                columnkeyhash = column_name
+                # FIXME: should be column.name because it is visible to database
+                columnkeyhash = column.key
                 if prefix:
                     columnkeyhash = f"{tables_and_models[prefix][0].name}_{column.key}"
 

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -55,7 +55,7 @@ class BaseQuerySet(
     TenancyMixin,
     QuerySetPropsMixin,
     PrefetchMixin,
-    BulkMixin,
+    BulkMixin[EdgyModel],
     QuerySetType[EdgyModel, EdgyEmbedTarget],
     Generic[EdgyModel, EdgyEmbedTarget],
 ):
@@ -431,13 +431,15 @@ class BaseQuerySet(
         return tables_and_models[crawl_result.forward_path][0].columns[crawl_result.field_name]
 
     async def _embed_parent_in_result(
-        self, result: EdgyModel | Awaitable[EdgyModel]
-    ) -> tuple[EdgyModel, EdgyEmbedTarget]:
+        self, result: EdgyModel | Awaitable[EdgyModel] | None
+    ) -> tuple[EdgyModel, EdgyEmbedTarget] | tuple[None, None]:
         """
         This is a result transformation, called by the Parser.
         """
         if isawaitable(result):
             result = await result
+        if result is None:
+            return None, None
         if not self.embed_parent:
             return result, cast(EdgyEmbedTarget, result)
         token = MODEL_GETATTR_BEHAVIOR.set("coro")

--- a/edgy/core/db/querysets/compiler.py
+++ b/edgy/core/db/querysets/compiler.py
@@ -173,7 +173,8 @@ class QueryCompiler:
                 if not prefix:
                     columns_and_extra.append(column)
                 else:
-                    columns_and_extra.append(column.label(f"{table.name}_{column_key}"))
+                    # FIXME: label is visible to database, so we should use the column.name
+                    columns_and_extra.append(column.label(f"{table.name}_{column.key}"))
 
         assert columns_and_extra, "no columns or extra_select specified"
         return columns_and_extra

--- a/edgy/core/db/querysets/mixins/bulk.py
+++ b/edgy/core/db/querysets/mixins/bulk.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
+import asyncio
 import warnings
 from collections.abc import (
     Awaitable,
+    Collection,
     Iterable,
     Sequence,
 )
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Generic, cast
 
 import orjson
 import sqlalchemy
+from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 
 from edgy.core.db.context_vars import CURRENT_INSTANCE
 from edgy.core.utils.concurrency import run_concurrently
@@ -28,161 +26,233 @@ from ..types import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
+    from databasez.core.connection import Connection
+
+    from edgy.core.db.models.types import BaseModelType
     from edgy.core.db.querysets.queryset import QuerySet
 
 _empty_set = cast(set[Any], frozenset())
 
 
-def _extract_unique_lookup_key(obj: Any, unique_fields: Iterable[str]) -> tuple | None:
+def _getter_dict(obj: Any, key: str) -> Any:
+    return obj[key]
+
+
+def _extract_unique_lookup_key(
+    obj: Any, unique_fields: Iterable[str], *, no_load: bool = False
+) -> tuple | None:
     """
     Extracts a unique lookup key from an object or dictionary.
     (Helper function, stays in base)
     """
+    if obj is None:
+        return None
     lookup_key = []
     if isinstance(obj, dict):
-        for field in unique_fields:
-            if field not in obj:
-                return None
-            value = obj[field]
-            lookup_key.append(
-                orjson.dumps(value, option=orjson.OPT_SORT_KEYS)
-                if isinstance(value, dict | list)
-                else value
-            )
+        _getter: Any = _getter_dict
+    elif no_load:
+        _getter = object.__getattribute__
     else:
-        for field in unique_fields:
-            if not hasattr(obj, field):
+        _getter = getattr
+    for field in unique_fields:
+        try:
+            value = _getter(obj, field)
+        except (KeyError, AttributeError):
+            return None
+        if isinstance(value, BaseModel):
+            if not getattr(value, "can_load", False):
                 return None
-            value = getattr(obj, field)
-            lookup_key.append(
-                orjson.dumps(value, option=orjson.OPT_SORT_KEYS)
-                if isinstance(value, dict | list)
-                else value
+            value = orjson.dumps(
+                value.model_dump(mode="json", include=value.pknames), option=orjson.OPT_SORT_KEYS
             )
+        elif isinstance(value, dict | list):
+            value = orjson.dumps(value, option=orjson.OPT_SORT_KEYS)
+        lookup_key.append(value)
     return tuple(lookup_key)
 
 
-class BulkMixin:
+class BulkMixin(Generic[EdgyModel]):
+    model_class: type[EdgyModel]
+
     async def _bulk_get_update_or_create(
-        self: QuerySet,
+        self,
         *,
         objs: Iterable[dict[str, Any] | EdgyModel],
         resolve_embed: bool,
-        unique_fields: set[str] = _empty_set,
-        unique_columns: Sequence[str],
+        unique_fields: Collection[str] = _empty_set,
+        unique_columns: Collection[str],
         update_fields: set[str] = _empty_set,
+        create: bool,
         update: bool,
         retrieve: bool,
-    ) -> list[tuple[EdgyModel, bool]] | list[tuple[EdgyEmbedTarget, bool]]:
+        ignore_create_conflicts: bool = False,
+        none_on_existing: bool = False,
+        used_instance: BaseModelType | QuerySet | None = None,
+    ) -> Sequence[tuple[EdgyModel | None, bool]] | Sequence[tuple[EdgyEmbedTarget | None, bool]]:
         """
         Bulk gets, updates or creates records in a table.
 
         If records exist based on unique fields, they are retrieved.
         Otherwise, new records are created.
 
-        Args:
+        Kwargs:
             objs (Iterable[Union[dict[str, Any], EdgyModel]]): A list of objects or dictionaries.
-            unique_fields (set[str]): Fields that determine uniqueness.
-            unique_columns (Sequence[str]): Columns that determine uniqueness.
+            unique_fields (Collection[str]): Explicit set fields or columns that determine uniqueness.
+            unique_columns (Collection[str]): Resolved columns that determine uniqueness.
             update_fields (set[str]): Fields which are updated.
-            update (bool): Update retrieved objects.
+            create (bool): Create objects.
+            update (bool): Update retrieved objects or generate updates.
             retrieve (bool): Retrieve objects. Otherwise update only path.
+            ignore_create_conflicts (bool): Ignore conflicting entries on insert.
+            none_on_existing (bool): When in existing and a collision was found return None instead.
+            used_instance (BaseModelType | QuerySet | None): Use this value as instance.
 
         Returns:
-            tuple[list[EdgyModel], list[bool]]: A list of retrieved or newly created objects.
-                                                Second list is True if it was an update.
+           Sequence[tuple[EdgyModel | None, bool]] | Sequence[tuple[EdgyEmbedTarget | None, bool]]:
+               A list of retrieved or newly created objects. Second entry is True if instance was created.
         """
         queryset: QuerySet = self._clone()
-        create_objs: list[EdgyModel] = []
+        create_params: list[tuple[EdgyModel, int, set[str]]] = []
         update_objs: list[EdgyModel] = []
+        skip_post_save: set[int] = set()
+        used_instance = cast("QuerySet", self) if used_instance is None else used_instance
 
-        returned_objs_with_created: list[tuple[EdgyModel, bool]] = []
-        create_skip_post_save: set[int] = set()
+        returned_objs_with_created_with_null: list[tuple[EdgyModel | None, bool]] = []
         existing_records: dict[tuple, EdgyModel] = {}
+        _unique_cols_and_update_fields: set = update_fields.union(unique_columns)
+        can_result_cache = not self.embed_parent
         _update_columns: set[str] = {
             col
             for field in update_fields
             for col in queryset.model_class.meta.field_to_column_names[field]
         }
+        concurrent_limit = 1 if getattr(queryset.database, "force_rollback", False) else None
         model_class = self.model_class
+        proxy_model_class = cast("type[EdgyModel]", model_class.proxy_model)
+
+        def _add_create_obj(
+            obj: EdgyModel | dict,
+            pos: int,
+        ) -> tuple[EdgyModel | None, bool]:
+            lookup_key = _extract_unique_lookup_key(
+                obj, unique_fields or unique_columns, no_load=not unique_fields
+            )
+            if lookup_key and lookup_key in existing_records:
+                return (None if none_on_existing else existing_records[lookup_key], False)
+            created: EdgyModel
+            if isinstance(obj, dict):
+                created = model_class(
+                    **{k: v for k, v in obj.items() if k in model_class.meta.fields}
+                )
+                create_params.append((created, pos, set(obj.keys())))
+            else:
+                created = obj
+                create_params.append((created, pos, set(obj.meta.fields.keys())))
+            if lookup_key:
+                existing_records[lookup_key] = created
+            return created, True
+
         if retrieve:
+            # IMPROVEMENT TODO: move query part into a transaction and issue at best just one database query
             free_unique_columns: set[str] = {
                 colname
                 for colname in unique_columns
                 if colname not in model_class.meta.columns_to_field
             }
 
-            if unique_fields or free_unique_columns:
+            if unique_columns:
 
-                async def _iterate_retrieve(obj: EdgyModel | dict) -> tuple[EdgyModel, bool]:
-                    if not isinstance(obj, (model_class, dict)):
+                async def _iterate_retrieve(
+                    obj: EdgyModel | dict, pos: int
+                ) -> tuple[EdgyModel | None, bool]:
+                    if not isinstance(obj, (model_class, proxy_model_class, dict)):
                         raise ValueError(
                             f"Instance provided of wrong type: `{type(obj)!r}` required: `{model_class!r}`."
                         )
+                    # try deduplicating before issuing a db query
+                    lookup_key_precheck = (
+                        None
+                        if update
+                        else _extract_unique_lookup_key(
+                            obj, unique_fields or unique_columns, no_load=True
+                        )
+                    )
+                    if lookup_key_precheck and lookup_key_precheck in existing_records:
+                        return existing_records[lookup_key_precheck], False
                     filter_kwargs = {}
                     dict_fields = {}
+                    incomplete = False
                     if isinstance(obj, dict):
                         for field in unique_fields:
-                            if field in obj:
+                            if field not in obj:
+                                incomplete = True
+                            else:
                                 value = obj[field]
                                 if isinstance(value, dict):
                                     dict_fields[field] = value
                                 else:
                                     filter_kwargs[field] = value
                         for column in free_unique_columns:
-                            if column in obj:
+                            if column not in obj:
+                                incomplete = True
+                            else:
                                 value = obj[column]
                                 assert not isinstance(value, dict)
                                 filter_kwargs[column] = value
                     else:
                         for field in unique_fields:
-                            value = getattr(obj, field)
-                            if isinstance(value, dict):
-                                dict_fields[field] = value
+                            if not hasattr(obj, field):
+                                incomplete = True
                             else:
-                                filter_kwargs[field] = value
+                                value = getattr(obj, field)
+                                if isinstance(value, dict):
+                                    dict_fields[field] = value
+                                else:
+                                    filter_kwargs[field] = value
                         for column in free_unique_columns:
-                            if hasattr(obj, column):
+                            if not hasattr(obj, column):
+                                incomplete = True
+                            else:
                                 value = getattr(obj, column)
                                 assert not isinstance(value, dict)
                                 filter_kwargs[column] = value
-                    lookup_key = _extract_unique_lookup_key(obj, unique_fields)
-                    if lookup_key is not None and lookup_key in existing_records:
+                    lookup_key = _extract_unique_lookup_key(
+                        obj, unique_fields or unique_columns, no_load=not unique_fields
+                    )
+                    if lookup_key and lookup_key in existing_records:
                         return existing_records[lookup_key], False
                     found_obj: EdgyModel | None = None
-                    # This fixes edgy-guardian bug when using databasez.iterate indirectly and
-                    # is safe in case force_rollback is active
-                    # Models can also issue loads by accessing attrs for building unique_fields
-                    # For limiting use something like QuerySet.limit(100).bulk_get_or_create(...)
-                    for instance in await queryset.update_embed_parent(None).filter(
-                        **filter_kwargs
-                    ):
-                        if all(
-                            getattr(instance, k) == expected for k, expected in dict_fields.items()
+                    # prevent queries with user selected unique_fields/columns
+                    if not incomplete:
+                        # Using an array fixed an edgy-guardian bug when using databasez.iterate indirectly and
+                        # is safe in case force_rollback is active
+                        # Models can also issue loads by accessing attrs for building unique_fields
+                        # For limiting use something like QuerySet.limit(100).bulk_get_or_create(...)
+                        for instance in await queryset.update_embed_parent(None).filter(
+                            **filter_kwargs
                         ):
-                            lookup_key = _extract_unique_lookup_key(instance, unique_fields)
-                            assert lookup_key is not None, (
-                                "invalid fields/attributes in unique_fields"
-                            )
-                            if lookup_key not in existing_records:
-                                found_obj = existing_records[lookup_key] = instance
-                            else:
-                                found_obj = existing_records[lookup_key]
-                            break
-                    if found_obj is None:
-                        created: EdgyModel
-                        if isinstance(obj, dict):
-                            created = queryset.model_class(**obj)
-                            if (
-                                not model_class.meta.post_save_fields
-                                or model_class.meta.post_save_fields.isdisjoint(obj.keys())
+                            if all(
+                                # compare dicts
+                                getattr(instance, k) == expected
+                                for k, expected in dict_fields.items()
                             ):
-                                create_skip_post_save.add(id(created))
-                        else:
-                            created = obj
-                        create_objs.append(created)
-                        return created, True
-                    else:
+                                lookup_key = _extract_unique_lookup_key(
+                                    instance,
+                                    unique_fields or unique_columns,
+                                    no_load=not unique_fields,
+                                )
+                                assert lookup_key is not None, (
+                                    "invalid fields/attributes in unique_fields"
+                                )
+                                if lookup_key:
+                                    if lookup_key not in existing_records:
+                                        found_obj = existing_records[lookup_key] = instance
+                                    else:
+                                        found_obj = existing_records[lookup_key]
+                                else:
+                                    found_obj = instance
+                                break
+                    if found_obj is not None:
                         if update:
                             if isinstance(obj, dict):
                                 for key in update_fields:
@@ -193,69 +263,130 @@ class BulkMixin:
                                     if hasattr(obj, key):
                                         setattr(found_obj, key, getattr(obj, key))
                             update_objs.append(found_obj)
-                        return found_obj, False
+                        return None if none_on_existing else found_obj, False
+                    elif create:
+                        return _add_create_obj(obj, pos)
+                    else:
+                        return None, False
 
-                returned_objs_with_created = await run_concurrently(
-                    [_iterate_retrieve(obj) for obj in objs],
-                    limit=(1 if getattr(queryset.database, "force_rollback", False) else None),
+                returned_objs_with_created_with_null = await run_concurrently(
+                    [_iterate_retrieve(obj, pos) for pos, obj in enumerate(objs)],
+                    limit=concurrent_limit,
                 )
-        else:
-            assert not update, "update needs retrieval=True"
+        elif create:
+            for pos, obj in enumerate(objs):
+                returned_objs_with_created_with_null.append(_add_create_obj(obj, pos))
+        elif update:
+            # update is last, if creation fails fallback to update
             for obj in objs:
-                created: EdgyModel
+                updated: EdgyModel
                 if isinstance(obj, dict):
-                    created = queryset.model_class(**obj)
-                    if (
-                        not model_class.meta.post_save_fields
-                        or model_class.meta.post_save_fields.isdisjoint(obj.keys())
-                    ):
-                        create_skip_post_save.add(id(created))
+                    updated = proxy_model_class(**obj)
                 else:
-                    created = obj
-                    if not isinstance(created, model_class):
+                    updated = obj
+                    if not isinstance(updated, model_class | proxy_model_class):
                         raise ValueError(
-                            f"Instance provided of wrong type: `{type(created)!r}` required: `{model_class!r}`."
+                            f"Instance provided of wrong type: `{type(updated)!r}` required: `{model_class!r}`."
                         )
-                create_objs.append(created)
-                returned_objs_with_created.append((created, True))
+                if updated.can_load:
+                    update_objs.append(updated)
+                    returned_objs_with_created_with_null.append((updated, False))
+                else:
+                    returned_objs_with_created_with_null.append((None, False))
 
-        _unique_and_update: set = update_fields.union(unique_fields)
-        can_result_cache = not self.embed_parent
         if resolve_embed and self.embed_parent:
             # check if all are elligable and can be resolved
-            if not all(res[0].can_load or res[1] for res in returned_objs_with_created):
+            if not all(
+                res[0] is None or res[0].can_load or res[1]
+                for res in returned_objs_with_created_with_null
+            ):
                 raise QuerySetError(
                     detail="Not all resulting objects are fully defined for loading and `resolve_embed=True`",
                 )
             can_result_cache = True
 
         check_db_connection(queryset.database, 4)
+        con_lock = asyncio.Lock()
 
-        async def _iterate_create(obj: EdgyModel) -> dict[str, Any] | None:
-            if resolve_embed and self.embed_parent and not obj.can_load:
-                await obj.real_save(force_insert=True, values=None)
-                create_skip_post_save.add(id(obj))
-                return None
-            original_field_values = obj.extract_db_fields()
-            col_values: dict[str, Any] = obj.extract_column_values(
-                original_field_values, phase="prepare_insert", instance=self, model_instance=obj
+        async def _iterate_create(
+            item: tuple[EdgyModel, int, set[str]],
+            connection: Connection,
+            returning: list[sqlalchemy.ColumnElement],
+        ) -> dict[str, Any] | None:
+            original_field_values = item[0].extract_db_fields()
+            col_values: dict[str, Any] = item[0].extract_column_values(
+                original_field_values,
+                phase="prepare_insert",
+                instance=used_instance,
+                model_instance=item[0],
             )
             if model_class.meta.pre_save_fields:
                 col_values.update(
-                    await obj.execute_pre_save_hooks(
+                    await item[0].execute_pre_save_hooks(
                         col_values, original_field_values, is_update=False
                     )
                 )
+            if ignore_create_conflicts or (
+                resolve_embed and self.embed_parent and not item[0].can_load
+            ):
+                try:
+                    # con_lock ensures only one userlandthread is accessing the database concurrently
+                    # so the transaction is correctly mapped
+                    async with con_lock, connection.transaction():
+                        if returning:
+                            expression: Any = (
+                                queryset.table.insert().values(**col_values).returning(*returning)
+                            )
+                            returned_mapping = dict(
+                                (await connection.fetch_one(expression))._mapping
+                            )
+                        else:
+                            expression = queryset.table.insert().values(**col_values)
+                            pk_values = await connection.execute(expression)
+                            returned_mapping = (
+                                dict(pk_values._mapping) if hasattr(pk_values, "_mapping") else {}
+                            )
+                        for col_name, col_key in model_class.meta.columns_remapping.items():
+                            if col_name in returned_mapping:
+                                returned_mapping[col_key] = returned_mapping.pop(col_name)
+                        col_values.update(returned_mapping)
+
+                        new_kwargs = model_class.transform_input(
+                            col_values, phase="post_insert", instance=self, model_instance=item[0]
+                        )
+                        item[0].__dict__.update(new_kwargs)
+                except IntegrityError:
+                    if not ignore_create_conflicts:
+                        raise
+                    if update and item[0].can_load:
+                        # we can do an update, but not a retrieval because
+                        # a retrieval doesn't overwrite the potential wrong values
+                        # maybe still issue a load afterwards
+                        # we need to be **sure** that the instance is loadable and copy the `identifying_db_fields`
+                        # othewise we can end with an invalid proxy
+                        proxy = proxy_model_class(
+                            **item[0].extract_db_fields(_unique_cols_and_update_fields)
+                        )
+                        proxy.identifying_db_fields = item[0].identifying_db_fields
+                        update_objs.append(proxy)
+                        returned_objs_with_created_with_null[item[1]] = (proxy, False)
+                        skip_post_save.add(id(item[0]))
+                    else:
+                        # always return None because we don't know why it failed or we can't recover
+                        returned_objs_with_created_with_null[item[1]] = (None, False)
+                        skip_post_save.add(id(item[0]))
+                return None
             return col_values
 
         async def _iterate_update(obj: EdgyModel) -> dict[str, Any]:
-            original_field_values = obj.extract_db_fields(_unique_and_update)
+            original_field_values = obj.extract_db_fields(_unique_cols_and_update_fields)
+            # copied from update
             col_values: dict[str, Any] = model_class.extract_column_values(
                 original_field_values,
                 is_update=True,
                 is_partial=True,
                 phase="prepare_update",
-                instance=self,
+                instance=used_instance,
                 model_instance=obj,
             )
             if model_class.meta.pre_save_fields:
@@ -268,16 +399,54 @@ class BulkMixin:
                 raise QuerySetError(
                     detail=f"Missing columns: {_update_columns.difference(col_values)}. Check `update_fields` or the input values."
                 )
+            new_kwargs = model_class.transform_input(
+                col_values, phase="post_update", instance=self, model_instance=obj
+            )
+            obj.__dict__.update(new_kwargs)
             return {f"__{item[0]}": item[1] for item in col_values.items()}
 
-        token = CURRENT_INSTANCE.set(self)
+        token = CURRENT_INSTANCE.set(used_instance)
         try:
-            async with queryset.database as database, database.transaction():
+            async with (
+                queryset.database as database,
+                database.transaction(),
+                database.connection() as connection,
+            ):
+                create_obj_values: list[dict | None] = []
+                if create_params:
+                    # we can't just use label. If the column.key has an invalid name for the db
+                    # we would cause an foo AS invalid clause
+                    returning: list[sqlalchemy.ColumnElement] = (
+                        [
+                            col
+                            for col in queryset.table.columns.values()
+                            if col.server_default is not None or col.autoincrement
+                        ]
+                        if database.engine.dialect.insert_returning
+                        else []
+                    )
+                    create_obj_values = [
+                        val
+                        for val in (
+                            await run_concurrently(
+                                [
+                                    _iterate_create(tup, connection, returning)
+                                    for tup in create_params
+                                ],
+                                limit=concurrent_limit,
+                            )
+                        )
+                        if val is not None
+                    ]
+                    # we need to recheck if the conditions are still valid
+                    if create_obj_values:
+                        expression_create = queryset.table.insert().values(create_obj_values)
+                        await connection.execute_many(expression_create)
                 # prevent calling db with empty iterable, this causes errors
                 if update_objs:
                     update_obj_values = await run_concurrently(
                         [_iterate_update(obj) for obj in update_objs],
-                        limit=(1 if getattr(queryset.database, "force_rollback", False) else None),
+                        limit=concurrent_limit,
                     )
                     # by default pknames
                     unique_query_placeholder = (
@@ -296,24 +465,9 @@ class BulkMixin:
                         for col in _update_columns
                     }
                     expression_update = expression_update.values(values_placeholder)
-                    await database.execute_many(expression_update, update_obj_values)
+                    await connection.execute_many(expression_update, update_obj_values)
 
-                if create_objs:
-                    create_obj_values = await run_concurrently(
-                        [_iterate_create(obj) for obj in create_objs],
-                        limit=(1 if getattr(queryset.database, "force_rollback", False) else None),
-                    )
-                    create_obj_values = [
-                        values for values in create_obj_values if values is not None
-                    ]
-                    # we need to recheck if the conditions are still valid
-                    if create_obj_values:
-                        expression_create = queryset.table.insert().values(
-                            [values for values in create_obj_values if values is not None]
-                        )
-                        await database.execute_many(expression_create)
-
-                if update_objs or create_objs:
+                if update_objs or create_params:
                     # only the results change
                     self._clear_cache(
                         keep_cached_selected=True,
@@ -322,94 +476,75 @@ class BulkMixin:
                     operations: list[Awaitable] = []
                     if model_class.meta.post_save_fields:
                         operations.extend(
-                            obj.execute_post_save_hooks(
-                                set(model_class.meta.fields.keys()), is_update=False
-                            )
-                            for obj in create_objs
-                            if id(obj) not in create_skip_post_save
+                            tup[0].execute_post_save_hooks(tup[2], is_update=False)
+                            # otherwise we would execute twice or one time for non-existing rows
+                            for tup in create_params
+                            if id(tup[0]) not in skip_post_save
                         )
                         if not model_class.meta.post_save_fields.isdisjoint(update_fields):
                             operations.extend(
                                 obj.execute_post_save_hooks(update_fields, is_update=True)
                                 for obj in update_objs
+                                # we currently doesn't put update_objs in skip_post_save
                             )
                     if operations:
                         await run_concurrently(
                             operations,
-                            limit=(
-                                1 if getattr(queryset.database, "force_rollback", False) else None
-                            ),
+                            limit=concurrent_limit,
                         )
         finally:
             CURRENT_INSTANCE.reset(token)
-
         if not self.embed_parent:
             self._cache.update(
                 model_class,
-                [tup[0] for tup in returned_objs_with_created if tup[0].can_load],
+                [
+                    tup[0]
+                    for tup in returned_objs_with_created_with_null
+                    if tup[0] is not None and tup[0].can_load
+                ],
                 cache_keys=[
                     self._cache.create_cache_key(model_class, tup[0])
-                    for tup in returned_objs_with_created
-                    if tup[0].can_load
+                    for tup in returned_objs_with_created_with_null
+                    if tup[0] is not None and tup[0].can_load
                 ],
             )
         elif resolve_embed:
-            minstances, values = zip(
-                *(
-                    await run_concurrently(
-                        [
-                            self._embed_parent_in_result(res[0])
-                            for res in returned_objs_with_created
-                        ],
-                        limit=(1 if getattr(queryset.database, "force_rollback", False) else None),
-                    )
-                ),
-                strict=True,
+            immediate = await run_concurrently(
+                [
+                    self._embed_parent_in_result(tup[0])
+                    for tup in returned_objs_with_created_with_null
+                ],
+                limit=concurrent_limit,
             )
             self._cache.update(
                 self.model_class,
-                values,
-                cache_keys=[self._cache.create_cache_key(model_class, key) for key in minstances],
+                [item[1] for item in immediate if item[0] is not None],
+                cache_keys=[
+                    self._cache.create_cache_key(model_class, item[0])
+                    for item in immediate
+                    if item[0] is not None
+                ],
             )
 
             return cast(
-                "list[tuple[EdgyEmbedTarget, bool]]",
-                list(zip(values, (res[1] for res in returned_objs_with_created), strict=True)),
+                "list[tuple[EdgyEmbedTarget | None, bool]]",
+                list(
+                    zip(
+                        [item[1] for item in immediate],
+                        (res[1] for res in returned_objs_with_created_with_null),
+                        strict=True,
+                    )
+                ),
             )
-        return returned_objs_with_created
-
-    @overload
-    async def bulk_create(
-        self, objs: Iterable[dict[str, Any] | EdgyModel], *, resolve_embed: Literal[True]
-    ) -> list[EdgyEmbedTarget]:
-        """
-        Args:
-            ...
-            resolve_embed (True): Enables embedding.
-
-        Returns:
-            list[EdgyEmbedTarget]: A list of created objects.
-                                   Warning: Instances which are not compatible (`can_load` is False)
-                                   will execute an extra save.
-        """
-
-    @overload
-    async def bulk_create(
-        self, objs: Iterable[dict[str, Any] | EdgyModel], *, resolve_embed: Literal[False] = False
-    ) -> list[EdgyModel]:
-        """
-        Args:
-            ...
-            resolve_embed (False): Disables embedding. Default.
-        Returns:
-            list[EdgyModel]: A list of created objects.
-                             Warning: for performance reasons no embedding is applied and
-                             the returned objects are maybe incomplete (check `can_load` property).
-        """
+        return returned_objs_with_created_with_null
 
     async def bulk_create(
-        self, objs: Iterable[dict[str, Any] | EdgyModel], resolve_embed: bool = False
-    ) -> list[EdgyModel] | list[EdgyEmbedTarget]:
+        self,
+        objs: Iterable[dict[str, Any] | EdgyModel],
+        *,
+        ignore_conflicts: bool = False,
+        resolve_embed: bool = False,
+    ) -> list[EdgyModel | None] | list[EdgyEmbedTarget | None]:
         """
         Bulk creates multiple records in a single batch operation.
 
@@ -419,6 +554,8 @@ class BulkMixin:
         Args:
             objs (Iterable[dict[str, Any] | EdgyModel]): An iterable of dictionaries or
                                                          model instances to create.
+        Kwargs:
+            ignore_conflicts (bool): Ignore insert conflicts. Support varies between database systems.
             resolve_embed (bool): Triggers mode in which embedding is applied when True.
 
         Returns:
@@ -428,60 +565,23 @@ class BulkMixin:
                 the returned objects are maybe incomplete (check `can_load` property).
         """
         return cast(
-            "list[EdgyModel] | list[EdgyEmbedTarget]",
+            "list[EdgyModel | None] | list[EdgyEmbedTarget | None]",
             [
                 tup[0]
                 for tup in await self._bulk_get_update_or_create(
                     objs=objs,
-                    unique_fields=set(self.model_class.pknames),
                     unique_columns=self.model_class.pkcolumns,
+                    create=True,
                     update=False,
                     retrieve=False,
                     resolve_embed=resolve_embed,
+                    none_on_existing=ignore_conflicts,
+                    ignore_create_conflicts=ignore_conflicts,
                 )
             ],
         )
 
     bulk_insert = bulk_create
-
-    @overload
-    async def bulk_update(
-        self,
-        objs: Iterable[EdgyModel],
-        *,
-        update_fields: Iterable[str] | None = None,
-        unique_fields: Iterable[str] | None = None,
-        resolve_embed: Literal[True],
-    ) -> list[EdgyEmbedTarget]:
-        """
-        Args:
-            ...
-            resolve_embed (True): Enables embedding.
-
-        Returns:
-            list[EdgyEmbedTarget]: A list of updated objects.
-                                   Warning: All models must be loadable (`can_load` property is true)
-                                   otherwise an error is raised.
-        """
-
-    @overload
-    async def bulk_update(
-        self,
-        objs: Iterable[EdgyModel],
-        *,
-        update_fields: Iterable[str] | None = None,
-        unique_fields: Iterable[str] | None = None,
-        resolve_embed: Literal[False] = False,
-    ) -> list[EdgyModel]:
-        """
-        Args:
-            ...
-            resolve_embed (False): Disables embedding. Default.
-        Returns:
-            list[EdgyModel]: A list of updated objects.
-                             Warning: for performance reasons no embedding is applied and
-                             the returned objects are maybe incomplete (check `can_load` property).
-        """
 
     async def bulk_update(
         self,
@@ -491,12 +591,13 @@ class BulkMixin:
         unique_fields: Iterable[str] | None = None,
         fields: Iterable[str] | None = None,
         resolve_embed: bool = False,
-    ) -> list[EdgyModel] | list[EdgyEmbedTarget]:
+    ) -> list[EdgyModel | None] | list[EdgyEmbedTarget | None]:
         """
         Update multiple objects in a single bulk operation.
 
         Args:
-            objs (Iterable[EdgyModel]): A sequence of model instances to update.
+            objs (Iterable[dict[str, Any] | EdgyModel]): A sequence of model instances to update.
+        Kwargs:
             update_fields (Iterable[str]): A list of field names to update for each object. If None use all fields.
             unique_fields (Iterable[str] | None): Fields that determine uniqueness.
                                                     If None, pknames are used. If empty it fails.
@@ -513,10 +614,9 @@ class BulkMixin:
                 "Use `update_fields` instead `fields`.", DeprecationWarning, stacklevel=2
             )
             update_fields = fields
-        _unique_fields: set[str]
+        _unique_fields: set[str] = set()
         _unique_columns: Sequence[str]
         if unique_fields is None:
-            _unique_fields = set(self.model_class.pknames)
             _unique_columns = self.model_class.pkcolumns
         else:
             _unique_fields = set(unique_fields)
@@ -538,58 +638,22 @@ class BulkMixin:
             else set(update_fields)
         )
         return cast(
-            "list[EdgyModel] | list[EdgyEmbedTarget]",
+            "list[EdgyModel | None] | list[EdgyEmbedTarget | None]",
             [
                 tup[0]
                 for tup in await self._bulk_get_update_or_create(
                     objs=objs,
-                    unique_fields=_unique_fields,
+                    # Somehow this is required to be non-empty
+                    unique_fields=_unique_fields or _unique_columns,
                     unique_columns=_unique_columns,
                     update_fields=_update_fields,
                     update=True,
-                    retrieve=True,
+                    retrieve=resolve_embed,
+                    create=False,
                     resolve_embed=resolve_embed,
                 )
             ],
         )
-
-    @overload
-    async def bulk_update_or_create(
-        self,
-        objs: Iterable[dict[str, Any] | EdgyModel],
-        *,
-        update_fields: Iterable[str] | None = None,
-        unique_fields: Iterable[str] | None = None,
-        resolve_embed: Literal[True],
-    ) -> list[tuple[EdgyEmbedTarget, bool]]:
-        """
-        Args:
-            ...
-            resolve_embed (True): Enables embedding.
-
-        Returns:
-            list[tuple[EdgyEmbedTarget, bool]]: A list of `(instance, created)` tuples.
-                                                Warning: All models must be loadable (`can_load` property is true)
-                                                otherwise an `QuerySetError` is raised.
-        """
-
-    @overload
-    async def bulk_update_or_create(
-        self,
-        objs: Iterable[dict[str, Any] | EdgyModel],
-        *,
-        update_fields: Iterable[str] | None = None,
-        unique_fields: Iterable[str] | None = None,
-        resolve_embed: Literal[False] = False,
-    ) -> list[tuple[EdgyModel, bool]] | list[tuple[EdgyEmbedTarget, bool]]:
-        """
-        Args:
-            resolve_embed (False): Disables embedding. Default.
-        Returns:
-            list[tuple[EdgyModel, bool]]: A list of `(instance, created)` tuples.
-                                          Warning: for performance reasons no embedding is applied and
-                                          the returned objects are maybe incomplete (check `can_load` property).
-        """
 
     async def bulk_update_or_create(
         self,
@@ -598,7 +662,7 @@ class BulkMixin:
         update_fields: Iterable[str] | None = None,
         unique_fields: Iterable[str] | None = None,
         resolve_embed: bool = False,
-    ) -> list[tuple[EdgyModel, bool]] | list[tuple[EdgyEmbedTarget, bool]]:
+    ) -> list[tuple[EdgyModel | None, bool]] | list[tuple[EdgyEmbedTarget | None, bool]]:
         """
         Bulk updates or creates records in a table.
 
@@ -607,6 +671,7 @@ class BulkMixin:
 
         Args:
             objs (Sequence[Union[dict[str, Any], EdgyModel]]): A list of objects or dictionaries.
+        Kwargs:
             update_fields (Iterable[str]): A list of field names to update for each object (when found).
                                     If None use all fields.
             unique_fields (Iterable[str] | None): Fields that determine uniqueness.
@@ -618,21 +683,21 @@ class BulkMixin:
                 A list of `(instance, created)` tuples.
                 Warning: for performance reasons no embedding is applied by default and
                 the returned objects are maybe incomplete (check `can_load` property).
+                Warning: you might want to issue a load to get correct data outside of update_fields.
         """
-        _unique_fields: set[str]
-        _unique_columns: Sequence[str]
+        _unique_fields: set[str] = set()
+        _unique_columns: set[str]
         if unique_fields is None:
-            _unique_fields = set(self.model_class.pknames)
-            _unique_columns = self.model_class.pkcolumns
+            _unique_columns = set(self.model_class.pkcolumns)
         else:
             _unique_fields = set(unique_fields)
             if not _unique_fields:
                 raise ValueError("`unique_fields` empty.")
-            _unique_columns = tuple(
+            _unique_columns = {
                 col
                 for field in _unique_fields
                 for col in self.model_class.meta.field_to_column_names[field]
-            )
+            }
         _update_fields = (
             {
                 key
@@ -642,52 +707,24 @@ class BulkMixin:
             if update_fields is None
             else set(update_fields)
         )
-        return await self._bulk_get_update_or_create(
-            objs=objs,
-            unique_fields=_unique_fields,
-            unique_columns=_unique_columns,
-            update_fields=_update_fields,
-            update=True,
-            retrieve=True,
-            resolve_embed=resolve_embed,
+        unique_equals_pk = set(self.model_class.pkcolumns) == _unique_columns
+        return cast(
+            "list[tuple[EdgyModel | None, bool]] | list[tuple[EdgyEmbedTarget  | None, bool]]",
+            await self._bulk_get_update_or_create(
+                objs=objs,
+                unique_fields=_unique_fields,
+                unique_columns=_unique_columns,
+                update_fields=_update_fields,
+                create=True,
+                update=True,
+                # if unique_equals_pk we can just issue an insert and check if there was a conflict
+                # this allows us to sidestep the retrieve mechanic
+                # for resolve_embed the other mechanic is implicitly used
+                retrieve=not unique_equals_pk,
+                ignore_create_conflicts=unique_equals_pk,
+                resolve_embed=resolve_embed,
+            ),
         )
-
-    @overload
-    async def bulk_get_or_create(
-        self,
-        objs: Iterable[dict[str, Any] | EdgyModel],
-        *,
-        unique_fields: Iterable[str] | None = None,
-        resolve_embed: Literal[True],
-    ) -> list[tuple[EdgyEmbedTarget, bool]]:
-        """
-        Args:
-            ...
-            resolve_embed (True): Enables embedding.
-
-        Returns:
-            list[tuple[EdgyEmbedTarget, bool]]: A list of `(instance, created)` tuples.
-                                                Warning: Instances which are not compatible (`can_load` is False)
-                                                will execute an extra save.
-        """
-
-    @overload
-    async def bulk_get_or_create(
-        self,
-        objs: Iterable[dict[str, Any] | EdgyModel],
-        *,
-        unique_fields: Iterable[str] | None = None,
-        resolve_embed: Literal[False] = False,
-    ) -> list[tuple[EdgyModel, bool]]:
-        """
-        Args:
-            ...
-            resolve_embed (False): Disables embedding. Default.
-        Returns:
-            list[tuple[EdgyModel, bool]]: A list of `(instance, created)` tuples.
-                                          Warning: for performance reasons no embedding is applied and
-                                          the returned objects are maybe incomplete (check `can_load` property).
-        """
 
     async def bulk_get_or_create(
         self,
@@ -704,6 +741,7 @@ class BulkMixin:
 
         Args:
             objs (Iterable[Union[dict[str, Any], EdgyModel]]): A list of objects or dictionaries.
+        Kwargs:
             unique_fields (Iterable[str] | None): Fields that determine uniqueness.
                                                   If None, pknames are used. If empty it fails.
             resolve_embed (bool): Triggers mode in which embedding is applied when True.
@@ -715,8 +753,8 @@ class BulkMixin:
                 the returned objects are maybe incomplete (check `can_load` property).
         """
 
-        _unique_fields: set[str]
-        _unique_columns: Sequence[str]
+        _unique_fields: set[str] = set()
+        _unique_columns: Collection[str]
         if unique_fields is None:
             _unique_fields = set(self.model_class.pknames)
             _unique_columns = self.model_class.pkcolumns
@@ -724,18 +762,22 @@ class BulkMixin:
             _unique_fields = set(unique_fields)
             if not _unique_fields:
                 raise ValueError("`unique_fields` empty.")
-            _unique_columns = tuple(
+            _unique_columns = {
                 col
                 for field in _unique_fields
                 for col in self.model_class.meta.field_to_column_names[field]
-            )
-        return await self._bulk_get_update_or_create(
-            objs=objs,
-            unique_fields=_unique_fields,
-            unique_columns=_unique_columns,
-            update=False,
-            retrieve=True,
-            resolve_embed=resolve_embed,
+            }
+        return cast(
+            "list[tuple[EdgyModel, bool]] | list[tuple[EdgyEmbedTarget, bool]]",
+            await self._bulk_get_update_or_create(
+                objs=objs,
+                unique_fields=_unique_fields,
+                unique_columns=_unique_columns,
+                create=True,
+                update=False,
+                retrieve=True,
+                resolve_embed=resolve_embed,
+            ),
         )
 
     bulk_select_or_insert = bulk_get_or_create

--- a/edgy/core/db/querysets/queryset.py
+++ b/edgy/core/db/querysets/queryset.py
@@ -612,7 +612,7 @@ class QuerySet(BaseQuerySet[EdgyModel, EdgyEmbedTarget], Generic[EdgyModel, Edgy
             queryset._update_select_related_weak(queryset._order_by, clear=False)
         return queryset
 
-    def distinct(self, first: bool | str = True, *distinct_on: str) -> QuerySet:
+    def distinct(self, first: bool | str = True, /, *distinct_on: str) -> QuerySet:
         """
         Returns a queryset with distinct results.
 

--- a/edgy/core/db/querysets/types.py
+++ b/edgy/core/db/querysets/types.py
@@ -354,7 +354,7 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
         ...
 
     @abstractmethod
-    def distinct(self, *distinct_on: Sequence[str]) -> QuerySetType:
+    def distinct(self, first: bool | str = True, /, *distinct_on: str) -> QuerySetType:
         """
         Abstract method to select distinct rows based on specific columns or all columns.
 
@@ -508,7 +508,20 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
 
     @overload
     async def bulk_create(
-        self, objs: Iterable[dict[str, Any] | EdgyModel], *, resolve_embed: Literal[True]
+        self,
+        objs: Iterable[dict[str, Any] | EdgyModel],
+        *,
+        ignore_conflicts: Literal[True],
+        resolve_embed: Literal[True],
+    ) -> list[EdgyEmbedTarget | None]: ...
+
+    @overload
+    async def bulk_create(
+        self,
+        objs: Iterable[dict[str, Any] | EdgyModel],
+        *,
+        ignore_conflicts: Literal[False] = False,
+        resolve_embed: Literal[True],
     ) -> list[EdgyEmbedTarget]:
         """
         Args:
@@ -523,7 +536,20 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
 
     @overload
     async def bulk_create(
-        self, objs: Iterable[dict[str, Any] | EdgyModel], *, resolve_embed: Literal[False] = False
+        self,
+        objs: Iterable[dict[str, Any] | EdgyModel],
+        *,
+        ignore_conflicts: Literal[True],
+        resolve_embed: Literal[False] = False,
+    ) -> list[EdgyModel | None]: ...
+
+    @overload
+    async def bulk_create(
+        self,
+        objs: Iterable[dict[str, Any] | EdgyModel],
+        *,
+        ignore_conflicts: Literal[False] = False,
+        resolve_embed: Literal[False] = False,
     ) -> list[EdgyModel]:
         """
         Args:
@@ -537,14 +563,20 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
 
     @abstractmethod
     async def bulk_create(
-        self, objs: Iterable[dict[str, Any] | EdgyModel], *, resolve_embed: bool = False
-    ) -> list[EdgyModel] | list[EdgyEmbedTarget]:
+        self,
+        objs: Iterable[dict[str, Any] | EdgyModel],
+        *,
+        ignore_conflicts: bool = False,
+        resolve_embed: bool = False,
+    ) -> list[EdgyModel | None] | list[EdgyEmbedTarget | None]:
         """
         Abstract method to create multiple objects in a single bulk operation.
 
         Args:
             objs (Iterable[dict[str, Any] | EdgyModel]): An iterable of dictionaries or
                                                          model instances to create.
+        Kwargs:
+            ignore_conflicts (bool): Ignore insert conflicts. Support varies between database systems.
             resolve_embed (bool): Triggers mode in which embedding is applied when True.
 
         Returns:
@@ -558,14 +590,14 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
     @overload
     async def bulk_update(
         self,
-        objs: Iterable[EdgyModel],
+        objs: Iterable[EdgyModel | dict[str, Any]],
         *,
         update_fields: Iterable[str] | None = None,
         unique_fields: Iterable[str] | None = None,
         resolve_embed: Literal[True],
-    ) -> list[EdgyEmbedTarget]:
+    ) -> list[EdgyEmbedTarget | None]:
         """
-        Args:
+        Kwargs:
             ...
             resolve_embed (True): Enables embedding.
 
@@ -578,14 +610,14 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
     @overload
     async def bulk_update(
         self,
-        objs: Iterable[EdgyModel],
+        objs: Iterable[EdgyModel | dict[str, Any]],
         *,
         update_fields: Iterable[str] | None = None,
         unique_fields: Iterable[str] | None = None,
         resolve_embed: Literal[False] = False,
-    ) -> list[EdgyModel]:
+    ) -> list[EdgyModel | None]:
         """
-        Args:
+        Kwargs:
             ...
             resolve_embed (False): Disables embedding. Default.
         Returns:
@@ -597,17 +629,18 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
     @abstractmethod
     async def bulk_update(
         self,
-        objs: Iterable[EdgyModel],
+        objs: Iterable[EdgyModel | dict[str, Any]],
         *,
         update_fields: Iterable[str] | None = None,
         unique_fields: Iterable[str] | None = None,
         resolve_embed: bool = False,
-    ) -> list[EdgyModel] | list[EdgyEmbedTarget]:
+    ) -> list[EdgyModel | None] | list[EdgyEmbedTarget | None]:
         """
         Abstract method to update multiple objects in a single bulk operation.
 
         Args:
-            objs (Iterable[EdgyModel]): A sequence of model instances to update.
+            objs (Iterable[EdgyModel | dict[str, Any]]): A sequence of model instances to update.
+        Kwargs:
             update_fields (Iterable[str]): A list of field names to update for each object. If None use all fields.
             unique_fields (Iterable[str] | None): Fields that determine uniqueness.
                                                     If None, pknames are used. If empty it fails.
@@ -629,9 +662,9 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
         update_fields: Iterable[str] | None = None,
         unique_fields: Iterable[str] | None = None,
         resolve_embed: Literal[True],
-    ) -> list[tuple[EdgyEmbedTarget, bool]]:
+    ) -> list[tuple[EdgyEmbedTarget | None, bool]]:
         """
-        Args:
+        Kwargs:
             ...
             resolve_embed (True): Enables embedding.
 
@@ -649,9 +682,9 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
         update_fields: Iterable[str] | None = None,
         unique_fields: Iterable[str] | None = None,
         resolve_embed: Literal[False] = False,
-    ) -> list[tuple[EdgyModel, bool]] | list[tuple[EdgyEmbedTarget, bool]]:
+    ) -> list[tuple[EdgyModel | None, bool]]:
         """
-        Args:
+        Kwargs:
             ...
             resolve_embed (False): Disables embedding. Default.
         Returns:
@@ -668,7 +701,7 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
         update_fields: Iterable[str] | None = None,
         unique_fields: Iterable[str] | None = None,
         resolve_embed: bool = False,
-    ) -> list[tuple[EdgyModel, bool]] | list[tuple[EdgyEmbedTarget, bool]]:
+    ) -> list[tuple[EdgyModel | None, bool]] | list[tuple[EdgyEmbedTarget | None, bool]]:
         """
         Abstract method to bulk updates or creates records in a table.
 
@@ -677,6 +710,7 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
 
         Args:
             objs (Sequence[Union[dict[str, Any], EdgyModel]]): A list of objects or dictionaries.
+        Kwargs:
             update_fields (Iterable[str]): A list of field names to update for each object (when found).
                                     If None use all fields.
             unique_fields (Iterable[str] | None): Fields that determine uniqueness.
@@ -684,10 +718,11 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
             resolve_embed (bool): Triggers mode in which embedding is applied when True.
 
         Returns:
-            list[tuple[EdgyModel, bool]] | list[tuple[EdgyEmbedTarget, bool]]:
+            list[tuple[EdgyModel | None, bool]] | list[tuple[EdgyEmbedTarget | None, bool]]:
                 A list of `(instance, created)` tuples.
                 Warning: for performance reasons no embedding is applied by default and
                 the returned objects are maybe incomplete (check `can_load` property).
+                `None` is returned for insert conflicts where no update could be generated.
         """
         ...
 
@@ -700,7 +735,7 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
         resolve_embed: Literal[True],
     ) -> list[tuple[EdgyEmbedTarget, bool]]:
         """
-        Args:
+        Kwargs:
             ...
             resolve_embed (True): Enables embedding.
 
@@ -719,7 +754,7 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
         resolve_embed: Literal[False] = False,
     ) -> list[tuple[EdgyModel, bool]]:
         """
-        Args:
+        Kwargs:
             ...
             resolve_embed (False): Disables embedding. Default.
         Returns:
@@ -744,6 +779,7 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
 
         Args:
             objs (Iterable[Union[dict[str, Any], EdgyModel]]): A list of objects or dictionaries.
+        Kwargs:
             unique_fields (Iterable[str] | None): Fields that determine uniqueness.
                                                   If None, pknames are used. If empty it fails.
             resolve_embed (bool): Triggers mode in which embedding is applied when True.

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from inspect import isawaitable
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import BaseModel
-from sqlalchemy.exc import IntegrityError
 
-from edgy.core.db.context_vars import CURRENT_INSTANCE, MODEL_GETATTR_BEHAVIOR
+from edgy.core.db.context_vars import CURRENT_INSTANCE
 from edgy.core.db.fields.base import RelationshipField
 from edgy.exceptions import ObjectNotFound, RelationshipIncompatible, RelationshipNotFound
 from edgy.protocols.many_relationship import ManyRelationProtocol
@@ -124,7 +122,7 @@ class ManyRelation(ManyRelationProtocol):
             if not self.through.meta.fields[self.to_foreign_key].is_cross_db():
                 # not initialized yet
                 queryset._select_related.add(self.to_foreign_key)
-        return queryset
+        return queryset.using(schema=self.instance.get_active_instance_schema())
 
     async def save_related(self) -> None:
         """
@@ -132,17 +130,24 @@ class ManyRelation(ManyRelationProtocol):
         This method iterates through the `refs` (staged children) and adds them
         to the relationship.
         """
-        # TODO: improve performance
-        # Get the foreign key field on the 'through' model that points back to the 'from' model.
-        fk = self.through.meta.fields[self.from_foreign_key]
-        # Iterate while there are references in the list.
-        while self.refs:
-            # Pop the last reference from the list.
-            ref = self.refs.pop()
-            # Clean the foreign key value and update the reference's dictionary.
-            ref.__dict__.update(fk.clean(fk.name, self.instance))
-            # Asynchronously add the reference to the relationship.
-            await self.add(ref)
+        refs = list(self.refs)
+        self.refs.clear()
+        if not refs:
+            return
+        await self.get_queryset()._bulk_get_update_or_create(
+            objs=refs,
+            unique_columns={
+                col
+                for field in [self.from_foreign_key, self.to_foreign_key]
+                for col in self.through.meta.field_to_column_names[field]
+            },
+            ignore_create_conflicts=True,
+            create=True,
+            retrieve=False,
+            update=False,
+            used_instance=self.instance,
+            resolve_embed=False,
+        )
 
     def __getattr__(self, item: Any) -> Any:
         """
@@ -199,6 +204,14 @@ class ManyRelation(ManyRelationProtocol):
             Any: An instance of the `through` model or its proxy, ready for use
                  in the relationship.
         """
+        # Validate that the child is compatible with the relationship.
+        if not isinstance(
+            value,
+            self.to | self.to.proxy_model | self.through | self.through.proxy_model | dict,
+        ):
+            raise RelationshipIncompatible(
+                f"The child is not from the types '{self.to.__name__}', '{self.through.__name__}'."
+            )
         through = self.through
 
         # If the value is already an instance of the through model or its proxy, return it directly.
@@ -207,11 +220,15 @@ class ManyRelation(ManyRelationProtocol):
 
         # Create a new proxy model instance of the 'through' model.
         # This instance links the current 'from' model instance with the 'to' model instance.
-        instance = through.proxy_model(
+        instance = cast("type[BaseModelType]", through.proxy_model)(
             **{self.from_foreign_key: self.instance, self.to_foreign_key: value}
         )
         # Set identifying database fields for the 'through' model instance.
-        instance.identifying_db_fields = [self.from_foreign_key, self.to_foreign_key]  # type: ignore
+        instance.identifying_db_fields = tuple(
+            col
+            for field in [self.from_foreign_key, self.to_foreign_key]
+            for col in through.meta.field_to_column_names[field]
+        )
         # If the 'through' model is a tenant model, set the active schema for the instance.
         if getattr(through.meta, "is_tenant", False):
             instance.__using_schema__ = self.instance.get_active_instance_schema()  # type: ignore
@@ -231,15 +248,6 @@ class ManyRelation(ManyRelationProtocol):
                                       `to` model, `through` model, or a dictionary.
         """
         for child in children:
-            # Validate that the child is compatible with the relationship.
-            if not isinstance(
-                child,
-                self.to | self.to.proxy_model | self.through | self.through.proxy_model | dict,
-            ):
-                raise RelationshipIncompatible(
-                    f"The child is not from the types '{self.to.__name__}', "
-                    f"'{self.through.__name__}'."
-                )
             # Expand the child into a 'through' model instance and append it to refs.
             self.refs.append(self.expand_relationship(child))
 
@@ -274,11 +282,32 @@ class ManyRelation(ManyRelationProtocol):
                                         or None for each record that already exists
                                         (IntegrityError).
         """
-        results = []
+        prepared = []
+        through = self.through
         for child in children:
-            result = await self.add(child)
-            results.append(result)
-        return results
+            prepared.append(self.expand_relationship(child))
+        if not prepared:
+            return []
+        return cast(
+            "list[BaseModelType | None]",
+            [
+                tup[0]
+                for tup in await self.get_queryset()._bulk_get_update_or_create(
+                    objs=prepared,
+                    unique_columns={
+                        col
+                        for field in [self.from_foreign_key, self.to_foreign_key]
+                        for col in through.meta.field_to_column_names[field]
+                    },
+                    ignore_create_conflicts=True,
+                    create=True,
+                    retrieve=False,
+                    update=False,
+                    used_instance=self.instance,
+                    resolve_embed=True,
+                )
+            ],
+        )
 
     async def add(self, child: BaseModelType) -> BaseModelType | None:
         """
@@ -297,43 +326,7 @@ class ManyRelation(ManyRelationProtocol):
         Raises:
             RelationshipIncompatible: If the child type is not compatible.
         """
-        # Validate that the child is compatible with the relationship.
-        if not isinstance(
-            child,
-            self.to | self.to.proxy_model | self.through | self.through.proxy_model | dict,
-        ):
-            raise RelationshipIncompatible(
-                f"The child is not from the types '{self.to.__name__}', '{self.through.__name__}'."
-            )
-        # Expand the child into a 'through' model instance.
-        through_instance = self.expand_relationship(child)
-
-        token = CURRENT_INSTANCE.set(through_instance)
-        try:
-            # Attempt to save the intermediate model. If it fails due to IntegrityError,
-            # it means the record already exists, so return None.
-            result = await through_instance.real_save(force_insert=True, values=None)
-        except IntegrityError:
-            # The record already exists.
-            return None
-        finally:
-            CURRENT_INSTANCE.reset(token)
-        if isinstance(child, self.through | self.through.proxy_model | dict):
-            return cast("BaseModelType", getattr(result, self.to_foreign_key))
-        if self.embed_parent:
-            embed_token = MODEL_GETATTR_BEHAVIOR.set("coro")
-            try:
-                new_result: Any = result
-                for part in self.embed_parent[0].split("__"):
-                    new_result = getattr(new_result, part)
-                    if isawaitable(new_result):
-                        new_result = await new_result
-            finally:
-                MODEL_GETATTR_BEHAVIOR.reset(embed_token)
-            if self.embed_parent[1]:
-                # object.__setattr__ will set it if extra="forbid" or "ignore" and not a field
-                setattr(child, self.embed_parent[1], new_result)
-        return child
+        return (await self.add_many(child))[0]
 
     async def remove_many(self, *children: BaseModelType) -> None:
         """
@@ -383,14 +376,6 @@ class ManyRelation(ManyRelationProtocol):
                 # If no child is specified and the foreign key is not unique, raise an error.
                 raise RelationshipNotFound(detail="No child specified.")
 
-        # Validate that the child is compatible before removal.
-        if not isinstance(
-            child,
-            self.to | self.to.proxy_model | self.through | self.through.proxy_model,
-        ):
-            raise RelationshipIncompatible(
-                f"The child is not from the types '{self.to.__name__}', '{self.through.__name__}'."
-            )
         # Cast the child to BaseModelType as it is now confirmed to be a model instance.
         child = cast("BaseModelType", self.expand_relationship(child))
         # Count the number of relationships based on the identifying clauses of the child.
@@ -578,9 +563,12 @@ class SingleRelation(ManyRelationProtocol):
                  in the relationship.
         """
         target = self.to
+        if not isinstance(value, self.to | self.to.proxy_model | dict):
+            raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")
 
         # If the value is already an instance of the target model or its proxy, return it directly.
         if isinstance(value, target | target.proxy_model):
+            setattr(value, self.to_foreign_key, self.instance)
             return value
 
         related_columns = self.to.meta.fields[self.to_foreign_key].related_columns.keys()
@@ -589,13 +577,14 @@ class SingleRelation(ManyRelationProtocol):
         if len(related_columns) == 1 and not isinstance(value, dict | BaseModel):
             value = {next(iter(related_columns)): value}
         # Create a new proxy model instance of the 'to' model using the value.
-        instance = target.proxy_model(**value)
+        target_instance = target.proxy_model(**value)
+        setattr(target_instance, self.to_foreign_key, self.instance)
         # Set identifying database fields for the 'to' model instance.
-        instance.identifying_db_fields = related_columns  # type: ignore
+        target_instance.identifying_db_fields = related_columns  # type: ignore
         # If the 'to' model is a tenant model, set the active schema for the instance.
         if getattr(target.meta, "is_tenant", False):
-            instance.__using_schema__ = self.instance.get_active_instance_schema()  # type: ignore
-        return instance
+            target_instance.__using_schema__ = self.instance.get_active_instance_schema()  # type: ignore
+        return target_instance
 
     def stage(self, *children: BaseModelType) -> None:
         """
@@ -611,12 +600,6 @@ class SingleRelation(ManyRelationProtocol):
                                       `to` model or a dictionary.
         """
         for child in children:
-            # Validate that the child is compatible with the relationship.
-            if not isinstance(child, self.to | self.to.proxy_model | dict):
-                raise RelationshipIncompatible(
-                    f"The child is not from the types '{self.to.__name__}', "
-                    f"'{self.through.__name__}'."
-                )
             # Expand the child into a 'to' model instance and append it to refs.
             self.refs.append(self.expand_relationship(child))
 
@@ -652,10 +635,22 @@ class SingleRelation(ManyRelationProtocol):
         This method iterates through the `refs` (staged children) and adds them
         to the relationship.
         """
-        # Iterate while there are references in the list.
-        while self.refs:
-            # Pop the last reference from the list and add it to the relationship.
-            await self.add(self.refs.pop())
+        refs = list(self.refs)
+        self.refs.clear()
+        if not refs:
+            return
+        to = self.to
+        await self.get_queryset()._bulk_get_update_or_create(
+            objs=refs,
+            unique_columns=to.pkcolumns,
+            update_fields={self.to_foreign_key},
+            ignore_create_conflicts=True,
+            retrieve=False,
+            create=True,
+            update=True,
+            used_instance=self.instance,
+            resolve_embed=False,
+        )
 
     async def create(self, *args: Any, **kwargs: Any) -> BaseModelType | None:
         """
@@ -669,10 +664,7 @@ class SingleRelation(ManyRelationProtocol):
         Returns:
             BaseModelType | None: The newly created and added child instance.
         """
-        # Set the foreign key in kwargs to link the new child to the current instance.
-        kwargs[self.to_foreign_key] = self.instance
-        # Create the new instance using the 'to' model's query manager.
-        return await cast("QuerySet[BaseModelType]", self.to.query).create(*args, **kwargs)
+        return await self.add(self.to(*args, **kwargs))
 
     async def add(self, child: BaseModelType) -> BaseModelType | None:
         """
@@ -689,37 +681,7 @@ class SingleRelation(ManyRelationProtocol):
         Raises:
             RelationshipIncompatible: If the child type is not compatible.
         """
-        # Validate that the child is compatible with the relationship.
-        if not isinstance(child, self.to | self.to.proxy_model | dict):
-            raise RelationshipIncompatible(f"The child is not from the type '{self.to.__name__}'.")
-        # Expand the child into a 'to' model instance.
-        child = self.expand_relationship(child)
-        # Save the child, setting its foreign key to the current instance.
-
-        token = CURRENT_INSTANCE.set(child)
-        try:
-            result = await child.real_save(
-                force_insert=False, values={self.to_foreign_key: self.instance}
-            )
-        except IntegrityError:
-            # one-to-one violation
-            return None
-        finally:
-            CURRENT_INSTANCE.reset(token)
-        if self.embed_parent:
-            embed_token = MODEL_GETATTR_BEHAVIOR.set("coro")
-            try:
-                new_result: Any = result
-                for part in self.embed_parent[0].split("__"):
-                    new_result = getattr(new_result, part)
-                    if isawaitable(new_result):
-                        new_result = await new_result
-            finally:
-                MODEL_GETATTR_BEHAVIOR.reset(embed_token)
-            if self.embed_parent[1]:
-                # object.__setattr__ will set it if extra="forbid" or "ignore" and not a field
-                setattr(child, self.embed_parent[1], new_result)
-        return child
+        return (await self.add_many(child))[0]
 
     async def add_many(self, *children: BaseModelType) -> list[BaseModelType | None]:
         """
@@ -737,11 +699,30 @@ class SingleRelation(ManyRelationProtocol):
         Raises:
             RelationshipIncompatible: If a child type is not compatible.
         """
-        results = []
+
+        prepared = []
+        to = self.to
         for child in children:
-            result = await self.add(child)
-            results.append(result)
-        return results
+            prepared.append(self.expand_relationship(child))
+        if not prepared:
+            return []
+        return cast(
+            "list[BaseModelType | None]",
+            [
+                tup[0]
+                for tup in await self.get_queryset()._bulk_get_update_or_create(
+                    objs=prepared,
+                    unique_columns=to.pkcolumns,
+                    update_fields={self.to_foreign_key},
+                    ignore_create_conflicts=True,
+                    retrieve=False,
+                    create=True,
+                    update=True,
+                    used_instance=self.instance,
+                    resolve_embed=True,
+                )
+            ],
+        )
 
     async def remove_many(self, *children: BaseModelType) -> None:
         """

--- a/edgy/core/utils/concurrency.py
+++ b/edgy/core/utils/concurrency.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Generator, Iterable, Sequence
-from itertools import islice
+from collections import deque
+from collections.abc import Awaitable, Collection
 from typing import TypeVar
 
 from edgy.conf import settings
@@ -10,23 +10,14 @@ from edgy.conf import settings
 T = TypeVar("T")
 
 
-def batched(iterable: Iterable[T], n: int) -> Generator[tuple[T, ...], None, None]:
-    # batched('ABCDEFG', 2) → AB CD EF G
-    if n < 1:
-        raise ValueError("n must be at least one")
-    iterator = iter(iterable)
-    while batch := tuple(islice(iterator, n)):
-        yield batch
-
-
-async def run_concurrently(coros: Sequence[Awaitable[T]], limit: int | None = None) -> list[T]:
+async def run_concurrently(coros: Collection[Awaitable[T]], limit: int | None = None) -> list[T]:
     """
     Generic concurrent runner for Edgy ORM operations that need to be executed
     in parallel while respecting global concurrency settings.
 
     Args:
-        coros: A sequence of already created `Awaitable[Any]` objects (coroutines)
-               to be executed.
+        coros: A Collection or Sequence of already created `Awaitable[Any]` objects (coroutines)
+               to be executed. The order will be honored in case the input has an order.
         limit:
             An optional limit. Can be 0 to be disabled, 1 for a sequential mode,
             None for using the orm_concurrency_limit setting.
@@ -35,6 +26,7 @@ async def run_concurrently(coros: Sequence[Awaitable[T]], limit: int | None = No
         A list containing the results of the awaited coroutines in the same order
         as the input sequence.
     """
+    # don't call gather with zero args, speedup path
     if not coros:
         return []
 
@@ -45,17 +37,31 @@ async def run_concurrently(coros: Sequence[Awaitable[T]], limit: int | None = No
 
     if not enabled:
         eff_limit = 1
-    if eff_limit == 1:
-        # Fast path for explicit sequential execution. This avoids creating
-        # short-lived asyncio.gather() calls for each single-item batch.
-        sequential_results: list[T] = []
-        for coro in coros:
-            sequential_results.append(await coro)
-        return sequential_results
     if eff_limit is None or eff_limit <= 0:
         return await asyncio.gather(*coros)
+    _coros: deque[Awaitable[T]] = deque(coros)
+    del coros
     results: list[T] = []
-    for batch in batched(coros, eff_limit):
-        results.extend(await asyncio.gather(*batch))
+    batch: list[Awaitable[T]] = []
+    try:
+        while _coros:
+            while _coros and len(batch) < eff_limit:
+                batch.append(_coros.popleft())
+            if len(batch) > 1:
+                results.extend(await asyncio.gather(*batch))
+            else:
+                results.append(await batch[0])
+            batch.clear()
+    except BaseException:
+        # cleanup not executed coroutines
+        cleanup_batch = []
+        while _coros:
+            future = asyncio.ensure_future(_coros.popleft())
+            # cancel them all
+            future.cancel()
+            cleanup_batch.append(future)
+        # and just ignore (don't return another exception except if gather is canceled)
+        await asyncio.gather(*cleanup_batch, return_exceptions=True)
+        raise
 
     return results

--- a/tests/fields/test_file_fields.py
+++ b/tests/fields/test_file_fields.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any
+from unittest.mock import call
 from uuid import uuid4
 
 import pytest
@@ -244,8 +245,8 @@ async def test_bulk_create2(create_test_database, mocker):
         {},
     ]
     spy = mocker.spy(MyModel, "execute_post_save_hooks")
-    await MyModel.query.bulk_create(obj_list)
-    spy.assert_not_called()
+    results = await MyModel.query.bulk_create(obj_list)
+    assert spy.call_args_list == [call(res, set(), is_update=False) for res in results]
     for obj in await MyModel.query.all():
         assert obj.file_field.file is None
 

--- a/tests/fields/test_server_defaults.py
+++ b/tests/fields/test_server_defaults.py
@@ -37,22 +37,23 @@ async def rollback_transactions():
 async def test_partial_overwrite():
     obj = await MyModel.query.create(first_name="foobar")
     assert obj.first_name == "foobar"
-    assert "last_name" not in obj.__dict__
-    assert obj.last_name == "edge"
-    # lazy load
+    assert obj.can_load
+    # using returning
     assert "last_name" in obj.__dict__
+    assert obj.last_name == "edge"
 
 
 async def test_export_without_load():
     obj = await MyModel.query.create(first_name="foobar")
-    assert obj.model_dump(exclude=["id"]) == {
-        "first_name": "foobar",
-    }
+    assert "last_name" in obj.__dict__
+    assert obj.model_dump(exclude=["id"]) == {"first_name": "foobar", "last_name": "edge"}
 
 
 async def test_export_with_implicit_load():
     obj = await MyModel.query.create(first_name="foobar")
-    # triggers also implicit load
+    del obj.__dict__["last_name"]
+    assert obj.model_dump(exclude=["id"]) == {"first_name": "foobar"}
+    # triggers implicit load
     assert obj.last_name == "edge"
     assert obj.model_dump(exclude=["id"]) == {"first_name": "foobar", "last_name": "edge"}
 

--- a/tests/models/test_bulk_create.py
+++ b/tests/models/test_bulk_create.py
@@ -109,9 +109,34 @@ async def test_bulk_create():
     assert not products[1].can_load
 
 
+async def test_bulk_create_ignore_conflicts():
+    await Product.query.bulk_create(
+        [
+            {"id": 40, "value": 123.456, "status": StatusEnum.RELEASED},
+            {"id": 41, "value": 456.789, "status": StatusEnum.DRAFT},
+        ],
+        ignore_conflicts=True,
+    )
+
+    await Product.query.bulk_create(
+        [
+            {"id": 41, "value": 1, "status": StatusEnum.RELEASED},
+            {"id": 42, "value": 456.789, "status": StatusEnum.DRAFT},
+        ],
+        ignore_conflicts=True,
+    )
+    products = await Product.query.order_by("id")
+    assert len(products) == 3
+    assert products[0].id == 40
+    assert products[0].value == 123.456
+    assert products[1].id == 41
+    assert products[1].value == 456.789
+    assert products[2].id == 42
+
+
 async def test_bulk_create_reflected():
     # we delete "id" as field to simulate reflection models
-    del FooReflected.meta.fields["id"]
+    FooReflected.meta.fields.pop("id", None)
     results = await FooReflected.query.bulk_create(
         [
             {"foo": 2},
@@ -120,9 +145,26 @@ async def test_bulk_create_reflected():
     )
     assert results[0].foo == 2
     assert not results[0].can_load
+    assert not results[1].can_load
+    assert results[1].foo == 3
+    assert results[1].id != 100
+
+
+async def test_bulk_create_reflected_ignore():
+    # we delete "id" as field to simulate reflection models
+    FooReflected.meta.fields.pop("id", None)
+    results = await FooReflected.query.bulk_create(
+        [
+            {"foo": 2},
+            {"foo": 3, "id": 100},
+        ],
+        ignore_conflicts=True,
+    )
+    assert results[0].foo == 2
+    assert results[0].can_load
     assert results[1].can_load
     assert results[1].foo == 3
-    assert results[1].id == 100
+    assert results[1].id != 100
 
 
 async def test_bulk_create_resolve_through():
@@ -139,3 +181,26 @@ async def test_bulk_create_resolve_through():
     assert results[1].get_real_class() is Album
     assert results[1].id
     assert results[1].track_used.title == "fighters"
+
+
+async def test_bulk_create_dedupe():
+    results = await Product.query.bulk_create(
+        [
+            {"id": 40, "value": 123.456, "status": StatusEnum.RELEASED},
+            {"id": 40, "value": 456.789, "status": StatusEnum.DRAFT},
+        ]
+    )
+    assert results[1] is results[0]
+    assert await Product.query.count() == 1
+
+
+async def test_bulk_create_dedupe_ignore():
+    results = await Product.query.bulk_create(
+        [
+            {"id": 40, "value": 123.456, "status": StatusEnum.RELEASED},
+            {"id": 40, "value": 456.789, "status": StatusEnum.DRAFT},
+        ],
+        ignore_conflicts=True,
+    )
+    assert results[1] is None
+    assert await Product.query.count() == 1

--- a/tests/models/test_bulk_get_or_create.py
+++ b/tests/models/test_bulk_get_or_create.py
@@ -2,9 +2,10 @@ import decimal
 from datetime import date, datetime
 from enum import Enum
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 import edgy
 from edgy.core.db import fields
@@ -28,7 +29,7 @@ class StatusEnum(Enum):
 
 class Product(edgy.StrictModel):
     id: int = fields.IntegerField(primary_key=True, autoincrement=True)
-    uuid: UUID = fields.UUIDField(null=True)
+    uuid: UUID = fields.UUIDField(null=True, unique=True)
     created: datetime = fields.DateTimeField(default=datetime.now)
     created_day: datetime = fields.DateField(default=date.today)
     created_time: datetime = fields.TimeField(default=time)
@@ -190,3 +191,47 @@ async def test_bulk_get_or_create_no_duplicates_filter_by_dict():
     assert products[1].data == {"foo": 456}
     assert products[1].value == 456.789
     assert products[1].status == StatusEnum.DRAFT
+
+
+async def test_bulk_get_or_create_many():
+    await Product.query.bulk_get_or_create(
+        [
+            {"data": {"foo": 123}, "value": 123.456, "status": StatusEnum.RELEASED},
+            {"data": {"foo": 456}, "value": 356.789, "status": StatusEnum.DRAFT},
+            {"data": {"foo": 456}, "value": 456.789, "status": StatusEnum.DRAFT},
+        ],
+        unique_fields=["data"],
+    )
+    products = await Product.query.order_by("id")
+    assert len(products) == 2
+    assert products[0].value == 123.456
+    assert products[1].value == 356.789
+
+
+async def test_bulk_get_or_create_unsuitable_unique():
+    # uuid is here unique but not part of unique_fields
+    products1 = await Product.query.bulk_create(
+        [
+            {"uuid": uuid4(), "status": StatusEnum.RELEASED},
+            {"uuid": uuid4(), "status": StatusEnum.DRAFT},
+            {"uuid": uuid4(), "status": StatusEnum.DRAFT},
+        ],
+    )
+    assert len(products1) == 3
+    with pytest.raises(IntegrityError):
+        await Product.query.bulk_get_or_create(
+            [
+                {"uuid": products1[0].uuid, "status": StatusEnum.RELEASED},
+                {"uuid": products1[0].uuid, "status": StatusEnum.DRAFT},
+                {"uuid": products1[0].uuid, "status": StatusEnum.DRAFT},
+            ],
+        )
+    # this works
+    await Product.query.bulk_get_or_create(
+        [
+            {"uuid": products1[0].uuid, "status": StatusEnum.RELEASED},
+            {"uuid": products1[0].uuid, "status": StatusEnum.DRAFT},
+            {"uuid": products1[0].uuid, "status": StatusEnum.DRAFT},
+        ],
+        unique_fields=["uuid"],
+    )

--- a/tests/models/test_bulk_parallel.py
+++ b/tests/models/test_bulk_parallel.py
@@ -1,0 +1,100 @@
+import decimal
+from datetime import date, datetime
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+import edgy
+from edgy.core.db import fields
+from edgy.testclient import DatabaseTestClient
+from edgy.testing.factory import ModelFactory
+from tests.settings import DATABASE_URL
+
+pytestmark = pytest.mark.anyio
+
+database = DatabaseTestClient(DATABASE_URL, force_rollback=False, drop_database=True)
+models = edgy.Registry(database=database)
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def create_test_database():
+    async with models:
+        await models.create_all()
+        yield
+        if not database.drop:
+            await models.drop_all()
+
+
+def time():
+    return datetime.now().time()
+
+
+class StatusEnum(Enum):
+    DRAFT = "Draft"
+    RELEASED = "Released"
+
+
+class Product(edgy.StrictModel):
+    id: int = fields.IntegerField(primary_key=True, autoincrement=True)
+    uuid: UUID = fields.UUIDField(null=True, unique=True)
+    created: datetime = fields.DateTimeField(default=datetime.now)
+    created_day: datetime = fields.DateField(default=date.today)
+    created_time: datetime = fields.TimeField(default=time)
+    created_date: datetime = fields.DateField(auto_now_add=True)
+    created_datetime: datetime = fields.DateTimeField(auto_now_add=True)
+    updated_datetime: datetime = fields.DateTimeField(auto_now=True)
+    updated_date: datetime = fields.DateField(auto_now=True)
+    data: dict[Any, Any] = fields.JSONField(default=dict)
+    description: str = fields.CharField(null=True, max_length=255)
+    huge_number: int = fields.BigIntegerField(default=0)
+    price: decimal.Decimal = fields.DecimalField(max_digits=9, decimal_places=2, null=True)
+    status: str = fields.ChoiceField(StatusEnum, default=StatusEnum.DRAFT)
+    value: float = fields.FloatField(null=True)
+
+    class Meta:
+        registry = models
+
+
+class ProductFactory(ModelFactory):
+    class Meta:
+        model = Product
+
+
+@pytest.mark.parametrize("method", ["bulk_create", "bulk_update_or_create", "bulk_get_or_create"])
+async def test_bulk_create_like(method):
+    factory = ProductFactory(price=None, uuid=None)
+    inputs = [factory.build(overwrites={"created_time": time()}) for i in range(100)]
+    await getattr(Product.query, method)(inputs)
+
+
+async def test_bulk_create_bulk_ignore():
+    factory = ProductFactory(price=None, uuid=None)
+    inputs = [factory.build(overwrites={"created_time": time()}) for i in range(100)]
+    await Product.query.bulk_create(inputs, ignore_conflicts=True)
+
+
+@pytest.mark.parametrize("rollback", [True, False])
+@pytest.mark.parametrize("method", ["bulk_update", "bulk_update_or_create"])
+async def test_bulk_update_like(method, rollback):
+    factory = ProductFactory(price=None, uuid=None)
+    await Product.query.bulk_create(
+        [factory.build(overwrites={"created_time": time()}) for i in range(100)]
+    )
+    products1 = await Product.query.order_by("id").distinct()
+    inputs2 = [
+        factory.build(overwrites={"id": products1[i].id, "created_time": time()})
+        for i in range(50)
+    ]
+    with database.force_rollback(rollback):
+        products2 = await getattr(Product.query, method)(inputs2)
+        products = await Product.query.order_by("id").distinct()
+    assert len(products) == 100
+    for i in range(100):
+        if i < 50:
+            assert (
+                products[i] == products2[i][0] if isinstance(products2[i], tuple) else products2[i]
+            )
+        else:
+            assert products[i] == products1[i]

--- a/tests/models/test_bulk_update.py
+++ b/tests/models/test_bulk_update.py
@@ -138,7 +138,7 @@ async def test_bulk_update_with_relation():
     albums = await Track.query.update_embed_parent(("album", "")).bulk_update(
         tracks, update_fields=["album"], resolve_embed=True
     )
-    assert isinstance(albums[0], Album)
+    assert isinstance(albums[0], Album.proxy_model)
     tracks = await Track.query.all()
     assert tracks[0].album.pk == album2.pk
     assert tracks[1].album.pk == album2.pk
@@ -162,3 +162,13 @@ async def test_bulk_update_with_relation_unique():
     )
     assert albums[0].embedded.position == 4
     assert albums[1].embedded.position == 5
+
+
+async def test_bulk_update_not_existing():
+    await Album.query.bulk_update([{"name": "foo"}, {"name": "boo"}])
+    assert await Album.query.count() == 0
+
+
+async def test_bulk_update_no_create():
+    await Album.query.bulk_update([{"name": "foo"}, {"name": "boo"}], unique_fields=["name"])
+    assert await Album.query.count() == 0

--- a/tests/models/test_bulk_update_or_create.py
+++ b/tests/models/test_bulk_update_or_create.py
@@ -2,7 +2,7 @@ import decimal
 from datetime import date, datetime
 from enum import Enum
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -28,7 +28,7 @@ class StatusEnum(Enum):
 
 class Product(edgy.StrictModel):
     id: int = fields.IntegerField(primary_key=True, autoincrement=True)
-    uuid: UUID = fields.UUIDField(null=True)
+    uuid: UUID = fields.UUIDField(null=True, unique=True)
     created: datetime = fields.DateTimeField(default=datetime.now)
     created_day: datetime = fields.DateField(default=date.today)
     created_time: datetime = fields.TimeField(default=time)
@@ -224,8 +224,6 @@ async def test_bulk_bulk_update_or_create_resolve_embed():
 
 
 async def test_bulk_bulk_update_or_create_fail():
-    # FIXME: causes warning RuntimeWarning: coroutine 'BulkMixin._bulk_get_update_or_create.<locals>._iterate_retrieve'
-    # was never awaited
     with pytest.raises(ValueError):
         await Track.query.update_embed_parent(("album", "embedded")).bulk_update_or_create(
             [
@@ -234,3 +232,64 @@ async def test_bulk_bulk_update_or_create_fail():
             ],
             resolve_embed=True,
         )
+
+
+async def test_bulk_update_or_create_create_new():
+    await Album.query.bulk_update_or_create([{"name": "foo"}, {"name": "boo"}])
+    assert await Album.query.count() == 2
+    await Album.query.bulk_update_or_create([{"name": "foo"}, {"name": "boo"}])
+    assert await Album.query.count() == 4
+
+
+async def test_bulk_update_or_create_existing_pk():
+    await Album.query.bulk_update_or_create([{"name": "foo"}, {"name": "boo"}])
+    albums = await Album.query.all()
+    assert len(albums) == 2
+    await Album.query.bulk_update_or_create(albums)
+    assert await Album.query.count() == 2
+
+
+async def test_bulk_update_or_create_existing_unique():
+    await Album.query.bulk_update_or_create(
+        [{"name": "foo"}, {"name": "boo"}], unique_fields=["name"]
+    )
+    assert await Album.query.count() == 2
+    await Album.query.bulk_update_or_create(
+        [{"name": "foo"}, {"name": "boo"}], unique_fields=["name"]
+    )
+    assert await Album.query.count() == 2
+
+
+async def test_bulk_update_or_create_unsuitable_unique():
+    # uuid is here unique but not part of unique_fields
+    products1 = await Product.query.bulk_create(
+        [
+            {"uuid": uuid4(), "status": StatusEnum.RELEASED},
+            {"uuid": uuid4(), "status": StatusEnum.DRAFT},
+            {"uuid": uuid4(), "status": StatusEnum.DRAFT},
+        ],
+    )
+    assert len(products1) == 3
+    products = await Product.query.bulk_update_or_create(
+        [
+            {"uuid": products1[0].uuid, "status": StatusEnum.RELEASED},
+            {"uuid": products1[0].uuid, "status": StatusEnum.DRAFT},
+            {"uuid": products1[0].uuid, "status": StatusEnum.DRAFT},
+        ],
+    )
+    assert len(products) == 3
+    assert products[0][0] is None
+    products = await Product.query.all()
+    assert len(products) == 3
+    products = await Product.query.bulk_update_or_create(
+        [
+            {"uuid": products1[0].uuid, "status": StatusEnum.RELEASED},
+            {"uuid": products1[0].uuid, "status": StatusEnum.DRAFT},
+            {"uuid": products1[0].uuid, "status": StatusEnum.DRAFT},
+        ],
+        unique_fields=["id"],
+    )
+    assert len(products) == 3
+    assert products[0][0] is None
+    products = await Product.query.all()
+    assert len(products) == 3

--- a/tests/test_concurrency_utils.py
+++ b/tests/test_concurrency_utils.py
@@ -1,21 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable
 
 import pytest
 
-from edgy.core.utils.concurrency import batched, run_concurrently
+from edgy.core.utils.concurrency import run_concurrently
 
 pytestmark = pytest.mark.anyio
-
-
-def test_batched_invalid_size() -> None:
-    with pytest.raises(ValueError, match="n must be at least one"):
-        tuple(batched((1, 2, 3), 0))
-
-
-def test_batched_groups_items() -> None:
-    assert tuple(batched((1, 2, 3, 4, 5), 2)) == ((1, 2), (3, 4), (5,))
 
 
 async def test_run_concurrently_limit_one_avoids_gather(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -30,3 +22,45 @@ async def test_run_concurrently_limit_one_avoids_gather(monkeypatch: pytest.Monk
 
     result = await run_concurrently([coro(1), coro(2), coro(3)], limit=1)
     assert result == [1, 2, 3]
+
+
+@pytest.mark.parametrize("limit", [2, None, 0, -1])
+async def test_run_concurrently_shall_gather(monkeypatch: pytest.MonkeyPatch, limit) -> None:
+    async def coro(value: int) -> int:
+        await asyncio.sleep(0)
+        return value
+
+    gathered = 0
+
+    async def succeed_gather(*args: Awaitable, **kwargs: object) -> object:
+        nonlocal gathered
+        gathered = len(args)
+        return [await arg for arg in args]
+
+    monkeypatch.setattr(asyncio, "gather", succeed_gather)
+
+    result = await run_concurrently([coro(1), coro(2)], limit=limit)
+    assert result == [1, 2]
+    assert gathered == 2
+
+
+@pytest.mark.parametrize("limit", [0, 1, 2])
+async def test_run_concurrently_fail(limit) -> None:
+    called = 0
+
+    async def coro(value: int) -> None:
+        nonlocal called
+        called += 1
+        await asyncio.sleep(0)
+        raise ValueError
+
+    arr = [coro(1), coro(2), coro(3)]
+    assert called == 0
+    with pytest.raises(ValueError):
+        await run_concurrently(arr, limit=limit)
+    if limit == 0:
+        assert called == 3
+    elif limit == 1:
+        assert called == 1
+    else:
+        assert called == 2


### PR DESCRIPTION
Changes:

- improve `_bulk_get_update_or_create` to ignore create errors
- use improved `_bulk_get_update_or_create` for relation add operations
- expose bulk_create ignore_conflicts
- improve tests
- improve code by resolving cubic.ai pointed issues

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dymmond/edgy/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

