### PR TITLE
fix timestamp support of files

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -33,6 +33,7 @@
 - `run_concurrently` now properly cleans up not executed coroutines in case of an error.
 - `SuspiciousFileOperation` inherits now correctly from `EdgyException`.
 - Return row count for update.
+- Fix `get_created_time`, `get_modified_time` and `get_accessed_time` on filesystem storage. Previously it used a not existing setting and didn't followed the specs.
 
 ### Removed
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -33,7 +33,7 @@
 - `run_concurrently` now properly cleans up not executed coroutines in case of an error.
 - `SuspiciousFileOperation` inherits now correctly from `EdgyException`.
 - Return row count for update.
-- Fix `get_created_time`, `get_modified_time` and `get_accessed_time` on filesystem storage. Previously it used a not existing setting and didn't followed the specs.
+- Fix `get_created_time`, `get_modified_time` and `get_accessed_time` on filesystem storage. Previously it used a non-existing setting and didn't follow the specs.
 
 ### Removed
 

--- a/edgy/core/files/storage/filesystem.py
+++ b/edgy/core/files/storage/filesystem.py
@@ -393,7 +393,7 @@ class FileSystemStorage(Storage):
     def _datetime_from_timestamp(ts: float) -> datetime:
         """
         Converts a UNIX timestamp (float) into a `datetime` object.
-        The datetime will be timezone-aware if `settings.USE_TZ` is True.
+        The datetime will be in utc.
 
         Args:
             ts (float): The UNIX timestamp.
@@ -401,13 +401,12 @@ class FileSystemStorage(Storage):
         Returns:
             datetime: The corresponding `datetime` object.
         """
-        tz = timezone.utc if settings.USE_TZ else None
-        return datetime.fromtimestamp(ts, tz=tz)
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
 
     def get_accessed_time(self, name: str) -> datetime:
         """
         Returns the last accessed time (as a `datetime` object) of the file.
-        The datetime will be timezone-aware if `settings.USE_TZ` is True.
+        The datetime will be in utc.
 
         Args:
             name (str): The name (relative path) of the file.
@@ -420,7 +419,7 @@ class FileSystemStorage(Storage):
     def get_created_time(self, name: str) -> datetime:
         """
         Returns the creation time (as a `datetime` object) of the file.
-        The datetime will be timezone-aware if `settings.USE_TZ` is True.
+        The datetime will be in utc.
 
         Args:
             name (str): The name (relative path) of the file.
@@ -433,7 +432,7 @@ class FileSystemStorage(Storage):
     def get_modified_time(self, name: str) -> datetime:
         """
         Returns the last modified time (as a `datetime` object) of the file.
-        The datetime will be timezone-aware if `settings.USE_TZ` is True.
+        The datetime will be in utc.
 
         Args:
             name (str): The name (relative path) of the file.

--- a/edgy/core/files/storage/filesystem.py
+++ b/edgy/core/files/storage/filesystem.py
@@ -427,7 +427,13 @@ class FileSystemStorage(Storage):
         Returns:
             datetime: The creation time of the file.
         """
-        return self._datetime_from_timestamp(os.path.getctime(self.path(name)))
+        stat_result = os.stat(self.path(name))
+        timestamp = (
+            stat_result.st_birthtime
+            if getattr(stat_result, "st_birthtime", None) is not None
+            else stat_result.st_ctime
+        )
+        return self._datetime_from_timestamp(timestamp)
 
     def get_modified_time(self, name: str) -> datetime:
         """

--- a/tests/fields/test_file_fields.py
+++ b/tests/fields/test_file_fields.py
@@ -118,10 +118,11 @@ async def test_save_file_create(create_test_database):
     with model.file_field.open() as rob:
         assert rob.read() == b"!# /bin/sh"
     path = model.file_field.path
-    assert model.file_field.storage.get_accessed_time(path)
+    name = model.file_field.name
+    assert model.file_field.storage.get_accessed_time(name)
     assert model.file_field.storage.get_modified_time(
-        path
-    ) == model.file_field.storage.get_created_time(path)
+        name
+    ) == model.file_field.storage.get_created_time(name)
     assert os.path.exists(path)
     assert model.file_field.storage.exists(model.file_field.name)
     model.file_field.delete()

--- a/tests/fields/test_file_fields.py
+++ b/tests/fields/test_file_fields.py
@@ -118,6 +118,10 @@ async def test_save_file_create(create_test_database):
     with model.file_field.open() as rob:
         assert rob.read() == b"!# /bin/sh"
     path = model.file_field.path
+    assert model.file_field.storage.get_accessed_time(path)
+    assert model.file_field.storage.get_modified_time(
+        path
+    ) == model.file_field.storage.get_created_time(path)
     assert os.path.exists(path)
     assert model.file_field.storage.exists(model.file_field.name)
     model.file_field.delete()
@@ -126,7 +130,7 @@ async def test_save_file_create(create_test_database):
     assert not os.path.exists(path)
 
 
-async def test_save_file_create_specal(create_test_database):
+async def test_save_file_create_special(create_test_database):
     model = await MyModäl.query.create(ä=edgy.files.ContentFile(b"!# /bin/sh", name="foo.sh"))
     # get cached
     assert model.__dict__["ä"].__dict__["size"] == 10

--- a/tests/fields/test_file_fields.py
+++ b/tests/fields/test_file_fields.py
@@ -122,7 +122,7 @@ async def test_save_file_create(create_test_database):
     assert model.file_field.storage.get_accessed_time(name)
     assert model.file_field.storage.get_modified_time(
         name
-    ) == model.file_field.storage.get_created_time(name)
+    ) >= model.file_field.storage.get_created_time(name)
     assert os.path.exists(path)
     assert model.file_field.storage.exists(model.file_field.name)
     model.file_field.delete()


### PR DESCRIPTION
Changes:
- Fix `get_created_time`, `get_modified_time` and `get_accessed_time` on filesystem storage. Previously it used a not existing setting and didn't followed the specs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dymmond/edgy/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

