### PR TITLE
add lazy to mode to ForeignKeys and ManyToMany

### DIFF
--- a/docs/fields/index.md
+++ b/docs/fields/index.md
@@ -595,6 +595,25 @@ When the second parameter is empty, the parent object is not included as attribu
 
 The reverse end of a `ForeignKey` is a [Many to one relation](../queries/many-to-one.md).
 
+##### Swappable library version
+
+You can also use a function as `to`. This is particular useful for libraries where models should be able to be swapped.
+
+
+```python
+import edgy
+
+class LibraryModel(edgy.Model):
+    user: User = edgy.ForeignKey(lambda: edgy.settings.default_user, on_delete=edgy.CASCADE)
+    class Meta:
+        abstract = True
+```
+
+!!! Warning
+    When changing the setting you might need to adapt your migrations.
+
+!!! Warning
+    When a registry is defined or not abstract the lambda is immediately resolved.
 
 ##### Parameters
 
@@ -677,6 +696,26 @@ class MyModel(edgy.Model):
 
 !!! Tip
     You can use `edgy.ManyToManyField` as alternative to `ManyToMany` instead.
+
+##### Swappable library version
+
+You can also use a function as `to` like with `ForeignKey`. This is particular useful for libraries where models should be able to be swapped.
+
+```python
+import edgy
+
+class LibraryModel(edgy.Model):
+    users: User = edgy.ManyToMany(lambda: edgy.settings.default_user)
+
+    class Meta:
+        abstract = True
+```
+
+!!! Warning
+    When changing the setting you might need to adapt your migrations.
+
+!!! Warning
+    When a registry is defined or not abstract the lambda is immediately resolved.
 
 ##### Parameters
 

--- a/docs/fields/index.md
+++ b/docs/fields/index.md
@@ -705,7 +705,7 @@ You can also use a function as `to` like with `ForeignKey`. This is particular u
 import edgy
 
 class LibraryModel(edgy.Model):
-    users: User = edgy.ManyToMany(lambda: edgy.settings.default_user)
+    users: list[User] = edgy.ManyToMany(lambda: edgy.settings.default_user)
 
     class Meta:
         abstract = True

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,7 @@
 - Add bulk signals (`pre/post_bulk`).
 - Add `SkipOperation` exception for signals.
 - Add `injected_filters` parameter for `pre_delete` to dynamically inject protection rules.
+- Allow lazy references for `ForeignKey` and `ManyToMany`. This is useful for libraries.
 
 ### Changed
 

--- a/edgy/contrib/multi_tenancy/models.py
+++ b/edgy/contrib/multi_tenancy/models.py
@@ -199,7 +199,7 @@ class DomainMixin(edgy.Model):
 
     domain: str = edgy.CharField(max_length=253, unique=True, db_index=True)
     tenant: Any = edgy.ForeignKey(
-        edgy.monkay.settings.tenant_model, index=True, related_name="domains"
+        lambda: edgy.monkay.settings.tenant_model, index=True, related_name="domains"
     )
     is_primary: bool = edgy.BooleanField(default=True, index=True)
 
@@ -299,12 +299,12 @@ class TenantUserMixin(edgy.Model):
     """
 
     user: Any = edgy.ForeignKey(
-        edgy.monkay.settings.auth_user_model,
+        lambda: edgy.monkay.settings.auth_user_model,
         null=False,
         related_name="tenant_user_users",
     )
     tenant: Any = edgy.ForeignKey(
-        edgy.monkay.settings.tenant_model,
+        lambda: edgy.monkay.settings.tenant_model,
         null=False,
         related_name="tenant_users_tenant",
     )

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -1174,6 +1174,8 @@ class BaseForeignKey(RelationshipField):
         """Set `to` to value and clear cache."""
         with contextlib.suppress(AttributeError):
             delattr(self, "_to_cached")
+        with contextlib.suppress(AttributeError):
+            delattr(self, "_target")
         self._to = value
 
     @to.deleter
@@ -1181,6 +1183,8 @@ class BaseForeignKey(RelationshipField):
         """Clear cache of `to`."""
         with contextlib.suppress(AttributeError):
             delattr(self, "_to_cached")
+        with contextlib.suppress(AttributeError):
+            delattr(self, "_target")
         # keep _to because it is required
 
     @property
@@ -1213,10 +1217,7 @@ class BaseForeignKey(RelationshipField):
         Args:
             value: The target model class to set.
         """
-        # Suppress AttributeError if _target doesn't exist and delete it.
-        with contextlib.suppress(AttributeError):
-            delattr(self, "_target")
-        # Set the 'to' attribute to the new value.
+        # Set the 'to' attribute to the new value and clear with this the caches
         self.to = value
 
     @target.deleter

--- a/edgy/core/db/fields/base.py
+++ b/edgy/core/db/fields/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import inspect
 from abc import abstractmethod
 from collections.abc import Sequence
 from functools import cached_property
@@ -1155,6 +1156,32 @@ class BaseForeignKey(RelationshipField):
         # Suppress AttributeError if _target_registry doesn't exist.
         with contextlib.suppress(AttributeError):
             delattr(self, "_target_registry")
+
+    @property
+    def to(self) -> Any:
+        """Manages to. Resolves lazy attributes."""
+        # Check if _to_cached attribute is already set.
+        if not hasattr(self, "_to_cached"):
+            to = self._to
+            if not inspect.isclass(to) and callable(to):
+                self._to_cached = to()
+            else:
+                self._to_cached = to
+        return self._to_cached
+
+    @to.setter
+    def to(self, value: Any) -> None:
+        """Set `to` to value and clear cache."""
+        with contextlib.suppress(AttributeError):
+            delattr(self, "_to_cached")
+        self._to = value
+
+    @to.deleter
+    def to(self) -> None:
+        """Clear cache of `to`."""
+        with contextlib.suppress(AttributeError):
+            delattr(self, "_to_cached")
+        # keep _to because it is required
 
     @property
     def target(self) -> Any:

--- a/edgy/core/db/fields/factories.py
+++ b/edgy/core/db/fields/factories.py
@@ -328,7 +328,7 @@ class ForeignKeyFieldFactory(FieldFactory):
     def __new__(
         cls,
         *,
-        to: Any = None,
+        to: Any,
         on_update: str = CASCADE,
         on_delete: str = RESTRICT,
         related_name: str | Literal[False] = "",
@@ -343,7 +343,6 @@ class ForeignKeyFieldFactory(FieldFactory):
 
         Args:
             to (Any): The target model or model name to which the foreign key points.
-                      Defaults to `None`.
             on_update (str): The action to perform on update of the referenced key.
                              Defaults to `CASCADE`.
             on_delete (str): The action to perform on deletion of the referenced row.
@@ -391,15 +390,17 @@ class ForeignKeyFieldFactory(FieldFactory):
         null = kwargs["null"]
 
         if on_delete is None:
-            raise FieldDefinitionError("on_delete must not be null.")
+            raise FieldDefinitionError("`on_delete` must not be `None`.")
+        if kwargs.get("target") is not None:
+            raise FieldDefinitionError("`target` must be `None`.")
 
         # If SET_NULL is enabled for on_delete, the field must be nullable.
         if on_delete == SET_NULL and not null:
-            raise FieldDefinitionError("When SET_NULL is enabled, null must be True.")
+            raise FieldDefinitionError("When SET_NULL is enabled, null must be `True`.")
 
         # If SET_NULL is enabled for on_update, the field must be nullable.
         if on_update and (on_update == SET_NULL and not null):
-            raise FieldDefinitionError("When SET_NULL is enabled, null must be True.")
+            raise FieldDefinitionError("When SET_NULL is enabled, null must be `True`.")
         related_name = kwargs.get("related_name", "")
 
         # related_name can be None or False, which is tolerated.

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -750,7 +750,7 @@ class ForeignKey(ForeignKeyFieldFactory, cast(Any, object)):
 
     def __new__(
         cls,
-        to: type[BaseModelType] | str,
+        to: type[BaseModelType] | str | Callable[[], type[BaseModelType] | str],
         **kwargs: Any,
     ) -> BaseFieldType:
         """
@@ -760,8 +760,9 @@ class ForeignKey(ForeignKeyFieldFactory, cast(Any, object)):
         `kwargs` to the parent `ForeignKeyFieldFactory` for field construction.
 
         Args:
-            to (type[BaseModelType] | str): The target model class or its string name
-                                          to which this foreign key points.
+            to (type[BaseModelType] | str | Callable[[], type[BaseModelType] | str]):
+                The target model class or its string name or a lazy version of it
+                to which this foreign key points.
             **kwargs (Any): Additional keyword arguments for the foreign key field.
 
         Returns:

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -539,7 +539,7 @@ class ManyToManyField(ForeignKeyFieldFactory, list):
 
     def __new__(
         cls,
-        to: BaseModelType | type[Model] | str,
+        to: type[BaseModelType] | str | Callable[[], type[BaseModelType] | str],
         *,
         to_fields: Sequence[str] = (),
         to_foreign_key: str = "",
@@ -554,7 +554,9 @@ class ManyToManyField(ForeignKeyFieldFactory, list):
         Creates a new `ManyToManyField` instance.
 
         Args:
-            to (Union[BaseModelType, type[Model], str]): The target model class or its string name.
+            to (type[BaseModelType] | str | Callable[[], type[BaseModelType] | str]):
+                The target model class or its string name or a lazy version of it
+                to which this foreign key points.
             to_fields (Sequence[str]): Fields on the `target` model that the `through`
                                       model's foreign key to `target` will reference.
             to_foreign_key (str): The name of the foreign key field in the `through`

--- a/edgy/core/db/fields/ref_foreign_key.py
+++ b/edgy/core/db/fields/ref_foreign_key.py
@@ -80,7 +80,7 @@ class RefForeignKey(ForeignKeyFieldFactory, list):
         """
         return None
 
-    def __new__(cls, to: ModelRef, null: bool = False) -> BaseFieldType:
+    def __new__(cls, to: type[ModelRef], null: bool = False) -> BaseFieldType:
         """
         Creates a new `RefForeignKey` instance.
 

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -1066,6 +1066,9 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
                     )
                 # make sure we have a fresh copy where we can set the owner and overwrite methods
                 value = copy.copy(value)
+                if isinstance(value, BaseForeignKey) and getattr(value, "_target", None) is None:
+                    # clear cache if target isn't set (e.g. abstract class)
+                    del value.to
                 if value.factory is not None:
                     value.factory.repack(value)
                 if value.primary_key:

--- a/edgy/core/db/models/metaclasses.py
+++ b/edgy/core/db/models/metaclasses.py
@@ -1066,7 +1066,7 @@ class BaseModelMeta(ModelMetaclass, ABCMeta):
                     )
                 # make sure we have a fresh copy where we can set the owner and overwrite methods
                 value = copy.copy(value)
-                if isinstance(value, BaseForeignKey) and getattr(value, "_target", None) is None:
+                if isinstance(value, BaseForeignKey) and not hasattr(value, "_target"):
                     # clear cache if target isn't set (e.g. abstract class)
                     del value.to
                 if value.factory is not None:

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -206,7 +206,7 @@ def _set_related_name_for_foreign_keys(
         return
 
     for name in meta.foreign_key_fields:
-        foreign_key = meta.fields[name]
+        foreign_key = cast("BaseForeignKey", meta.fields[name])
         related_name = getattr(foreign_key, "related_name", None)
         if related_name is False:
             # skip related_field

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -35,14 +35,21 @@ class Album(edgy.StrictModel):
         registry = models
 
 
-class Track(edgy.StrictModel):
-    id = edgy.IntegerField(primary_key=True, autoincrement=True)
-    album = edgy.ForeignKey("Album", on_delete=edgy.CASCADE, null=True)
-    title = edgy.CharField(max_length=100)
-    position = edgy.IntegerField()
+class BaseTrack(edgy.StrictModel):
+    album = edgy.ForeignKey(lambda: lazy_album, on_delete=edgy.CASCADE, null=True)
 
     class Meta:
+        abstract = True
         registry = models
+
+
+lazy_album = "Album"
+
+
+class Track(BaseTrack):
+    id = edgy.IntegerField(primary_key=True, autoincrement=True)
+    title = edgy.CharField(max_length=100)
+    position = edgy.IntegerField()
 
 
 class Organisation(edgy.StrictModel):
@@ -355,7 +362,7 @@ async def test_assertation_error_on_set_null():
         class MyOtherModel(edgy.StrictModel):
             model = edgy.ForeignKey(MyModel, on_delete=edgy.SET_NULL)
 
-    assert raised.value.args[0] == "When SET_NULL is enabled, null must be True."
+    assert raised.value.args[0] == "When SET_NULL is enabled, null must be `True`."
 
 
 async def test_error_on_missing_on_delete():
@@ -367,7 +374,7 @@ async def test_error_on_missing_on_delete():
         class MyOtherModel(edgy.StrictModel):
             model = edgy.ForeignKey(MyModel, on_delete=None)
 
-    assert raised.value.args[0] == "on_delete must not be null."
+    assert raised.value.args[0] == "`on_delete` must not be `None`."
 
 
 async def test_error_on_embed_parent_double_underscore_attr():

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -8,8 +8,8 @@ from tests.settings import DATABASE_URL
 
 pytestmark = pytest.mark.anyio
 
-database = DatabaseTestClient(DATABASE_URL)
-models = edgy.Registry(database=edgy.Database(database, force_rollback=True))
+database = DatabaseTestClient(DATABASE_URL, full_isolation=False)
+models = edgy.Registry(database=database)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -62,7 +62,7 @@ class Organisation(edgy.StrictModel):
 
 class Team(edgy.StrictModel):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
-    org = edgy.ForeignKey(Organisation, on_delete=edgy.RESTRICT)
+    org = edgy.ForeignKey(lambda: Organisation, on_delete=edgy.RESTRICT)
     name = edgy.CharField(max_length=100)
 
     class Meta:

--- a/tests/foreign_keys/test_foreignkey_special.py
+++ b/tests/foreign_keys/test_foreignkey_special.py
@@ -12,7 +12,7 @@ models = edgy.Registry(database=database)
 
 class Älbum(edgy.StrictModel):
     äd = edgy.IntegerField(primary_key=True, autoincrement=True, column_name="id")
-    name = edgy.CharField(max_length=100)
+    name = edgy.CharField(max_length=100, primary_key=True)
 
     class Meta:
         registry = models
@@ -41,6 +41,11 @@ async def rollback_connections():
     with database.force_rollback():
         async with database:
             yield
+
+
+async def test_columns():
+    assert Track.meta.field_to_column_names["album"] == {"album_äd", "album_name"}
+    assert Track.table.columns.album_äd.name == "album_id"
 
 
 async def test_new_create():

--- a/tests/foreign_keys/test_foreignkey_unique_and_no_constraint.py
+++ b/tests/foreign_keys/test_foreignkey_unique_and_no_constraint.py
@@ -294,7 +294,7 @@ async def test_assertation_error_on_set_null():
         class MyOtherModel(edgy.StrictModel):
             model = edgy.ForeignKey(MyModel, on_delete=edgy.SET_NULL)
 
-    assert raised.value.args[0] == "When SET_NULL is enabled, null must be True."
+    assert raised.value.args[0] == "When SET_NULL is enabled, null must be `True`."
 
 
 async def test_assertation_error_on_missing_on_delete():

--- a/tests/foreign_keys/test_foreignkey_unique_and_no_constraint.py
+++ b/tests/foreign_keys/test_foreignkey_unique_and_no_constraint.py
@@ -306,4 +306,4 @@ async def test_assertation_error_on_missing_on_delete():
         class MyOtherModel(edgy.StrictModel):
             model = edgy.ForeignKey(MyModel, on_delete=None)
 
-    assert raised.value.args[0] == "on_delete must not be null."
+    assert raised.value.args[0] == "`on_delete` must not be `None`."

--- a/tests/foreign_keys/test_many_to_many_field.py
+++ b/tests/foreign_keys/test_many_to_many_field.py
@@ -30,7 +30,7 @@ class Track(edgy.StrictModel):
 
 
 class BaseAlbum(edgy.StrictModel):
-    tracks = edgy.ForeignKey(lambda: lazy_track, embed_through="embedded")
+    tracks = edgy.ManyToMany(lambda: lazy_track, embed_through="embedded")
 
     class Meta:
         abstract = True

--- a/tests/foreign_keys/test_many_to_many_field.py
+++ b/tests/foreign_keys/test_many_to_many_field.py
@@ -29,10 +29,20 @@ class Track(edgy.StrictModel):
         registry = models
 
 
-class Album(edgy.StrictModel):
+class BaseAlbum(edgy.StrictModel):
+    tracks = edgy.ForeignKey(lambda: lazy_track, embed_through="embedded")
+
+    class Meta:
+        abstract = True
+        registry = models
+
+
+lazy_track = "Track"
+
+
+class Album(BaseAlbum):
     id = edgy.IntegerField(primary_key=True, autoincrement=True)
     name = edgy.CharField(max_length=100)
-    tracks = edgy.ManyToMany(Track, embed_through="embedded")
 
     class Meta:
         registry = models
@@ -40,7 +50,7 @@ class Album(edgy.StrictModel):
 
 class Studio(edgy.StrictModel):
     name = edgy.CharField(max_length=255)
-    users = edgy.ManyToMany(User)
+    users = edgy.ManyToMany(lambda: User)
     albums = edgy.ManyToMany(Album)
 
     class Meta:


### PR DESCRIPTION
Changes:
- add lazy `to` mode for ForeignKeys and ManyToMany
- migrate tenancy to it

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dymmond/edgy/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

