### PR TITLE
fix overwrites in tenancy and change interface to fix sources of errors

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -174,10 +174,10 @@ you can set the class variable:
 
 `__require_model_based_deletion__ = True`
 
-Afterwards you can overwrite the `async def raw_delete(skip_post_delete_hooks, remove_referenced_call)` method
+Afterwards you can overwrite the `async def raw_delete(self, *, skip_post_delete_hooks, remove_referenced_call)` method
 for customizing the deletion for QuerySet deletions and direct deletions of a model instance.
 If you only want a special deletion when called directly on a model instance,
-then overload `async def delete(skip_post_delete_hooks=False)`.
+then check in a `raw_delete` overwrite if `CURRENT_INSTANCE.get() is self`.
 
 If you want having also delete signals for virtual cascade deletions and model based deletions
 you set the variable `__deletion_with_signals__` to `True` before calling the internal `raw_delete`.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,6 +25,8 @@
 - Bulk operations are now keywords only (except the first `objs` parameter).
 - Dedupe `bulk_create`, `bulk_get_or_create`, and `bulk_update_or_create` inputs.
 - Refactor `QueryExecutor` so it can update itself.
+- `real_save`, `raw_delete` and `delete` are now keyword only to prevent bad overwrites.
+- Remove the `skip_post_delete_hooks` parameter from `delete` as it is for internal use and shouldn't be exposed.
 
 ### Fixed
 
@@ -53,6 +55,9 @@
 - The typings changed for QuerySetType: `EdgyEmbedTarget` and `EdgyModel` (the queryset model) are switched in the `Generic` definition.
 - Stop issuing `pre_delete` and `post_delete` signals during relation operations; use `pre_relation_remove` and `post_relation_remove` signals instead.
 - `bulk_get_or_create` can return `None` values if signals are used.
+- `real_save`, `raw_delete` and `delete` are now keyword only.
+- Remove the `skip_post_delete_hooks` parameter from `delete` as it is for internal use and shouldn't be exposed. Check in
+  `raw_delete` if `CURRENT_INSTANCE.get() is self` instead.
 
 ## 0.35.11
 

--- a/docs_src/tenancy/example/models.py
+++ b/docs_src/tenancy/example/models.py
@@ -56,10 +56,11 @@ class Tenant(edgy.Model):
 
     async def real_save(
         self,
-        force_insert: bool = False,
-        values: Union[dict[str, Any], set[str], None] = None,
+        *,
+        force_insert: bool,
+        values: Union[dict[str, Any], set[str], None],
     ) -> Model:
-        tenant = await super().real_save(force_insert, values)
+        tenant = await super().real_save(force_insert=force_insert, values=values)
         try:
             await registry.schema.create_schema(
                 schema=tenant.schema_name,

--- a/edgy/contrib/multi_tenancy/models.py
+++ b/edgy/contrib/multi_tenancy/models.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
+import sys
 import uuid
-import warnings
 from datetime import date
 from typing import Any, ClassVar, cast
 from uuid import UUID
@@ -12,10 +12,15 @@ from edgy.core.db.models.model import Model
 from edgy.core.utils.db import check_db_connection
 from edgy.exceptions import ModelSchemaError, ObjectNotFound
 
+if sys.version_info >= (3, 11):  # pragma: no cover
+    from typing import Self
+else:  # pragma: no cover
+    from typing_extensions import Self
+
 logger = logging.getLogger(__name__)
 
 
-class TenantMixin(edgy.Model):
+class TenantMixin(Model):
     """
     Abstract table that acts as an entry-point for managing tenants in an Edgy
     application.
@@ -67,10 +72,7 @@ class TenantMixin(edgy.Model):
         return f"{self.tenant_name} - {self.schema_name}"
 
     async def real_save(
-        self,
-        force_insert: bool = False,
-        values: dict[str, Any] | set[str] | None = None,
-        force_save: bool | None = None,
+        self: Model, *, force_insert: bool, values: dict[str, Any] | set[str] | None
     ) -> Model:
         """
         Creates or updates a tenant record and manages its associated database schema.
@@ -89,7 +91,6 @@ class TenantMixin(edgy.Model):
                                                                 or a set of
                                                                 field names to save.
                                                                 Defaults to `None`.
-            force_save (bool | None, optional): Deprecated. Use `force_insert` instead.
 
         Raises:
             ModelSchemaError: If an attempt is made to save a tenant to
@@ -101,15 +102,6 @@ class TenantMixin(edgy.Model):
         registry = self.meta.registry
         # Ensure the registry is set, as it's crucial for schema operations.
         assert registry, "registry is not set"
-
-        # Deprecation warning for 'force_save'.
-        if force_save is not None:
-            warnings.warn(
-                "'force_save' is deprecated in favor of 'force_insert'",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            force_insert = force_save
 
         # Extract database fields from the model instance.
         fields = self.extract_db_fields()
@@ -132,7 +124,7 @@ class TenantMixin(edgy.Model):
             )
 
         # Save the tenant record using the parent's `real_save` method.
-        tenant = await super().real_save(force_insert, values)
+        tenant: Model = await super().real_save(force_insert=force_insert, values=values)
         if (
             self.auto_create_schema
             if self.auto_create_schema is not None
@@ -157,7 +149,7 @@ class TenantMixin(edgy.Model):
                 await self.delete()
         return tenant
 
-    async def delete(self, force_drop: bool = False) -> int:
+    async def delete(self, *, force_drop: bool = False) -> int | None:
         """
         Deletes a tenant record and, if `auto_drop_schema` is True,
         also drops its associated database schema.
@@ -165,7 +157,7 @@ class TenantMixin(edgy.Model):
         This method includes a safeguard to prevent accidental deletion
         of the default public schema.
 
-        Args:
+        Kwargs:
             force_drop (bool, optional): If `True`, forces the schema to be
                                          dropped regardless of `auto_drop_schema`.
                                          Defaults to `False`.
@@ -224,10 +216,7 @@ class DomainMixin(edgy.Model):
         return self.domain
 
     async def real_save(
-        self: Any,
-        force_insert: bool = False,
-        values: dict[str, Any] | set[str] | None = None,
-        force_save: bool | None = None,
+        self, *, force_insert: bool, values: dict[str, Any] | set[str] | None
     ) -> Model:
         """
         Creates or updates a domain record, ensuring proper handling of the
@@ -246,15 +235,10 @@ class DomainMixin(edgy.Model):
                                                                 or a set of
                                                                 field names to save.
                                                                 Defaults to `None`.
-            force_save (bool | None, optional): Deprecated. Use `force_insert` instead.
 
         Returns:
             Model: The saved domain model instance.
         """
-        # Deprecation warning for 'force_save'.
-        if force_save is not None:
-            force_insert = force_save
-
         # Ensure a database connection is established before proceeding.
         check_db_connection(self.database)
 
@@ -280,9 +264,9 @@ class DomainMixin(edgy.Model):
                 await domains.update(is_primary=False)
 
             # Call the parent's `real_save` method to persist the domain record.
-            return await super().real_save(force_insert, values)
+            return await super().real_save(force_insert=force_insert, values=values)
 
-    async def delete(self) -> int:
+    async def delete(self) -> int | None:
         """
         Deletes a domain record, with a safeguard to prevent accidental
         deletion of the public domain.
@@ -372,7 +356,10 @@ class TenantUserMixin(edgy.Model):
         """
         return f"User: {self.user.pk}, Tenant: {self.tenant}"
 
-    async def real_save(self, *args: Any, **kwargs: Any) -> edgy.Model:
+    async def real_save(
+        self,
+        **kwargs: Any,
+    ) -> Self:
         """
         Creates or updates a tenant user mapping, ensuring that only one
         mapping for a given user is `is_active=True`.
@@ -381,7 +368,6 @@ class TenantUserMixin(edgy.Model):
         mappings for the same user will be automatically set to `is_active=False`.
 
         Args:
-            *args (Any): Positional arguments passed to the parent's `real_save` method.
             **kwargs (Any): Keyword arguments passed to the parent's `real_save` method.
 
         Returns:
@@ -392,7 +378,7 @@ class TenantUserMixin(edgy.Model):
         assert registry, "registry is not set"
 
         # Call the parent's `real_save` method to persist the current record.
-        await super().real_save(*args, **kwargs)
+        await super().real_save(**kwargs)
 
         # If the current mapping is set to active, deactivate all other active
         # mappings for the same user.

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -976,14 +976,12 @@ class DatabaseMixin:
             )
         return row_count
 
-    async def delete(self: Model, skip_post_delete_hooks: bool = False) -> int:
+    async def delete(self: Model) -> int | None:
         """
         Deletes the current model instance from the database.
 
         This method triggers pre-delete and post-delete signals.
 
-        Args:
-            skip_post_delete_hooks: If True, post-delete hooks will not be executed.
         """
         real_class = self.get_real_class()
         try:
@@ -998,7 +996,7 @@ class DatabaseMixin:
         token = CURRENT_INSTANCE.set(self)
         try:
             row_count = await self.raw_delete(
-                skip_post_delete_hooks=skip_post_delete_hooks,
+                skip_post_delete_hooks=False,
                 remove_referenced_call=False,
             )
         except SkipOperation:
@@ -1196,6 +1194,7 @@ class DatabaseMixin:
 
     async def real_save(
         self,
+        *,
         force_insert: bool,
         values: dict[str, Any] | set[str] | None,
     ) -> Self:

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -191,8 +191,9 @@ class BaseModelType(ABC):
     @abstractmethod
     async def real_save(
         self,
-        force_insert: bool = False,
-        values: dict[str, Any] | set[str] | list[str] | None = None,
+        *,
+        force_insert: bool,
+        values: dict[str, Any] | set[str] | list[str] | None,
     ) -> BaseModelType:
         """
         Abstract asynchronous method for saving the model instance to the database.
@@ -200,7 +201,7 @@ class BaseModelType(ABC):
         This is the raw save operation used internally by querysets and direct calls.
         It allows for fine-grained control over the save process.
 
-        Args:
+        Kwargs:
             force_insert (bool): If `True`, forces an SQL INSERT operation, even if
                                  the instance might already exist (e.g., if primary key is set).
                                  Defaults to `False`.
@@ -225,7 +226,7 @@ class BaseModelType(ABC):
         This is the user-facing save operation, intended for direct calls on model instances.
         It provides a simpler interface compared to `real_save`.
 
-        Args:
+        Kwargs:
             force_insert (bool): If `True`, forces an SQL INSERT operation. Defaults to `False`.
             values (dict[str, Any] | set[str] | list[str] | None): Optional. Values or field names
                                                                  to save. Defaults to `None`.
@@ -264,16 +265,13 @@ class BaseModelType(ABC):
         """
 
     @abstractmethod
-    async def delete(self, skip_post_delete_hooks: bool = False) -> int | None:
+    async def delete(self) -> int | None:
         """
         Abstract asynchronous method to delete the model instance from the database.
 
         This is the user-facing delete operation, intended for direct calls on
         model instances and not typically used by internal methods which prefer `raw_delete`.
 
-        Args:
-            skip_post_delete_hooks (bool): If `True`, skips the execution of post-delete
-                                           hooks on related fields. Defaults to `False`.
         """
 
     @abstractmethod
@@ -392,7 +390,7 @@ class BaseModelType(ABC):
         phase: str = "",
         instance: BaseModelType | QuerySetType | None = None,
         model_instance: BaseModelType | None = None,
-        evaluate_kwarg_values: bool = False,
+        evaluate_values: bool = False,
     ) -> dict[str, Any]:
         """
         Abstract class method to extract and process column values from a dictionary,
@@ -416,9 +414,8 @@ class BaseModelType(ABC):
                                                          Defaults to `None`.
             model_instance (BaseModelType | None): The specific model instance being operated on.
                                                   Defaults to `None`.
-            evaluate_kwarg_values (bool): If `True`, evaluates values that are
-                                         callable (e.g., default factories).
-                                         Defaults to `False`.
+            evaluate_values (bool): If `True`, evaluates values that are callable (e.g., default factories).
+                                    Defaults to `False`.
 
         Returns:
             dict[str, Any]: A dictionary containing the extracted and processed column values.

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -656,14 +656,16 @@ class BaseQuerySet(
         return queryset
 
     async def raw_delete(
-        self, use_models: bool = False, remove_referenced_call: str | bool = False
-    ) -> int:
+        self, *, use_models: bool = False, remove_referenced_call: str | bool = False
+    ) -> int | None:
         """
-        Executes delete without raising an extra signal.
+        Internal delete method.
+
+        Exposes remove_referenced_call and doesn't raise an extra signal.
 
         Delegates to QueryExecutor.delete.
         """
-        # We must create new specialists *every time* because the queryset
+        # We must create new executors *every time* because the queryset
         # state might have changed (e.g., in _model_based_delete)
         executor = QueryExecutor(self)
 

--- a/edgy/core/db/querysets/executor.py
+++ b/edgy/core/db/querysets/executor.py
@@ -314,7 +314,7 @@ class QueryExecutor(Generic[EdgyModel, EdgyEmbedTarget]):
         use_models: bool = False,
         remove_referenced_call: str | bool = False,
         injected_filters: Iterable = (),
-    ) -> int:
+    ) -> int | None:
         """
         Executes a delete operation.
 
@@ -348,7 +348,7 @@ class QueryExecutor(Generic[EdgyModel, EdgyEmbedTarget]):
 
             check_db_connection(self.database)
             async with self.database as database:
-                row_count = cast(int, await database.execute(expression))
+                row_count = cast(int | None, await database.execute(expression))
 
         # clear cache after deletion.
         if row_count != 0:

--- a/edgy/core/db/querysets/queryset.py
+++ b/edgy/core/db/querysets/queryset.py
@@ -1017,7 +1017,7 @@ class QuerySet(BaseQuerySet[EdgyModel, EdgyEmbedTarget], Generic[EdgyModel, Edgy
         queryset.embed_parent = embed_parent
         return queryset
 
-    async def delete(self, use_models: bool = False) -> int:
+    async def delete(self, *, use_models: bool = False) -> int | None:
         """
         Deletes records from the database.
 

--- a/edgy/core/db/querysets/types.py
+++ b/edgy/core/db/querysets/types.py
@@ -788,7 +788,17 @@ class QuerySetType(ABC, Generic[EdgyModel, EdgyEmbedTarget]):
     bulk_select_or_insert = bulk_get_or_create
 
     @abstractmethod
-    async def delete(self) -> int:
+    async def raw_delete(
+        self, *, use_models: bool = False, remove_referenced_call: str | bool = False
+    ) -> int | None:
+        """
+        Abstract internal delete method.
+
+        Exposes remove_referenced_call and doesn't raise an extra signal.
+        """
+
+    @abstractmethod
+    async def delete(self, *, use_models: bool = False) -> int | None:
         """
         Abstract method to delete all objects matching the QuerySet criteria from the database.
         """

--- a/tests/models/test_model_class.py
+++ b/tests/models/test_model_class.py
@@ -170,5 +170,5 @@ async def test_queryset_cache(model_based, create_test_database):
     assert len(queryset._cache.cache[queryset._cache.create_category(User)]) == 3
     await queryset.create(name="Test 4")
     assert len(queryset._cache.cache[queryset._cache.create_category(User)]) == 4
-    await queryset.delete(model_based)
+    await queryset.delete(use_models=model_based)
     assert not queryset._cache

--- a/tests/signals/test_deletion_signals_skip.py
+++ b/tests/signals/test_deletion_signals_skip.py
@@ -137,7 +137,7 @@ async def test_deletion_called_once_query(klass, model_based):
     await klass.query.create(name="Edgy")
     logs = await Log.query.all()
     assert len(logs) == 0
-    await klass.query.delete(model_based)
+    await klass.query.delete(use_models=model_based)
     assert await klass.query.count() == 1
     logs = await Log.query.all()
     assert len(logs) == 1


### PR DESCRIPTION
Changes:
- make some methods keyword only to prevent incorrect overwrites
- fix tenancy overwrites
- remove `skip_post_delete_hooks` parameter from delete`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dymmond/edgy/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

