### PR TITLE
add dirty tracking

### DIFF
--- a/docs/fields/custom.md
+++ b/docs/fields/custom.md
@@ -88,6 +88,7 @@ Within a model context it contains the current phase it is called for:
 * `init`: Called    in model `__init__`.
 * `init_db`: Called in model `__init__` when loaded from a row.
 * `set`: Called in model `__setattr__` (when setting an attribute).
+* `prepare_clauses`: Called in identifying clauses.
 * `load`: Called after load. Contains db values.
 * `post_insert`: Called after insert. Arguments are the ones passed to save.
 * `post_update`: Called after update. Arguments are the ones passed to save.

--- a/docs/fields/custom.md
+++ b/docs/fields/custom.md
@@ -88,7 +88,6 @@ Within a model context it contains the current phase it is called for:
 * `init`: Called    in model `__init__`.
 * `init_db`: Called in model `__init__` when loaded from a row.
 * `set`: Called in model `__setattr__` (when setting an attribute).
-* `prepare_clauses`: Called in identifying clauses.
 * `load`: Called after load. Contains db values.
 * `post_insert`: Called after insert. Arguments are the ones passed to save.
 * `post_update`: Called after update. Arguments are the ones passed to save.
@@ -99,7 +98,7 @@ For  `extract_column_values` following phases exist (except when called manually
 * `prepare_update`: Called in extract_column_values for update.
 * `delete`: Called when preparing deletion.
 
-Comparing, accessing the values and generating clauses have no `CURRENT_PHASE` set nor `CURRENT_INSTANCE` nor `CURRENT_MODEL_INSTANCE`.
+Comparing, accessing the values and generating clauses have no `CURRENT_PHASE` set (`CURRENT_PHASE.get() == ""`) nor `CURRENT_INSTANCE` nor `CURRENT_MODEL_INSTANCE`.
 
 ### Using the field context
 

--- a/docs/fields/custom.md
+++ b/docs/fields/custom.md
@@ -92,7 +92,6 @@ Within a model context it contains the current phase it is called for:
 * `load`: Called after load. Contains db values.
 * `post_insert`: Called after insert. Arguments are the ones passed to save.
 * `post_update`: Called after update. Arguments are the ones passed to save.
-* `compare`: Called when comparing model instances (bypasses `extract_column_values`).
 
 For  `extract_column_values` following phases exist (except when called manually):
 
@@ -100,6 +99,7 @@ For  `extract_column_values` following phases exist (except when called manually
 * `prepare_update`: Called in extract_column_values for update.
 * `delete`: Called when preparing deletion.
 
+Comparing, accessing the values and generating clauses have no `CURRENT_PHASE` set nor `CURRENT_INSTANCE` nor `CURRENT_MODEL_INSTANCE`.
 
 ### Using the field context
 
@@ -109,7 +109,7 @@ You can manipulate it like you wish but it will be resetted after the field has 
 ### Using the instance
 
 There are 2 ContextVar named `CURRENT_INSTANCE` and `CURRENT_MODEL_INSTANCE`. `CURRENT_INSTANCE` is the executing instance of a QuerySet or Model while
-`CURRENT_MODEL_INSTANCE` is always a model instance or `None`. When calling manually also `CURRENT_INSTANCE` can be `None`.
+`CURRENT_MODEL_INSTANCE` is always a model instance or `None` (get like access like comparing, generating clauses). When calling manually also `CURRENT_INSTANCE` can be `None`.
 They are available during setting an attribute, `transform_input` and `extract_column_values` calls when set as well as in the `pre_save_callback` or `post_save_callback` hooks.
 This implies you can use them in all sub methods like get_default...
 
@@ -135,7 +135,7 @@ For getting an immutable object attached to a Model instance, there are two ways
 
 The last way is a bit more complicated than managers. You need to consider 3 ways the field is affected:
 
-1. `__init__` and `load`: Some values are passed to the field. Use `to_model` for providing an initial object with the CURRENT_INSTANCE context var.
+1. `__init__` and `load`: Some values are passed to the field. Use `to_model` for providing an initial object with the `CURRENT_MODEL_INSTANCE` context var.
     Note: this doesn't gurantee the initialization. We still need the  `__get__`-
 2. `__getattr__` here the object can get an instance it can attach to. Use `__get__` for this.
 3. Set access. Either use `__set__` or `to_model` so it uses the old value.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@
 - Add `SkipOperation` exception for signals.
 - Add `injected_filters` parameter for `pre_delete` to dynamically inject protection rules.
 - Allow lazy references for `ForeignKey` and `ManyToMany`. This is useful for libraries.
+- Add dirty tracking.
 
 ### Changed
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,6 +29,7 @@
 - Refactor `QueryExecutor` so it can update itself.
 - `real_save`, `raw_delete` and `delete` are now keyword only to prevent bad overwrites.
 - Remove the `skip_post_delete_hooks` parameter from `delete` as it is for internal use and shouldn't be exposed.
+- (Internal detail only) bypass the overwritten `__getattr__`, `__getattribute__` and `__setattr__` for speed improvements.
 
 ### Fixed
 

--- a/edgy/contrib/contenttypes/fields.py
+++ b/edgy/contrib/contenttypes/fields.py
@@ -96,7 +96,11 @@ class BaseContentTypeField(BaseForeignKeyField):
         return cast(
             ManyRelationProtocol,
             SingleRelation(
-                to=self.owner, to_foreign_key=self.name, embed_parent=self.embed_parent, **kwargs
+                to=self.owner,
+                reverse_name=self.reverse_name,
+                to_foreign_key=self.name,
+                embed_parent=self.embed_parent,
+                **kwargs,
             ),
         )
 

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -189,7 +189,15 @@ class BaseForeignKeyField(BaseForeignKey):
         # If the value is already a target model instance or its proxy.
         if isinstance(value, target | target.proxy_model):
             # Save the related model first to ensure its primary key is available.
-            await value.real_save(force_insert=False, values=None)
+            if value._db_dirty is not None:
+                # when None _db_dirty is disabled so don't try to save
+                if not value._db_loaded or not value.can_load:
+                    # save when not loaded (could affect relationship)
+                    # required; otherwise save loops can happen.
+                    await value.real_save(force_insert=False, values=None)
+                else:
+                    # save when fields were changed (could affect relationship)
+                    await value.real_save(force_insert=False, values=value._db_dirty)
             # Clean the value to extract the foreign key column values.
             _value: dict[str, Any] = self.clean(self.name, value, for_query=False)
             # it is an error if it couldn't be parsed.
@@ -237,7 +245,11 @@ class BaseForeignKeyField(BaseForeignKey):
         return cast(
             ManyRelationProtocol,
             relation(
-                to=self.owner, to_foreign_key=self.name, embed_parent=self.embed_parent, **kwargs
+                to=self.owner,
+                reverse_name=self.reverse_name,
+                to_foreign_key=self.name,
+                embed_parent=self.embed_parent,
+                **kwargs,
             ),
         )
 

--- a/edgy/core/db/fields/foreign_keys.py
+++ b/edgy/core/db/fields/foreign_keys.py
@@ -188,8 +188,12 @@ class BaseForeignKeyField(BaseForeignKey):
 
         # If the value is already a target model instance or its proxy.
         if isinstance(value, target | target.proxy_model):
+            maybe_loop = False
+            db_dirty = value._db_dirty
             # Save the related model first to ensure its primary key is available.
-            if value._db_dirty is not None:
+            if db_dirty is None:
+                maybe_loop = True
+            else:
                 # when None _db_dirty is disabled so don't try to save
                 if not value._db_loaded or not value.can_load:
                     # save when not loaded (could affect relationship)
@@ -197,11 +201,17 @@ class BaseForeignKeyField(BaseForeignKey):
                     await value.real_save(force_insert=False, values=None)
                 else:
                     # save when fields were changed (could affect relationship)
-                    await value.real_save(force_insert=False, values=value._db_dirty)
+                    await value.real_save(force_insert=False, values=db_dirty)
             # Clean the value to extract the foreign key column values.
             _value: dict[str, Any] = self.clean(self.name, value, for_query=False)
             # it is an error if it couldn't be parsed.
-            if isinstance(_value.get(self.name), BaseModelType):
+            if isinstance(_value.get(self.name), BaseModelType) or (
+                original_value is not None and not _value
+            ):
+                if maybe_loop:
+                    raise ValueError(
+                        f"Couldn't save `{self.name}`. Please save child first. Is a loop?"
+                    )
                 raise ValueError(f"Couldn't save `{self.name}`.")
             return _value
         # If the value is a dictionary, convert it to a target model instance and

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -506,15 +506,13 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         `ManyRelationProtocol` object associated with that instance, initializing it
         if it hasn't been already.
         """
-        if instance:
-            # If the relation hasn't been set or is None, initialize it.
-            if instance.__dict__.get(self.name, None) is None:
-                instance.__dict__[self.name] = self.get_relation()
-            # Ensure the relation object has a reference to its instance.
-            if instance.__dict__[self.name].instance is None:
-                instance.__dict__[self.name].instance = instance
-            return instance.__dict__[self.name]  # type: ignore
-        raise ValueError("Missing instance")
+        if instance is None:
+            raise ValueError("Missing instance")
+        # If the relation hasn't been set or is None, initialize it.
+        relation: ManyRelationProtocol | None
+        if (relation := instance.__dict__.get(self.name, None)) is None:
+            relation = instance.__dict__[self.name] = self.get_relation()
+        return relation.__get__(instance, owner)
 
     async def post_save_callback(self, value: ManyRelationProtocol, is_update: bool) -> None:
         """

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import inspect
 import warnings
-from collections.abc import Collection, Sequence
+from collections.abc import Callable, Collection, Hashable, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -33,6 +33,7 @@ _empty = cast(set[str], frozenset())
 _excempted_attrs: set[str] = {
     "_db_loaded",
     "_db_deleted",
+    "_db_dirty",
     "_edgy_namespace",
     "_edgy_private_attrs",
 }
@@ -68,6 +69,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
     _db_loaded: bool = PrivateAttr(default=False)
     # not in db anymore or deleted
     _db_deleted: bool = PrivateAttr(default=False)
+    _db_dirty: set[str] | None = PrivateAttr(default=None)
     _db_schemas: ClassVar[dict[str, type[BaseModelType]]]
 
     def __init__(
@@ -94,6 +96,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         # Always set _db_loaded and _db_deleted in __dict__ to prevent __getattr__ loop.
         self.__dict__["_db_loaded"] = False
         self.__dict__["_db_deleted"] = False
+        self.__dict__["_db_dirty"] = None
         klass = self.__class__
         # Initialize _edgy_namespace with class-level private attribute values.
         self.__dict__["_edgy_namespace"] = _edgy_namespace = {
@@ -149,17 +152,18 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         del self.__dict__["_edgy_namespace"]
         _db_loaded = self.__dict__.pop("_db_loaded")
         _db_deleted = self.__dict__.pop("_db_deleted")
+        self.__dict__.pop("_db_dirty")
         # Call Pydantic BaseModel's __init__.
         super().__init__(**kwargs)
         # Re-set _db_loaded and _db_deleted properly after Pydantic initialization.
         self._db_loaded = _db_loaded
         self._db_deleted = _db_deleted
+        self._db_dirty = set()
         self._edgy_namespace = _edgy_namespace
         # Move Pydantic extra attributes to __dict__.
         if self.__pydantic_extra__ is not None:
             self.__dict__.update(self.__pydantic_extra__)
             self.__pydantic_extra__ = None
-
         # Clean up fields not present in kwargs from __dict__.
         for field_name in self.meta.fields:
             if field_name not in kwargs:
@@ -605,6 +609,8 @@ class EdgyBaseModel(BaseModel, BaseModelType):
                         else:
                             # Otherwise, bypass __setattr__ to update __dict__ directly.
                             object.__setattr__(self, k, v)
+                if (db_dirty := self._db_dirty) is not None:
+                    db_dirty.add(key)
             elif key in type(self).model_fields:
                 # If it's a Pydantic model field, use super().__setattr__.
                 super().__setattr__(key, value)
@@ -699,17 +705,17 @@ class EdgyBaseModel(BaseModel, BaseModelType):
                 cast("FIELD_CONTEXT_TYPE", {"field": field})
             )
         try:
-            getter: Any = None
+            getter: Callable[[BaseModelType, type[BaseModelType]], Any] | None = None
             if field is not None and hasattr(field, "__get__"):
-                getter = field.__get__
+                getter = cast("Callable[[BaseModelType, type[BaseModelType]], Any]", field.__get__)
                 # If behavior is "coro" or "passdown", return the getter result directly.
                 if behavior == "coro" or behavior == "passdown":
-                    return field.__get__(self, self.__class__)
+                    return getter(self, type(self))
                 else:
                     # Otherwise, set "passdown" behavior and try to get the field value.
                     token = MODEL_GETATTR_BEHAVIOR.set("passdown")
                     try:
-                        return field.__get__(self, self.__class__)
+                        return getter(self, type(self))
                     except AttributeError:
                         # If AttributeError, forward to the load routine.
                         pass
@@ -784,7 +790,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         other_tup = other.create_model_key(allow_missing_and_none=True)
         return self_tup == other_tup
 
-    def create_model_key(self, *, allow_missing_and_none: bool = False) -> tuple:
+    def create_model_key(self, *, allow_missing_and_none: bool = False) -> tuple[Hashable, ...]:
         """
         Generates a unique cache key for the model instance.
 

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -654,6 +654,14 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         except KeyError:
             raise AttributeError(f"Attribute: {name} not found") from None
 
+    def _get_from_edgy_namespace(self, name: str) -> Any:
+        """Shared helper from `__getattribute__`  and `__getattr__` to access _edgy_namespace quickly."""
+        try:
+            # we need __getattr__ here, not __getattribute__
+            return super().__getattr__("_edgy_namespace")[name]
+        except KeyError as exc:
+            raise AttributeError from exc
+
     def __getattribute__(self, name: str) -> Any:
         """
         Custom getter for model attributes.
@@ -669,11 +677,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         if name != "_edgy_private_attrs" and name in super().__getattribute__(
             "_edgy_private_attrs"
         ):
-            try:
-                # we need __getattr__ here, not __getattribute__
-                return super().__getattr__("_edgy_namespace")[name]
-            except KeyError as exc:
-                raise AttributeError from exc
+            return self._get_from_edgy_namespace(name)
         # For all other attributes, use the default __getattribute__ behavior.
         return super().__getattribute__(name)
 
@@ -693,8 +697,10 @@ class EdgyBaseModel(BaseModel, BaseModelType):
 
         # bypass own __getattr__ overwrite for pydantic attributes
         pydantic_getter = BaseModel.__getattr__
+        # this direct call improves speed enormously
         if name in pydantic_getter(self, "_edgy_private_attrs"):
-            return self.__getattribute__(name)
+            # skip rendundant check, just access the edgy namespace
+            return self._get_from_edgy_namespace(name)
         # Attributes exempted from triggering special __getattr__ logic.
         if name in _excempted_attrs:
             return super().__getattr__(name)

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -109,7 +109,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         }
         # Override __show_pk__ if provided in kwargs.
         if __show_pk__ is not None:
-            self.__dict__["__show_pk__"] = __show_pk__
+            _edgy_namespace["__show_pk__"] = __show_pk__
 
         # Handle ModelRef instances for relation fields.
         for arg in args:
@@ -154,10 +154,9 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         _db_loaded = self.__dict__.pop("_db_loaded")
         _db_deleted = self.__dict__.pop("_db_deleted")
         self.__dict__.pop("_db_dirty")
-        self.__dict__.pop("__show_pk__")
         # Call Pydantic BaseModel's __init__.
         super().__init__(**kwargs)
-        # bypass own __setattr__ overwrite
+        # bypass own __setattr__ overwrite for pydantic attributes
         pydantic_setter = BaseModel.__setattr__
         # Re-set _db_loaded and _db_deleted properly after Pydantic initialization.
         pydantic_setter(self, "_db_loaded", _db_loaded)
@@ -665,12 +664,13 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         :return: The value of the attribute.
         :raises AttributeError: If the attribute is not found in private namespace.
         """
-        super_getter: Callable[[str], Any] = super().__getattribute__
         # If the attribute is an Edgy private attribute and not the private attributes set itself,
         # try to retrieve it from _edgy_namespace.
-        if name != "_edgy_private_attrs" and name in super_getter("_edgy_private_attrs"):
+        if name != "_edgy_private_attrs" and name in super().__getattribute__(
+            "_edgy_private_attrs"
+        ):
             try:
-                return super_getter("_edgy_namespace")[name]
+                return super().__getattr__("_edgy_namespace")[name]
             except KeyError as exc:
                 raise AttributeError from exc
         # For all other attributes, use the default __getattribute__ behavior.
@@ -690,10 +690,12 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         :return: The value of the attribute.
         """
 
-        # bypass own __getattr__ overwrite
+        # bypass own __getattr__ overwrite for pydantic attributes
         pydantic_getter = BaseModel.__getattr__
+        if name in pydantic_getter(self, "_edgy_private_attrs"):
+            return self.__getattribute__(name)
         # Attributes exempted from triggering special __getattr__ logic.
-        if name in _excempted_attrs or name in pydantic_getter(self, "_edgy_private_attrs"):
+        if name in _excempted_attrs:
             return super().__getattr__(name)
 
         behavior = MODEL_GETATTR_BEHAVIOR.get()

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -25,6 +25,7 @@ from .types import BaseModelType
 if TYPE_CHECKING:
     from edgy.core.connection.database import Database
     from edgy.core.db.fields.types import FIELD_CONTEXT_TYPE, BaseFieldType
+    from edgy.core.db.models.managers import Manager
     from edgy.core.db.models.model import Model
     from edgy.core.db.querysets.types import QuerySetType
 
@@ -576,12 +577,14 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         :param key: The name of the attribute to set.
         :param value: The value to set.
         """
+        # bypass our overwrites
+        super_getter: Callable[[str], Any] = super().__getattr__
         # Handle Edgy's private attributes by storing them in _edgy_namespace.
-        if key in self._edgy_private_attrs:
-            self._edgy_namespace[key] = value
+        if key in super_getter("_edgy_private_attrs"):
+            super_getter("_edgy_namespace")[key] = value
             return
         # Handle Pydantic's private attributes directly.
-        if key in self.__private_attributes__:
+        if key in super_getter("__private_attributes__"):
             super().__setattr__(key, value)
             return
 
@@ -637,7 +640,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
             # If a getter is provided, use it, handling awaitable results.
             token = MODEL_GETATTR_BEHAVIOR.set("coro")
             try:
-                result = getter(self, self.__class__)
+                result = getter(self, type(self))
                 if inspect.isawaitable(result):
                     result = await result
                 return result
@@ -659,11 +662,12 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         :return: The value of the attribute.
         :raises AttributeError: If the attribute is not found in private namespace.
         """
+        super_getter: Callable[[str], Any] = super().__getattribute__
         # If the attribute is an Edgy private attribute and not the private attributes set itself,
         # try to retrieve it from _edgy_namespace.
-        if name != "_edgy_private_attrs" and name in self._edgy_private_attrs:
+        if name != "_edgy_private_attrs" and name in super_getter("_edgy_private_attrs"):
             try:
-                return self._edgy_namespace[name]
+                return super_getter("_edgy_namespace")[name]
             except KeyError as exc:
                 raise AttributeError from exc
         # For all other attributes, use the default __getattribute__ behavior.
@@ -682,19 +686,23 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         :param name: The name of the attribute to retrieve.
         :return: The value of the attribute.
         """
+
+        # bypass our overwrites
+        super_getter: Callable[[str], Any] = super().__getattr__
         # Attributes exempted from triggering special __getattr__ logic.
-        if name in _excempted_attrs or name in self._edgy_private_attrs:
-            return super().__getattr__(name)
+        if name in _excempted_attrs or name in super_getter("_edgy_private_attrs"):
+            return super_getter(name)
 
         behavior = MODEL_GETATTR_BEHAVIOR.get()
-        manager = self.meta.managers.get(name)
+        manager: None | Manager = super_getter("meta").managers.get(name)
         if manager is not None:
+            namespace: dict[str, Any]
             # Initialize and cache manager instances on first access.
-            if name not in self._edgy_namespace:
+            if name not in (namespace := super_getter("_edgy_namespace")):
                 manager = copy.copy(manager)
                 manager.instance = self
-                self._edgy_namespace[name] = manager
-            return self._edgy_namespace[name]
+                namespace[name] = manager
+            return namespace[name]
 
         field = self.meta.fields.get(name)
         if field is not None:
@@ -739,7 +747,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
                 # Otherwise, run the coroutine synchronously.
                 return run_sync(coro)
             # If none of the above, use the default __getattr__ behavior (will raise AttributeError).
-            return super().__getattr__(name)
+            return super_getter(name)
         finally:
             # Reset CURRENT_FIELD_CONTEXT if a field was involved.
             if field:

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -587,40 +587,37 @@ class EdgyBaseModel(BaseModel, BaseModelType):
 
         fields = self.meta.fields
         field = fields.get(key, None)
-        # Set context variables for the current instance, model instance, and phase.
-        token = CURRENT_INSTANCE.set(self)
-        token2 = CURRENT_MODEL_INSTANCE.set(self)
-        token3 = CURRENT_PHASE.set("set")
-        if field is not None:
-            token_field_ctx = CURRENT_FIELD_CONTEXT.set(
-                cast("FIELD_CONTEXT_TYPE", {"field": field})
-            )
-        try:
-            if field is not None:
-                # If the field has a custom __set__ method, use it.
-                if hasattr(field, "__set__"):
-                    field.__set__(self, value)
-                else:
-                    # Apply to_model transformation and set values.
-                    for k, v in field.to_model(key, value).items():
-                        if k in type(self).model_fields:
-                            # If it's a Pydantic model field, use super().__setattr__.
-                            super().__setattr__(k, v)
-                        else:
-                            # Otherwise, bypass __setattr__ to update __dict__ directly.
-                            object.__setattr__(self, k, v)
-                if (db_dirty := self._db_dirty) is not None:
-                    db_dirty.add(key)
-            elif key in type(self).model_fields:
+        if field is None:
+            if key in type(self).model_fields:
                 # If it's a Pydantic model field, use super().__setattr__.
                 super().__setattr__(key, value)
             else:
                 # For other attributes, bypass __setattr__ to update __dict__ directly.
                 object.__setattr__(self, key, value)
+            return
+        # Set context variables for the current instance, model instance, and phase.
+        token = CURRENT_INSTANCE.set(self)
+        token2 = CURRENT_MODEL_INSTANCE.set(self)
+        token3 = CURRENT_PHASE.set("set")
+        token_field_ctx = CURRENT_FIELD_CONTEXT.set(cast("FIELD_CONTEXT_TYPE", {"field": field}))
+        try:
+            # If the field has a custom __set__ method, use it.
+            if hasattr(field, "__set__"):
+                field.__set__(self, value)
+            else:
+                # Apply to_model transformation and set values.
+                for k, v in field.to_model(key, value).items():
+                    if k in type(self).model_fields:
+                        # If it's a Pydantic model field, use super().__setattr__.
+                        super().__setattr__(k, v)
+                    else:
+                        # Otherwise, bypass __setattr__ to update __dict__ directly.
+                        object.__setattr__(self, k, v)
+            if (db_dirty := self._db_dirty) is not None:
+                db_dirty.add(key)
         finally:
             # Reset context variables.
-            if field is not None:
-                CURRENT_FIELD_CONTEXT.reset(token_field_ctx)
+            CURRENT_FIELD_CONTEXT.reset(token_field_ctx)
             CURRENT_INSTANCE.reset(token)
             CURRENT_MODEL_INSTANCE.reset(token2)
             CURRENT_PHASE.reset(token3)
@@ -808,9 +805,6 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         pk_key_list: list[Any] = [type(self).__name__]
         # Iterate over primary key column names and append their string values to the key list.
         # Note: `pkcolumns` contains column names, not column objects.
-        token = CURRENT_PHASE.set("compare")
-        token2 = CURRENT_INSTANCE.set(self)
-        token3 = CURRENT_MODEL_INSTANCE.set(self)
         field_dict: FIELD_CONTEXT_TYPE = cast("FIELD_CONTEXT_TYPE", {})
         token_field_ctx = CURRENT_FIELD_CONTEXT.set(field_dict)
         try:
@@ -844,9 +838,6 @@ class EdgyBaseModel(BaseModel, BaseModelType):
                     else:
                         raise
         finally:
-            CURRENT_PHASE.reset(token)
-            CURRENT_INSTANCE.reset(token2)
-            CURRENT_MODEL_INSTANCE.reset(token3)
             CURRENT_FIELD_CONTEXT.reset(token_field_ctx)
         # Convert the list to a tuple to make it hashable for use as a dictionary key.
         # Raise AttributeError otherwise.

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -109,7 +109,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         }
         # Override __show_pk__ if provided in kwargs.
         if __show_pk__ is not None:
-            self.__show_pk__ = __show_pk__
+            self.__dict__["__show_pk__"] = __show_pk__
 
         # Handle ModelRef instances for relation fields.
         for arg in args:
@@ -154,6 +154,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         _db_loaded = self.__dict__.pop("_db_loaded")
         _db_deleted = self.__dict__.pop("_db_deleted")
         self.__dict__.pop("_db_dirty")
+        self.__dict__.pop("__show_pk__")
         # Call Pydantic BaseModel's __init__.
         super().__init__(**kwargs)
         # bypass own __setattr__ overwrite

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -654,14 +654,6 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         except KeyError:
             raise AttributeError(f"Attribute: {name} not found") from None
 
-    def _get_from_edgy_namespace(self, name: str) -> Any:
-        """Shared helper from `__getattribute__`  and `__getattr__` to access _edgy_namespace quickly."""
-        try:
-            # we need __getattr__ here, not __getattribute__
-            return super().__getattr__("_edgy_namespace")[name]
-        except KeyError as exc:
-            raise AttributeError from exc
-
     def __getattribute__(self, name: str) -> Any:
         """
         Custom getter for model attributes.
@@ -677,7 +669,11 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         if name != "_edgy_private_attrs" and name in super().__getattribute__(
             "_edgy_private_attrs"
         ):
-            return self._get_from_edgy_namespace(name)
+            try:
+                # we need __getattr__ here, not __getattribute__
+                return super().__getattr__("_edgy_namespace")[name]
+            except KeyError as exc:
+                raise AttributeError from exc
         # For all other attributes, use the default __getattribute__ behavior.
         return super().__getattribute__(name)
 
@@ -699,8 +695,11 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         pydantic_getter = BaseModel.__getattr__
         # this direct call improves speed enormously
         if name in pydantic_getter(self, "_edgy_private_attrs"):
-            # skip rendundant check, just access the edgy namespace
-            return self._get_from_edgy_namespace(name)
+            try:
+                # we need __getattr__ here, not __getattribute__
+                return super().__getattr__("_edgy_namespace")[name]
+            except KeyError as exc:
+                raise AttributeError from exc
         # Attributes exempted from triggering special __getattr__ logic.
         if name in _excempted_attrs:
             return super().__getattr__(name)

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -156,10 +156,12 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         self.__dict__.pop("_db_dirty")
         # Call Pydantic BaseModel's __init__.
         super().__init__(**kwargs)
+        # bypass own __setattr__ overwrite
+        pydantic_setter = BaseModel.__setattr__
         # Re-set _db_loaded and _db_deleted properly after Pydantic initialization.
-        self._db_loaded = _db_loaded
-        self._db_deleted = _db_deleted
-        self._db_dirty = set()
+        pydantic_setter(self, "_db_loaded", _db_loaded)
+        pydantic_setter(self, "_db_deleted", _db_deleted)
+        pydantic_setter(self, "_db_dirty", set())
         self._edgy_namespace = _edgy_namespace
         # Move Pydantic extra attributes to __dict__.
         if self.__pydantic_extra__ is not None:
@@ -616,7 +618,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
                     else:
                         # Otherwise, bypass __setattr__ to update __dict__ directly.
                         object.__setattr__(self, k, v)
-            if (db_dirty := self._db_dirty) is not None:
+            if (db_dirty := super_getter("_db_dirty")) is not None:
                 db_dirty.add(key)
         finally:
             # Reset context variables.
@@ -687,18 +689,18 @@ class EdgyBaseModel(BaseModel, BaseModelType):
         :return: The value of the attribute.
         """
 
-        # bypass our overwrites
-        super_getter: Callable[[str], Any] = super().__getattr__
+        # bypass own __getattr__ overwrite
+        pydantic_getter = BaseModel.__getattr__
         # Attributes exempted from triggering special __getattr__ logic.
-        if name in _excempted_attrs or name in super_getter("_edgy_private_attrs"):
-            return super_getter(name)
+        if name in _excempted_attrs or name in pydantic_getter(self, "_edgy_private_attrs"):
+            return super().__getattr__(name)
 
         behavior = MODEL_GETATTR_BEHAVIOR.get()
-        manager: None | Manager = super_getter("meta").managers.get(name)
+        manager: None | Manager = pydantic_getter(self, "meta").managers.get(name)
         if manager is not None:
             namespace: dict[str, Any]
             # Initialize and cache manager instances on first access.
-            if name not in (namespace := super_getter("_edgy_namespace")):
+            if name not in (namespace := pydantic_getter(self, "_edgy_namespace")):
                 manager = copy.copy(manager)
                 manager.instance = self
                 namespace[name] = manager
@@ -747,7 +749,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
                 # Otherwise, run the coroutine synchronously.
                 return run_sync(coro)
             # If none of the above, use the default __getattr__ behavior (will raise AttributeError).
-            return super_getter(name)
+            return super().__getattr__(name)
         finally:
             # Reset CURRENT_FIELD_CONTEXT if a field was involved.
             if field:

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -670,6 +670,7 @@ class EdgyBaseModel(BaseModel, BaseModelType):
             "_edgy_private_attrs"
         ):
             try:
+                # we need __getattr__ here, not __getattribute__
                 return super().__getattr__("_edgy_namespace")[name]
             except KeyError as exc:
                 raise AttributeError from exc

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -18,6 +18,7 @@ from edgy.core.db.context_vars import (
     CURRENT_FIELD_CONTEXT,
     CURRENT_INSTANCE,
     CURRENT_MODEL_INSTANCE,
+    CURRENT_PHASE,
     EXPLICIT_SPECIFIED_VALUES,
     MODEL_GETATTR_BEHAVIOR,
     NO_GLOBAL_FIELD_CONSTRAINTS,
@@ -72,6 +73,7 @@ _removed_copy_keys = {
     # remove extra
     "_db_loaded",
     "_db_deleted",
+    "_db_dirty",
     "_pkcolumns",
     "_table",
     "_db_schemas",
@@ -734,20 +736,35 @@ class DatabaseMixin:
         """
         # works only if the class of the model is the main class of the queryset
         # TODO: implement prefix handling and return generic column without table attached
+        model_self = cast("Model", self)
         if prefix:
             raise NotImplementedError()
         clauses: list[Any] = []
-        for field_name in self.identifying_db_fields:
-            field = self.meta.fields.get(field_name)
-            if field is not None:
-                for column_name, value in field.clean(
-                    field_name, self.__dict__[field_name]
-                ).items():
-                    clauses.append(getattr(self.table.columns, column_name) == value)
-            else:
-                clauses.append(
-                    getattr(self.table.columns, field_name) == self.__dict__[field_name]
-                )
+        token = CURRENT_PHASE.set("prepare_clauses")
+        instance = CURRENT_INSTANCE.get()
+        token2 = CURRENT_INSTANCE.set(model_self if instance is None else instance)
+        token3 = CURRENT_MODEL_INSTANCE.set(model_self)
+        field_dict: FIELD_CONTEXT_TYPE = cast("FIELD_CONTEXT_TYPE", {})
+        token_field_ctx = CURRENT_FIELD_CONTEXT.set(field_dict)
+        try:
+            for field_name in model_self.identifying_db_fields:
+                field = model_self.meta.fields.get(field_name)
+                if field is not None:
+                    field_dict.clear()
+                    field_dict["field"] = field
+                    for column_name, value in field.clean(
+                        field_name, self.__dict__[field_name]
+                    ).items():
+                        clauses.append(getattr(self.table.columns, column_name) == value)
+                else:
+                    clauses.append(
+                        getattr(self.table.columns, field_name) == self.__dict__[field_name]
+                    )
+        finally:
+            CURRENT_PHASE.reset(token)
+            CURRENT_INSTANCE.reset(token2)
+            CURRENT_MODEL_INSTANCE.reset(token3)
+            CURRENT_FIELD_CONTEXT.reset(token_field_ctx)
         return clauses
 
     async def _update(
@@ -808,19 +825,31 @@ class DatabaseMixin:
         row_count: int | None = None
         if column_values and clauses:
             check_db_connection(self.database, stacklevel=4)
-            async with self.database as database, database.transaction():
-                # can update column_values
-                column_values.update(
-                    await self.execute_pre_save_hooks(column_values, kwargs, is_update=True)
-                )
-                expression = self.table.update().values(**column_values).where(*clauses)
-                row_count = cast(int, await database.execute(expression))
+            db_dirty = self._db_dirty
+            # prevent loops
+            self._db_dirty = None
+            try:
+                async with self.database as database, database.transaction():
+                    # can update column_values
+                    column_values.update(
+                        await self.execute_pre_save_hooks(column_values, kwargs, is_update=True)
+                    )
+                    expression = self.table.update().values(**column_values).where(*clauses)
+                    row_count = cast(int, await database.execute(expression))
 
-            # Update the model instance.
-            new_kwargs = self.transform_input(
-                column_values, phase="post_update", instance=instance, model_instance=self
-            )
-            self.__dict__.update(new_kwargs)
+                # Update the model instance.
+                new_kwargs = self.transform_input(
+                    column_values, phase="post_update", instance=instance, model_instance=self
+                )
+                self.__dict__.update(new_kwargs)
+            except BaseException:
+                self._db_dirty = db_dirty
+                raise
+            if db_dirty is not None:
+                db_dirty.difference_update(new_kwargs.keys())
+                self._db_dirty = db_dirty
+            else:
+                self._db_dirty = set()
 
         # updates aren't required to change the db, they can also just affect the meta fields
         await self.execute_post_save_hooks(kwargs.keys(), is_update=True)
@@ -952,6 +981,7 @@ class DatabaseMixin:
                 row_count = cast(int, await database.execute(expression))
         # we cannot load anymore afterwards
         self._db_deleted = True
+        self._db_dirty = None
         # now cleanup with the saved values
         if field_values:
             token_instance = CURRENT_MODEL_INSTANCE.set(self)
@@ -1028,7 +1058,7 @@ class DatabaseMixin:
             ObjectNotFound: If no row is found in the database corresponding to
                             the instance's identifying clauses.
         """
-        if only_needed and self._db_loaded_or_deleted:
+        if only_needed and (self._db_loaded_or_deleted or self._db_dirty):
             return
         row = None
         clauses = self.identifying_clauses()
@@ -1044,6 +1074,7 @@ class DatabaseMixin:
         if row is None:
             self._db_deleted = True
             self._db_loaded = True
+            self._db_dirty = None
             raise ObjectNotFound("row does not exist anymore")
         # Update the instance.
         self.__dict__.update(
@@ -1053,6 +1084,7 @@ class DatabaseMixin:
         )
         self._db_deleted = False
         self._db_loaded = True
+        self._db_dirty = set()
 
     async def check_exist_in_db(self, only_needed: bool = False) -> bool:
         """
@@ -1136,53 +1168,62 @@ class DatabaseMixin:
             return
         check_db_connection(self.database, stacklevel=4)
         table: sqlalchemy.Table = self.table
-        async with (
-            self.database as database,
-            database.connection() as connection,
-            connection.transaction(),
-        ):
-            insert_returning = database.engine.dialect.insert_returning
-            # can update column_values
-            column_values.update(
-                await self.execute_pre_save_hooks(column_values, kwargs, is_update=False)
-            )
-            # we can't just use label. If the column.key has an invalid name for the db
-            # we would cause an foo AS invalid clause
-            returning = (
-                [
-                    col
-                    for col in table.columns.values()
-                    if col.key not in column_values
-                    and (col.server_default is not None or col.autoincrement)
-                ]
-                if insert_returning
-                else []
-            )
-
-            if returning:
-                expression: Any = table.insert().values(**column_values).returning(*returning)
-                returned_mapping = dict((await connection.fetch_one(expression))._mapping)
-            else:
-                expression = table.insert().values(**column_values)
-                pk_values = await connection.execute(expression)
-                returned_mapping = (
-                    dict(pk_values._mapping) if hasattr(pk_values, "_mapping") else {}
+        # prevent loops
+        db_dirty = self._db_dirty
+        self._db_dirty = None
+        try:
+            async with (
+                self.database as database,
+                database.connection() as connection,
+                connection.transaction(),
+            ):
+                insert_returning = database.engine.dialect.insert_returning
+                # can update column_values
+                column_values.update(
+                    await self.execute_pre_save_hooks(column_values, kwargs, is_update=False)
                 )
-        for col_name, col_key in self.meta.columns_remapping.items():
-            if col_name in returned_mapping:
-                returned_mapping[col_key] = returned_mapping.pop(col_name)
-        column_values.update(returned_mapping)
+                # we can't just use label. If the column.key has an invalid name for the db
+                # we would cause an foo AS invalid clause
+                returning = (
+                    [
+                        col
+                        for col in table.columns.values()
+                        if col.key not in column_values
+                        and (col.server_default is not None or col.autoincrement)
+                    ]
+                    if insert_returning
+                    else []
+                )
 
-        new_kwargs = self.transform_input(
-            column_values, phase="post_insert", instance=instance, model_instance=self
-        )
-        self.__dict__.update(new_kwargs)
+                if returning:
+                    expression: Any = table.insert().values(**column_values).returning(*returning)
+                    returned_mapping = dict((await connection.fetch_one(expression))._mapping)
+                else:
+                    expression = table.insert().values(**column_values)
+                    pk_values = await connection.execute(expression)
+                    returned_mapping = (
+                        dict(pk_values._mapping) if hasattr(pk_values, "_mapping") else {}
+                    )
+            for col_name, col_key in self.meta.columns_remapping.items():
+                if col_name in returned_mapping:
+                    returned_mapping[col_key] = returned_mapping.pop(col_name)
+            column_values.update(returned_mapping)
 
-        if self.meta.post_save_fields:
-            await self.execute_post_save_hooks(kwargs.keys(), is_update=False)
-        # Ensure on access refresh the results is active
-        self._db_loaded = False
+            new_kwargs = self.transform_input(
+                column_values, phase="post_insert", instance=instance, model_instance=self
+            )
+            self.__dict__.update(new_kwargs)
+
+            if self.meta.post_save_fields:
+                await self.execute_post_save_hooks(kwargs.keys(), is_update=False)
+        except BaseException:
+            self._db_dirty = db_dirty
+            raise
+        finally:
+            # Ensure on access refresh the results is active
+            self._db_loaded = False
         self._db_deleted = False
+        self._db_dirty = set()
         await post_fn(
             real_class,
             model_instance=self,
@@ -1215,8 +1256,10 @@ class DatabaseMixin:
         Returns:
             The saved model instance.
         """
+        model_self = cast("Model", self)
         instance: BaseModelType | QuerySet = CURRENT_INSTANCE.get()  # type: ignore
-        extracted_fields = self.extract_db_fields()
+        dirty = model_self._db_dirty
+        extracted_fields = model_self.extract_db_fields()
         if values is None:
             explicit_values: set[str] = set()
         elif isinstance(values, set):
@@ -1228,16 +1271,16 @@ class DatabaseMixin:
 
         token = MODEL_GETATTR_BEHAVIOR.set("coro")
         try:
-            for pkcolumn in type(self).pkcolumns:
+            for pkcolumn in type(model_self).pkcolumns:
                 # should trigger load in case of identifying_db_fields
                 value = getattr(self, pkcolumn, None)
                 if inspect.isawaitable(value):
                     value = await value
-                if value is None and self.table.columns[pkcolumn].autoincrement:
+                if value is None and model_self.table.columns[pkcolumn].autoincrement:
                     extracted_fields.pop(pkcolumn, None)
                     force_insert = True
                     break
-                field = self.meta.fields.get(pkcolumn)
+                field = model_self.meta.fields.get(pkcolumn)
                 # this is an IntegerField/DateTime with primary_key set
                 if field is not None:
                     if getattr(field, "increment_on_save", 0) != 0 or getattr(
@@ -1276,10 +1319,23 @@ class DatabaseMixin:
                     instance=instance,
                 )
             else:
+                if dirty and values is None and model_self._db_loaded:
+                    # check only for loaded model instances which have dirty tracing
+                    update_values = {k: v for k, v in extracted_fields.items() if k in dirty}
+
+                    is_partial = True
+                elif values is None:
+                    update_values = extracted_fields
+                    is_partial = False
+                else:
+                    update_values = values
+                    is_partial = not set(model_self.meta.fields.keys()).issubset(
+                        update_values.keys()
+                    )
+
                 await self._update(
-                    # assume partial when values are not None
-                    is_partial=values is not None,
-                    kwargs=extracted_fields if values is None else values,
+                    is_partial=is_partial,
+                    kwargs=update_values,
                     pre_fn=partial(
                         self.meta.signals.pre_save.send_async, is_update=True, is_migration=False
                     ),

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -698,7 +698,7 @@ class DatabaseMixin:
             value: The value to assign to the attribute.
         """
         if key == "__using_schema__":
-            # bypass own __getattr__ overwrite
+            # bypass own __getattr__ overwrite for pydantic attributes
             BaseModel.__getattr__(self, "_edgy_namespace").pop("_table", None)
         super().__setattr__(key, value)
 
@@ -796,9 +796,9 @@ class DatabaseMixin:
         Returns:
             The number of rows updated, or None if no update was performed.
         """
-        # bypass own __getattr__ overwrite
+        # bypass own __getattr__ overwrite for pydantic attributes
         pydantic_getter = BaseModel.__getattr__
-        # bypass own __setattr__ overwrite
+        # bypass own __setattr__ overwrite for pydantic attributes
         pydantic_setter = BaseModel.__setattr__
         real_class = self.get_real_class()
         column_values = self.extract_column_values(
@@ -935,9 +935,9 @@ class DatabaseMixin:
         Returns:
             The number of rows deleted.
         """
-        # bypass own __getattr__ overwrite
+        # bypass own __getattr__ overwrite for pydantic attributes
         pydantic_getter = BaseModel.__getattr__
-        # bypass own __setattr__ overwrite
+        # bypass own __setattr__ overwrite for pydantic attributes
         pydantic_setter = BaseModel.__setattr__
         if pydantic_getter(self, "_db_deleted"):
             return 0
@@ -1071,9 +1071,9 @@ class DatabaseMixin:
             ObjectNotFound: If no row is found in the database corresponding to
                             the instance's identifying clauses.
         """
-        # bypass own __getattr__ overwrite
+        # bypass own __getattr__ overwrite for pydantic attributes
         pydantic_getter = BaseModel.__getattr__
-        # bypass own __setattr__ overwrite
+        # bypass own __setattr__ overwrite for pydantic attributes
         pydantic_setter = BaseModel.__setattr__
         if only_needed and (self._db_loaded_or_deleted or pydantic_getter(self, "_db_dirty")):
             return
@@ -1114,9 +1114,9 @@ class DatabaseMixin:
         Returns:
             True if the instance exists in the database, False otherwise.
         """
-        # bypass own __getattr__ overwrite
+        # bypass own __getattr__ overwrite for pydantic attributes
         pydantic_getter = BaseModel.__getattr__
-        # bypass own __setattr__ overwrite
+        # bypass own __setattr__ overwrite for pydantic attributes
         pydantic_setter = BaseModel.__setattr__
         if only_needed:
             if pydantic_getter(self, "_db_deleted"):
@@ -1159,9 +1159,9 @@ class DatabaseMixin:
             post_fn: An asynchronous callable to be executed after the insert.
             instance: The model instance or queryset initiating the insert.
         """
-        # bypass own __getattr__ overwrite
+        # bypass own __getattr__ overwrite for pydantic attributes
         pydantic_getter = BaseModel.__getattr__
-        # bypass own __setattr__ overwrite
+        # bypass own __setattr__ overwrite for pydantic attributes
         pydantic_setter = BaseModel.__setattr__
         model_self = cast("Model", self)
         real_class = model_self.get_real_class()
@@ -1282,7 +1282,7 @@ class DatabaseMixin:
         Returns:
             The saved model instance.
         """
-        # bypass own __getattr__ overwrite
+        # bypass own __getattr__ overwrite for pydantic attributes
         pydantic_getter = BaseModel.__getattr__
         model_self = cast("Model", self)
         instance: BaseModelType | QuerySet = CURRENT_INSTANCE.get()  # type: ignore

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -18,7 +18,6 @@ from edgy.core.db.context_vars import (
     CURRENT_FIELD_CONTEXT,
     CURRENT_INSTANCE,
     CURRENT_MODEL_INSTANCE,
-    CURRENT_PHASE,
     EXPLICIT_SPECIFIED_VALUES,
     MODEL_GETATTR_BEHAVIOR,
     NO_GLOBAL_FIELD_CONSTRAINTS,
@@ -745,10 +744,6 @@ class DatabaseMixin:
         if prefix:
             raise NotImplementedError()
         clauses: list[Any] = []
-        token = CURRENT_PHASE.set("prepare_clauses")
-        instance = CURRENT_INSTANCE.get()
-        token2 = CURRENT_INSTANCE.set(model_self if instance is None else instance)
-        token3 = CURRENT_MODEL_INSTANCE.set(model_self)
         field_dict: FIELD_CONTEXT_TYPE = cast("FIELD_CONTEXT_TYPE", {})
         token_field_ctx = CURRENT_FIELD_CONTEXT.set(field_dict)
         try:
@@ -766,9 +761,6 @@ class DatabaseMixin:
                         getattr(self.table.columns, field_name) == self.__dict__[field_name]
                     )
         finally:
-            CURRENT_PHASE.reset(token)
-            CURRENT_INSTANCE.reset(token2)
-            CURRENT_MODEL_INSTANCE.reset(token3)
             CURRENT_FIELD_CONTEXT.reset(token_field_ctx)
         return clauses
 

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -463,8 +463,8 @@ class DatabaseMixin:
         Returns:
             The active schema as a string, or None if no schema is found.
         """
-        if self._edgy_namespace["__using_schema__"] is not Undefined:
-            return cast(str | None, self._edgy_namespace["__using_schema__"])
+        if (namespace := self._edgy_namespace["__using_schema__"]) is not Undefined:
+            return cast(str | None, namespace["__using_schema__"])
         return type(self).get_active_class_schema(
             check_schema=check_schema, check_tenant=check_tenant
         )
@@ -623,13 +623,14 @@ class DatabaseMixin:
         Returns:
             The SQLAlchemy `Table` object.
         """
-        if self._edgy_namespace.get("_table") is None:
+        namespace = self._edgy_namespace
+        if namespace.get("_table") is None:
             schema = self.get_active_instance_schema()
             return cast(
                 "sqlalchemy.Table",
                 type(self).table_schema(schema),
             )
-        return cast("sqlalchemy.Table", self._edgy_namespace["_table"])
+        return cast("sqlalchemy.Table", namespace["_table"])
 
     @table.setter
     def table(self, value: sqlalchemy.Table | None) -> None:
@@ -642,8 +643,9 @@ class DatabaseMixin:
             value: The SQLAlchemy `Table` object to set.
         """
         assert isinstance(value, sqlalchemy.Table), f"Cannot assign: {value!r} to table."
-        self._edgy_namespace.pop("_pkcolumns", None)
-        self._edgy_namespace["_table"] = value
+        namespace = self._edgy_namespace
+        namespace.pop("_pkcolumns", None)
+        namespace["_table"] = value
 
     @table.deleter
     def table(self) -> None:
@@ -652,8 +654,9 @@ class DatabaseMixin:
 
         Also clears cached primary key columns.
         """
-        self._edgy_namespace.pop("_pkcolumns", None)
-        self._edgy_namespace.pop("_table", None)
+        namespace = self._edgy_namespace
+        namespace.pop("_pkcolumns", None)
+        namespace.pop("_table", None)
 
     @property
     def pkcolumns(self) -> Sequence[str]:
@@ -665,12 +668,13 @@ class DatabaseMixin:
         Returns:
             A sequence of strings representing the primary key column names.
         """
-        if self._edgy_namespace.get("_pkcolumns") is None:
-            if self._edgy_namespace.get("_table") is None:
-                self._edgy_namespace["_pkcolumns"] = type(self).pkcolumns
+        namespace = self._edgy_namespace
+        if namespace.get("_pkcolumns") is None:
+            if namespace.get("_table") is None:
+                namespace["_pkcolumns"] = type(self).pkcolumns
             else:
-                self._edgy_namespace["_pkcolumns"] = build_pkcolumns(self)
-        return cast(Sequence[str], self._edgy_namespace["_pkcolumns"])
+                namespace["_pkcolumns"] = build_pkcolumns(self)
+        return cast(Sequence[str], namespace["_pkcolumns"])
 
     @property
     def pknames(self) -> Sequence[str]:
@@ -694,7 +698,8 @@ class DatabaseMixin:
             value: The value to assign to the attribute.
         """
         if key == "__using_schema__":
-            self._edgy_namespace.pop("_table", None)
+            # bypass own __getattr__ overwrite
+            BaseModel.__getattr__(self, "_edgy_namespace").pop("_table", None)
         super().__setattr__(key, value)
 
     def get_columns_for_name(self: Model, name: str) -> Sequence[sqlalchemy.Column]:
@@ -791,6 +796,10 @@ class DatabaseMixin:
         Returns:
             The number of rows updated, or None if no update was performed.
         """
+        # bypass own __getattr__ overwrite
+        pydantic_getter = BaseModel.__getattr__
+        # bypass own __setattr__ overwrite
+        pydantic_setter = BaseModel.__setattr__
         real_class = self.get_real_class()
         column_values = self.extract_column_values(
             extracted_values=kwargs,
@@ -825,9 +834,9 @@ class DatabaseMixin:
         row_count: int | None = None
         if column_values and clauses:
             check_db_connection(self.database, stacklevel=4)
-            db_dirty = self._db_dirty
+            db_dirty = pydantic_getter(self, "_db_dirty")
             # prevent loops
-            self._db_dirty = None
+            pydantic_setter(self, "_db_dirty", None)
             try:
                 async with self.database as database, database.transaction():
                     # can update column_values
@@ -843,22 +852,22 @@ class DatabaseMixin:
                 )
                 self.__dict__.update(new_kwargs)
             except BaseException:
-                self._db_dirty = db_dirty
+                pydantic_setter(self, "_db_dirty", db_dirty)
                 raise
             if db_dirty is not None:
                 db_dirty.difference_update(new_kwargs.keys())
-                self._db_dirty = db_dirty
+                pydantic_setter(self, "_db_dirty", db_dirty)
             else:
-                self._db_dirty = set()
+                pydantic_setter(self, "_db_dirty", set())
 
         # updates aren't required to change the db, they can also just affect the meta fields
         await self.execute_post_save_hooks(kwargs.keys(), is_update=True)
 
         if column_values or kwargs:
             # Ensure on access refresh the results is active
-            self._db_deleted = False if row_count is None else row_count == 0
+            pydantic_setter(self, "_db_deleted", False if row_count is None else row_count == 0)
             # TODO: maybe can be unchanged in case of not self._db_deleted
-            self._db_loaded = False
+            pydantic_setter(self, "_db_loaded", False)
         await post_fn(
             real_class,
             model_instance=self,
@@ -926,7 +935,11 @@ class DatabaseMixin:
         Returns:
             The number of rows deleted.
         """
-        if self._db_deleted:
+        # bypass own __getattr__ overwrite
+        pydantic_getter = BaseModel.__getattr__
+        # bypass own __setattr__ overwrite
+        pydantic_setter = BaseModel.__setattr__
+        if pydantic_getter(self, "_db_deleted"):
             return 0
         instance = CURRENT_INSTANCE.get()
         real_class = self.get_real_class()
@@ -980,8 +993,8 @@ class DatabaseMixin:
             async with self.database as database:
                 row_count = cast(int, await database.execute(expression))
         # we cannot load anymore afterwards
-        self._db_deleted = True
-        self._db_dirty = None
+        pydantic_setter(self, "_db_deleted", True)
+        pydantic_setter(self, "_db_dirty", None)
         # now cleanup with the saved values
         if field_values:
             token_instance = CURRENT_MODEL_INSTANCE.set(self)
@@ -1058,7 +1071,11 @@ class DatabaseMixin:
             ObjectNotFound: If no row is found in the database corresponding to
                             the instance's identifying clauses.
         """
-        if only_needed and (self._db_loaded_or_deleted or self._db_dirty):
+        # bypass own __getattr__ overwrite
+        pydantic_getter = BaseModel.__getattr__
+        # bypass own __setattr__ overwrite
+        pydantic_setter = BaseModel.__setattr__
+        if only_needed and (self._db_loaded_or_deleted or pydantic_getter(self, "_db_dirty")):
             return
         row = None
         clauses = self.identifying_clauses()
@@ -1072,9 +1089,9 @@ class DatabaseMixin:
                 row = await database.fetch_one(expression)
         # check if is in system
         if row is None:
-            self._db_deleted = True
-            self._db_loaded = True
-            self._db_dirty = None
+            pydantic_setter(self, "_db_deleted", True)
+            pydantic_setter(self, "_db_loaded", True)
+            pydantic_setter(self, "_db_dirty", None)
             raise ObjectNotFound("row does not exist anymore")
         # Update the instance.
         self.__dict__.update(
@@ -1082,9 +1099,9 @@ class DatabaseMixin:
                 dict(row._mapping), phase="load", instance=self, model_instance=self
             )
         )
-        self._db_deleted = False
-        self._db_loaded = True
-        self._db_dirty = set()
+        pydantic_setter(self, "_db_deleted", False)
+        pydantic_setter(self, "_db_loaded", True)
+        pydantic_setter(self, "_db_dirty", set())
 
     async def check_exist_in_db(self, only_needed: bool = False) -> bool:
         """
@@ -1097,10 +1114,14 @@ class DatabaseMixin:
         Returns:
             True if the instance exists in the database, False otherwise.
         """
+        # bypass own __getattr__ overwrite
+        pydantic_getter = BaseModel.__getattr__
+        # bypass own __setattr__ overwrite
+        pydantic_setter = BaseModel.__setattr__
         if only_needed:
-            if self._db_deleted:
+            if pydantic_getter(self, "_db_deleted"):
                 return False
-            if self._db_loaded:
+            if pydantic_getter(self, "_db_loaded"):
                 return True
         clauses = self.identifying_clauses()
         if not clauses:
@@ -1113,11 +1134,11 @@ class DatabaseMixin:
         check_db_connection(self.database)
         async with self.database as database:
             result = cast(bool, await database.fetch_val(expression))
-            self._db_deleted = not result
+            pydantic_setter(self, "_db_deleted", not result)
             return result
 
     async def _insert(
-        self: Model,
+        self,
         evaluate_values: bool,
         kwargs: dict[str, Any],
         pre_fn: Callable[..., Awaitable[Any]],
@@ -1138,20 +1159,25 @@ class DatabaseMixin:
             post_fn: An asynchronous callable to be executed after the insert.
             instance: The model instance or queryset initiating the insert.
         """
-        real_class = self.get_real_class()
-        column_values: dict[str, Any] = self.extract_column_values(
+        # bypass own __getattr__ overwrite
+        pydantic_getter = BaseModel.__getattr__
+        # bypass own __setattr__ overwrite
+        pydantic_setter = BaseModel.__setattr__
+        model_self = cast("Model", self)
+        real_class = model_self.get_real_class()
+        column_values: dict[str, Any] = model_self.extract_column_values(
             extracted_values=kwargs,
             is_partial=False,
             is_update=False,
             phase="prepare_insert",
             instance=instance,
-            model_instance=self,
+            model_instance=model_self,
             evaluate_values=evaluate_values,
         )
         try:
             await pre_fn(
                 real_class,
-                model_instance=self,
+                model_instance=model_self,
                 instance=instance,
                 column_values=column_values,
                 values=kwargs,
@@ -1159,28 +1185,28 @@ class DatabaseMixin:
         except SkipOperation:
             await post_fn(
                 real_class,
-                model_instance=self,
+                model_instance=model_self,
                 instance=instance,
                 column_values=column_values,
                 values=kwargs,
                 operation_skipped=True,
             )
             return
-        check_db_connection(self.database, stacklevel=4)
-        table: sqlalchemy.Table = self.table
+        check_db_connection(model_self.database, stacklevel=4)
+        table: sqlalchemy.Table = model_self.table
         # prevent loops
-        db_dirty = self._db_dirty
-        self._db_dirty = None
+        db_dirty = pydantic_getter(model_self, "_db_dirty")
+        pydantic_setter(model_self, "_db_dirty", None)
         try:
             async with (
-                self.database as database,
+                model_self.database as database,
                 database.connection() as connection,
                 connection.transaction(),
             ):
                 insert_returning = database.engine.dialect.insert_returning
                 # can update column_values
                 column_values.update(
-                    await self.execute_pre_save_hooks(column_values, kwargs, is_update=False)
+                    await model_self.execute_pre_save_hooks(column_values, kwargs, is_update=False)
                 )
                 # we can't just use label. If the column.key has an invalid name for the db
                 # we would cause an foo AS invalid clause
@@ -1204,29 +1230,29 @@ class DatabaseMixin:
                     returned_mapping = (
                         dict(pk_values._mapping) if hasattr(pk_values, "_mapping") else {}
                     )
-            for col_name, col_key in self.meta.columns_remapping.items():
+            for col_name, col_key in model_self.meta.columns_remapping.items():
                 if col_name in returned_mapping:
                     returned_mapping[col_key] = returned_mapping.pop(col_name)
             column_values.update(returned_mapping)
 
-            new_kwargs = self.transform_input(
-                column_values, phase="post_insert", instance=instance, model_instance=self
+            new_kwargs = model_self.transform_input(
+                column_values, phase="post_insert", instance=instance, model_instance=model_self
             )
             self.__dict__.update(new_kwargs)
 
-            if self.meta.post_save_fields:
-                await self.execute_post_save_hooks(kwargs.keys(), is_update=False)
+            if model_self.meta.post_save_fields:
+                await model_self.execute_post_save_hooks(kwargs.keys(), is_update=False)
         except BaseException:
-            self._db_dirty = db_dirty
+            pydantic_setter(model_self, "_db_dirty", db_dirty)
             raise
         finally:
             # Ensure on access refresh the results is active
-            self._db_loaded = False
-        self._db_deleted = False
-        self._db_dirty = set()
+            pydantic_setter(model_self, "_db_loaded", False)
+        pydantic_setter(model_self, "_db_deleted", False)
+        pydantic_setter(model_self, "_db_dirty", set())
         await post_fn(
             real_class,
-            model_instance=self,
+            model_instance=model_self,
             instance=instance,
             column_values=column_values,
             values=kwargs,
@@ -1256,9 +1282,11 @@ class DatabaseMixin:
         Returns:
             The saved model instance.
         """
+        # bypass own __getattr__ overwrite
+        pydantic_getter = BaseModel.__getattr__
         model_self = cast("Model", self)
         instance: BaseModelType | QuerySet = CURRENT_INSTANCE.get()  # type: ignore
-        dirty = model_self._db_dirty
+        db_dirty = pydantic_getter(model_self, "_db_dirty")
         extracted_fields = model_self.extract_db_fields()
         if values is None:
             explicit_values: set[str] = set()
@@ -1319,9 +1347,9 @@ class DatabaseMixin:
                     instance=instance,
                 )
             else:
-                if dirty and values is None and model_self._db_loaded:
+                if db_dirty and values is None and pydantic_getter(model_self, "_db_loaded"):
                     # check only for loaded model instances which have dirty tracing
-                    update_values = {k: v for k, v in extracted_fields.items() if k in dirty}
+                    update_values = {k: v for k, v in extracted_fields.items() if k in db_dirty}
 
                     is_partial = True
                 elif values is None:
@@ -1349,7 +1377,7 @@ class DatabaseMixin:
         return self
 
     async def save(
-        self: Model,
+        self,
         force_insert: bool = False,
         values: dict[str, Any] | set[str] | None = None,
         force_save: bool | None = None,
@@ -1372,6 +1400,7 @@ class DatabaseMixin:
         Returns:
             The saved model instance.
         """
+        model_self = cast("Model", self)
         if force_save is not None:
             warnings.warn(
                 "'force_save' is deprecated in favor of 'force_insert'",
@@ -1379,9 +1408,9 @@ class DatabaseMixin:
                 stacklevel=2,
             )
             force_insert = force_save
-        token = CURRENT_INSTANCE.set(self)
+        token = CURRENT_INSTANCE.set(model_self)
         try:
-            return await self.real_save(force_insert=force_insert, values=values)
+            return await model_self.real_save(force_insert=force_insert, values=values)
         finally:
             CURRENT_INSTANCE.reset(token)
 

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -1279,6 +1279,7 @@ class DatabaseMixin:
         model_self = cast("Model", self)
         instance: BaseModelType | QuerySet = CURRENT_INSTANCE.get()  # type: ignore
         db_dirty = pydantic_getter(model_self, "_db_dirty")
+        meta = model_self.meta
         extracted_fields = model_self.extract_db_fields()
         if values is None:
             explicit_values: set[str] = set()
@@ -1300,7 +1301,7 @@ class DatabaseMixin:
                     extracted_fields.pop(pkcolumn, None)
                     force_insert = True
                     break
-                field = model_self.meta.fields.get(pkcolumn)
+                field = meta.fields.get(pkcolumn)
                 # this is an IntegerField/DateTime with primary_key set
                 if field is not None:
                     if getattr(field, "increment_on_save", 0) != 0 or getattr(
@@ -1341,7 +1342,16 @@ class DatabaseMixin:
             else:
                 if db_dirty and values is None and pydantic_getter(model_self, "_db_loaded"):
                     # check only for loaded model instances which have dirty tracing
-                    update_values = {k: v for k, v in extracted_fields.items() if k in db_dirty}
+                    update_values = {
+                        k: v
+                        for k, v in extracted_fields.items()
+                        if k in db_dirty
+                        or (
+                            k in meta.foreign_key_fields
+                            and v is not None
+                            and pydantic_getter(v, "_db_dirty")
+                        )
+                    }
 
                     is_partial = True
                 elif values is None:

--- a/edgy/core/db/models/mixins/db.py
+++ b/edgy/core/db/models/mixins/db.py
@@ -463,7 +463,7 @@ class DatabaseMixin:
         Returns:
             The active schema as a string, or None if no schema is found.
         """
-        if (namespace := self._edgy_namespace["__using_schema__"]) is not Undefined:
+        if (namespace := self._edgy_namespace)["__using_schema__"] is not Undefined:
             return cast(str | None, namespace["__using_schema__"])
         return type(self).get_active_class_schema(
             check_schema=check_schema, check_tenant=check_tenant

--- a/edgy/core/db/models/mixins/row.py
+++ b/edgy/core/db/models/mixins/row.py
@@ -196,7 +196,7 @@ class ModelRowMixin:
         # update its attributes with the newly populated `item` and return it.
         if old_select_related_value:
             for k, v in model_kwargs.items():
-                setattr(old_select_related_value, k, v)
+                object.__setattr__(old_select_related_value, k, v)
             return old_select_related_value
 
         table_columns = tables_and_models[prefix][0].columns
@@ -326,10 +326,10 @@ class ModelRowMixin:
             if exclude_secrets or is_defer_fields or only_fields
             else cls(**model_kwargs, __phase__="init_db")
         )
+        model._db_deleted = False
 
         # Mark the model as fully loaded if no deferred or only_fields are active.
         if not is_defer_fields and not only_fields:
-            model._db_deleted = False
             model._db_loaded = True
 
         # If excluding secrets, ensure these attributes do not trigger a load.
@@ -425,7 +425,7 @@ class ModelRowMixin:
                 unidirectional fields).
             NotImplementedError: If prefetching from other databases is attempted.
         """
-        model_key = ()
+        model_key: tuple = ()
         if related._is_finished:
             # If the prefetch operation is marked as finished (meaning all rows for this
             # prefetch have been collected), then bake the results. This allows for
@@ -436,7 +436,7 @@ class ModelRowMixin:
         # If the model's key exists in the baked results, retrieve and set the prefetched
         # data directly.
         if model_key in related._baked_results:
-            setattr(model, related.to_attr, related._baked_results[model_key])
+            object.__setattr__(model, related.to_attr, related._baked_results[model_key])
         else:
             # If not in baked results, or not finished, proceed with fetching.
             # Crawl the relationship path to get details about the related model and
@@ -476,7 +476,7 @@ class ModelRowMixin:
                 for pkcol in cls.pkcolumns
             }
             # Execute the prefetched query and set the result on the model instance.
-            setattr(model, related.to_attr, await queryset.filter(clause))
+            object.__setattr__(model, related.to_attr, await queryset.filter(clause))
 
     @classmethod
     async def __handle_prefetch_related(

--- a/edgy/core/db/models/types.py
+++ b/edgy/core/db/models/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Collection, Iterable, Sequence
+from collections.abc import Collection, Hashable, Iterable, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -487,7 +487,7 @@ class BaseModelType(ABC):
         return type(self).__name__.lower()
 
     @abstractmethod
-    def create_model_key(self, *, allow_missing_and_none: bool = False) -> tuple:
+    def create_model_key(self, *, allow_missing_and_none: bool = False) -> tuple[Hashable, ...]:
         """
         Generates a unique cache key for the model instance.
 

--- a/edgy/core/db/querysets/base.py
+++ b/edgy/core/db/querysets/base.py
@@ -499,9 +499,6 @@ class BaseQuerySet(
         executor = QueryExecutor(self)
         results = [result async for result in executor.iterate(fetch_all_at_once=True)]
 
-        # Only attempt dedupe for "normal" querysets.
-        # Embedded querysets (e.g. album.tracks with embed_parent) must not go
-        # through this path – their model_class and returned objects differ.
         if len(results) > 1 and not getattr(self, "_suppress_pk_deduplication", False):
             seen: set[tuple] = set()
             unique = []

--- a/edgy/core/db/querysets/bulk.py
+++ b/edgy/core/db/querysets/bulk.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import (
     Awaitable,
     Collection,
+    Hashable,
     Iterable,
 )
 from contextlib import AsyncExitStack
@@ -68,6 +69,8 @@ def _extract_unique_lookup_key(
                 return None
         elif isinstance(value, dict | list):
             value = orjson.dumps(value, option=orjson.OPT_SORT_KEYS)
+        if not isinstance(value, Hashable):
+            return None
         lookup_key.append(value)
     return tuple(lookup_key)
 

--- a/edgy/core/db/relationships/related_field.py
+++ b/edgy/core/db/relationships/related_field.py
@@ -166,19 +166,13 @@ class RelatedField(RelationshipField):
             ValueError: If `instance` is None, indicating a missing model instance.
         """
         # Ensure a model instance is provided.
-        if not instance:
-            raise ValueError("missing instance")
-
-        # If the related field hasn't been initialized on the instance's dictionary.
-        if instance.__dict__.get(self.name, None) is None:
-            # Initialize it with a new relation obtained via get_relation.
-            instance.__dict__[self.name] = self.get_relation()
-        # If the relation instance itself doesn't have a reference to its parent.
-        if instance.__dict__[self.name].instance is None:
-            # Set the parent instance reference.
-            instance.__dict__[self.name].instance = instance
-        # Return the ManyRelationProtocol instance associated with this field.
-        return instance.__dict__[self.name]  # type: ignore
+        if instance is None:
+            raise ValueError("Missing instance")
+        # If the relation hasn't been set or is None, initialize it.
+        relation: ManyRelationProtocol | None
+        if (relation := instance.__dict__.get(self.name, None)) is None:
+            relation = instance.__dict__[self.name] = self.get_relation()
+        return relation.__get__(instance, owner)
 
     @functools.cached_property
     def foreign_key(self) -> BaseForeignKeyField:

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -31,6 +31,8 @@ class ManyRelation(ManyRelationProtocol):
     allowing it to be used as a descriptor on model fields.
     """
 
+    instance: BaseModelType | None = None
+
     def __init__(
         self,
         *,
@@ -41,7 +43,6 @@ class ManyRelation(ManyRelationProtocol):
         reverse: bool = False,
         embed_through: Literal[False] | str = "",
         refs: Any = (),
-        instance: BaseModelType | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -67,16 +68,12 @@ class ManyRelation(ManyRelationProtocol):
             refs (Any): Initial references to related objects to be staged.
                         Can be a single instance or a sequence of instances.
                         Defaults to an empty tuple.
-            instance (BaseModelType | None): The current instance of the model
-                                             that owns this relationship.
-                                             Defaults to None.
             **kwargs (Any): Additional keyword arguments passed to the
                             `ManyRelationProtocol` constructor.
         """
         super().__init__(**kwargs)
         self.through = through
         self.to = to
-        self.instance = instance
         self.reverse = reverse
         self.from_foreign_key = from_foreign_key
         self.to_foreign_key = to_foreign_key
@@ -187,6 +184,10 @@ class ManyRelation(ManyRelationProtocol):
             await operation.send_post_signal()
             return
         await operation.apply_db()
+        db_dirty = getattr(self.instance, "_db_dirty", None)
+        if db_dirty is not None and not self.refs:
+            # recheck then drop
+            db_dirty.discard(self.from_foreign_key)
         # no cache update because the queryset is temporarysignal
         # both parameters are the same here
         operation.signal_params["row_count"] = operation.signal_params.get("row_count_create")
@@ -274,7 +275,7 @@ class ManyRelation(ManyRelationProtocol):
         )
         # If the 'through' model is a tenant model, set the active schema for the instance.
         if getattr(through.meta, "is_tenant", False):
-            instance.__using_schema__ = self.instance.get_active_instance_schema()  # type: ignore
+            instance.__using_schema__ = self.instance.get_active_instance_schema()
         return instance
 
     def stage(self, *children: BaseModelType) -> None:
@@ -293,6 +294,12 @@ class ManyRelation(ManyRelationProtocol):
         for child in children:
             # Expand the child into a 'through' model instance and append it to refs.
             self.refs.append(self.expand_relationship(child))
+        db_dirty = cast("set[str] | None", getattr(self.instance, "_db_dirty", None))
+        if db_dirty is not None:
+            if self.refs:
+                db_dirty.add(self.from_foreign_key)
+            else:
+                db_dirty.discard(self.from_foreign_key)
 
     async def create(self, *args: Any, **kwargs: Any) -> BaseModelType | None:
         """
@@ -576,7 +583,14 @@ class ManyRelation(ManyRelationProtocol):
             ManyRelationProtocol: The ManyRelation instance itself, with its
                                   `instance` attribute set.
         """
-        self.instance = instance
+        if self.instance is not instance and instance is not None:
+            self.instance = instance
+            db_dirty = getattr(instance, "_db_dirty", None)
+            if db_dirty is not None:
+                if not self.refs:
+                    db_dirty.discard(self.from_foreign_key)
+                else:
+                    db_dirty.add(self.from_foreign_key)
         return self
 
 
@@ -588,14 +602,16 @@ class SingleRelation(ManyRelationProtocol):
     `ManyRelationProtocol`, acting as a descriptor for model fields.
     """
 
+    instance: BaseModelType | None = None
+
     def __init__(
         self,
         *,
+        reverse_name: str | Literal[False],
         to_foreign_key: str,
         to: type[BaseModelType],
         embed_parent: tuple[str, str] | None = None,
         refs: Any = (),
-        instance: BaseModelType | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -604,6 +620,7 @@ class SingleRelation(ManyRelationProtocol):
         Args:
             to_foreign_key (str): The name of the foreign key in the `to` model
                                   that points back to the owner of this relationship.
+            reverse_name (str): The reverse_name (name of the relationship field).
             to (type[BaseModelType]): The model class that is on the 'many' side
                                       of the relationship (or the single related model).
             embed_parent (tuple[str, str] | None): A tuple specifying how to embed
@@ -612,15 +629,12 @@ class SingleRelation(ManyRelationProtocol):
             refs (Any): Initial references to related objects to be staged.
                         Can be a single instance or a sequence of instances.
                         Defaults to an empty tuple.
-            instance (BaseModelType | None): The current instance of the model
-                                             that owns this relationship.
-                                             Defaults to None.
             **kwargs (Any): Additional keyword arguments passed to the
                             `ManyRelationProtocol` constructor.
         """
         super().__init__(**kwargs)
         self.to = to
-        self.instance = instance
+        self.reverse_name = reverse_name
         self.to_foreign_key = to_foreign_key
         self.embed_parent = embed_parent
         self.refs: list[BaseModelType] = []  # Initialize refs as a list
@@ -633,12 +647,11 @@ class SingleRelation(ManyRelationProtocol):
     @cached_property
     def _shared_relation_signals_params(self) -> dict:
         assert self.instance is not None
-        fk = self.to.meta.fields[self.to_foreign_key]
         # here reverse_name=related_name
         return {
             "source": type(self.instance),
             "target": self.to,
-            "field": fk.reverse_name,
+            "field": self.reverse_name,
             "relation": "one_to_many",
         }
 
@@ -742,7 +755,7 @@ class SingleRelation(ManyRelationProtocol):
         target_instance.identifying_db_fields = related_columns
         # If the 'to' model is a tenant model, set the active schema for the instance.
         if getattr(target.meta, "is_tenant", False):
-            target_instance.__using_schema__ = self.instance.get_active_instance_schema()  # type: ignore
+            target_instance.__using_schema__ = self.instance.get_active_instance_schema()
         return target_instance
 
     def stage(self, *children: BaseModelType) -> None:
@@ -761,6 +774,13 @@ class SingleRelation(ManyRelationProtocol):
         for child in children:
             # Expand the child into a 'to' model instance and append it to refs.
             self.refs.append(self.expand_relationship(child))
+
+        db_dirty = cast("set[str] | None", getattr(self.instance, "_db_dirty", None))
+        if db_dirty is not None:
+            if self.refs:
+                db_dirty.add(self.from_foreign_key)
+            else:
+                db_dirty.discard(self.from_foreign_key)
 
     def __getattr__(self, item: Any) -> Any:
         """
@@ -826,6 +846,10 @@ class SingleRelation(ManyRelationProtocol):
             await operation.send_post_signal()
             return
         await operation.apply_db()
+        db_dirty = getattr(self.instance, "_db_dirty", None)
+        if db_dirty is not None and not self.refs:
+            # recheck then drop
+            db_dirty.discard(self.from_foreign_key)
         # no cache update because the queryset is temporary
         # we can just rename the signals parameters for the post signal
         operation.signal_params["row_count"] = operation.signal_params.pop("row_count_update")
@@ -1068,7 +1092,14 @@ class SingleRelation(ManyRelationProtocol):
             ManyRelationProtocol: The SingleRelation instance itself, with its
                                   `instance` attribute set.
         """
-        self.instance = instance
+        if self.instance is not instance and instance is not None:
+            self.instance = instance
+            db_dirty = getattr(instance, "_db_dirty", None)
+            if db_dirty is not None:
+                if not self.refs:
+                    db_dirty.discard(self.reverse_name)
+                else:
+                    db_dirty.add(self.reverse_name)
         return self
 
 

--- a/edgy/core/db/relationships/relation.py
+++ b/edgy/core/db/relationships/relation.py
@@ -185,9 +185,12 @@ class ManyRelation(ManyRelationProtocol):
             return
         await operation.apply_db()
         db_dirty = getattr(self.instance, "_db_dirty", None)
-        if db_dirty is not None and not self.refs:
-            # recheck then drop
-            db_dirty.discard(self.from_foreign_key)
+        if db_dirty is not None:
+            # new ones are added
+            if self.refs:
+                db_dirty.add(self.from_foreign_key)
+            else:
+                db_dirty.discard(self.from_foreign_key)
         # no cache update because the queryset is temporarysignal
         # both parameters are the same here
         operation.signal_params["row_count"] = operation.signal_params.get("row_count_create")
@@ -607,7 +610,7 @@ class SingleRelation(ManyRelationProtocol):
     def __init__(
         self,
         *,
-        reverse_name: str | Literal[False],
+        reverse_name: str,
         to_foreign_key: str,
         to: type[BaseModelType],
         embed_parent: tuple[str, str] | None = None,
@@ -778,9 +781,9 @@ class SingleRelation(ManyRelationProtocol):
         db_dirty = cast("set[str] | None", getattr(self.instance, "_db_dirty", None))
         if db_dirty is not None:
             if self.refs:
-                db_dirty.add(self.from_foreign_key)
+                db_dirty.add(self.reverse_name)
             else:
-                db_dirty.discard(self.from_foreign_key)
+                db_dirty.discard(self.reverse_name)
 
     def __getattr__(self, item: Any) -> Any:
         """
@@ -847,9 +850,12 @@ class SingleRelation(ManyRelationProtocol):
             return
         await operation.apply_db()
         db_dirty = getattr(self.instance, "_db_dirty", None)
-        if db_dirty is not None and not self.refs:
-            # recheck then drop
-            db_dirty.discard(self.from_foreign_key)
+        if db_dirty is not None:
+            # new ones are added
+            if self.refs:
+                db_dirty.add(self.reverse_name)
+            else:
+                db_dirty.discard(self.reverse_name)
         # no cache update because the queryset is temporary
         # we can just rename the signals parameters for the post signal
         operation.signal_params["row_count"] = operation.signal_params.pop("row_count_update")

--- a/edgy/protocols/many_relationship.py
+++ b/edgy/protocols/many_relationship.py
@@ -142,3 +142,7 @@ class ManyRelationProtocol(Protocol):
             *children (BaseModelType): One or more specific related model instances to remove.
         """
         ...
+
+    def __get__(self, instance: BaseModelType, owner: Any = None) -> ManyRelationProtocol:
+        """Initialisation of relation. It must work like a property."""
+        ...

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -179,6 +179,16 @@ async def test_loop2():
     await user.load_recursive()
 
 
+async def test_loop_fail_gracefully():
+    user = User2(name="foo")
+    user.friend = user
+    with pytest.raises(ValueError) as excwrapper:
+        await user.save()
+    assert (
+        excwrapper.value.args[0] == "Couldn't save `friend`. Please save child first. Is a loop?"
+    )
+
+
 async def test_loop3():
     user = await User2.query.create(name="foo")
     user.friends.stage(user, user, user, User2(name="bar"))

--- a/tests/foreign_keys/test_foreignkey.py
+++ b/tests/foreign_keys/test_foreignkey.py
@@ -104,6 +104,14 @@ class AnotherPerson(edgy.StrictModel):
         registry = models
 
 
+class User2(edgy.StrictModel):
+    name: str = edgy.CharField(max_length=100)
+    friend: "User2" = edgy.ForeignKey("User2", null=True, related_name="friends")
+
+    class Meta:
+        registry = models
+
+
 async def test_no_relation():
     for field in Profile.meta.fields:
         assert not field.startswith("person")
@@ -154,6 +162,29 @@ async def test_create_dynamic():
     assert await Album.query.get(name="Malibu")
     await track.update(album=Album(name="Foo"))
     assert await Album.query.get(name="Foo")
+
+
+async def test_loop():
+    user = await User2.query.create(name="foo")
+    user.friend = user
+    await user.save()
+    await user.load_recursive()
+
+
+async def test_loop2():
+    user = User2(name="foo")
+    await user.save()
+    user.friend = user
+    await user.save()
+    await user.load_recursive()
+
+
+async def test_loop3():
+    user = await User2.query.create(name="foo")
+    user.friends.stage(user, user, user, User2(name="bar"))
+    await user.save()
+    await user.load_recursive()
+    assert await User2.query.order_by("id").values_list("name", flat=True) == ["foo", "bar"]
 
 
 async def test_select_related():

--- a/tests/foreign_keys/test_many_to_many.py
+++ b/tests/foreign_keys/test_many_to_many.py
@@ -68,6 +68,7 @@ async def create_test_database():
 async def test_loop():
     user = await User2.query.create(name="foo")
     await user.friends.add(user)
+    assert await user.friends.values_list("name", flat=True) == ["foo"]
     assert await User2.query.order_by("id").values_list("name", flat=True) == ["foo"]
 
 

--- a/tests/foreign_keys/test_many_to_many.py
+++ b/tests/foreign_keys/test_many_to_many.py
@@ -48,6 +48,14 @@ class Studio(edgy.StrictModel):
         registry = models
 
 
+class User2(edgy.StrictModel):
+    name: str = edgy.CharField(max_length=100)
+    friends: "User2" = edgy.ManyToMany("User2", null=True, related_name="friends_of")
+
+    class Meta:
+        registry = models
+
+
 @pytest.fixture(autouse=True, scope="function")
 async def create_test_database():
     async with database:
@@ -55,6 +63,30 @@ async def create_test_database():
         yield
         if not database.drop:
             await models.drop_all()
+
+
+async def test_loop():
+    user = await User2.query.create(name="foo")
+    await user.friends.add(user)
+    assert await User2.query.order_by("id").values_list("name", flat=True) == ["foo"]
+
+
+async def test_loop2():
+    user = User2(name="foo")
+    await user.save()
+    user.friends.stage(user)
+    user.friends.stage(User2(name="bar"))
+    assert await User2.query.order_by("id").values_list("name", flat=True) == ["foo"]
+    await user.save()
+    assert await User2.query.order_by("id").values_list("name", flat=True) == ["foo", "bar"]
+
+
+async def test_loop3():
+    user = await User2.query.create(name="foo")
+    user.friends_of.stage(user, user, user, User2(name="bar"))
+    await user.save()
+    await user.load_recursive()
+    assert await User2.query.order_by("id").values_list("name", flat=True) == ["foo", "bar"]
 
 
 async def test_add_many_to_many():


### PR DESCRIPTION
Changes:
- add dirty field tracking
- refactor relations setup
- speed improvements
- remove phase (`compare`), which was executed a in performance critical phase. It was never released nor mentioned in rl docs

<del>One loop tracing thing is missing (but wouldn't work either before):</del>
``` python
user = User(name="foo")
user.friends.stage(user)
await user.save()
```

Fail gracefully when such a condition is detected.