### PR TITLE
bake with create_model_key, deprecate low level variant

### DIFF
--- a/edgy/core/db/models/mixins/row.py
+++ b/edgy/core/db/models/mixins/row.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, cast
 
@@ -394,6 +395,11 @@ class ModelRowMixin:
         Returns:
             tuple: A tuple representing the unique key for the model instance.
         """
+        warnings.warn(
+            "This method is deprecated, use a models `create_model_key` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         pk_key_list: list[Any] = [cls.__name__]
         for attr in cls.pkcolumns:
             # Append the primary key value from the row to the key list.

--- a/edgy/core/db/querysets/executor.py
+++ b/edgy/core/db/querysets/executor.py
@@ -11,7 +11,6 @@ from edgy.core.db.context_vars import CURRENT_INSTANCE
 from edgy.core.db.datastructures import QueryModelResultCache
 from edgy.core.db.querysets.clauses import and_, or_
 from edgy.core.db.querysets.parser import ResultParser
-from edgy.core.db.querysets.prefetch import Prefetch, check_prefetch_collision
 from edgy.core.db.relationships.utils import crawl_relationship
 from edgy.core.utils.db import check_db_connection, hash_tablekey
 from edgy.exceptions import MultipleObjectsReturned, ObjectNotFound, QuerySetError, SkipOperation
@@ -20,6 +19,7 @@ from .types import EdgyEmbedTarget, EdgyModel
 
 if TYPE_CHECKING:  # pragma: no cover
     from edgy.core.db.querysets.base import BaseQuerySet
+    from edgy.core.db.querysets.prefetch import Prefetch
     from edgy.core.db.querysets.queryset import QuerySet
 
     from .types import tables_and_models_type
@@ -260,6 +260,8 @@ class QueryExecutor(Generic[EdgyModel, EdgyEmbedTarget]):
             NotImplementedError: If a prefetch crosses database boundaries.
             QuerySetError: If a prefetch path is invalid (e.g., unidirectional).
         """
+        from edgy.core.db.querysets.prefetch import Prefetch, check_prefetch_collision
+
         prepared_prefetches: list[Prefetch] = []
         qs = self.queryset
 

--- a/edgy/core/db/querysets/prefetch.py
+++ b/edgy/core/db/querysets/prefetch.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
-from edgy.core.db.querysets.executor import QueryExecutor
 from edgy.exceptions import QuerySetError
 
 if TYPE_CHECKING:
@@ -76,6 +75,8 @@ class Prefetch:
                                         results will eventually be attached. This
                                         is used to create the model keys for grouping.
         """
+        from edgy.core.db.querysets.executor import QueryExecutor
+
         # If already baked, not finished, or no queryset, do not proceed.
         if self._baked or not self._is_finished or self.queryset is None:
             return

--- a/edgy/core/db/querysets/prefetch.py
+++ b/edgy/core/db/querysets/prefetch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+from edgy.core.db.querysets.executor import QueryExecutor
 from edgy.exceptions import QuerySetError
 
 if TYPE_CHECKING:
@@ -80,15 +81,13 @@ class Prefetch:
             return
         self._baked = True
         # Execute the queryset and asynchronously iterate over the results.
-        # The `True` argument for `_execute_iterate` ensures all results are
+        # The `True` argument for `iterate` ensures all results are
         # fetched at once for processing.
-        async for result in self.queryset._execute_iterate(True):
+        async for raw_model, result in QueryExecutor(self.queryset).iterate(True):
             # Create a unique model key from the current SQLAlchemy row using the
             # specified bake prefix. This key links the prefetched item back to
             # its parent model instance.
-            model_key = model_class.create_model_key_from_sqla_row(
-                self.queryset._current_row, row_prefix=self._bake_prefix
-            )
+            model_key = raw_model.create_model_key()
             # Append the prefetched result to the list associated with its model key.
             self._baked_results[model_key].append(result)
 


### PR DESCRIPTION
Changes:
- bake cache keys with create_model_key instead of the low level variant
- deprecate the lowlevel variant

We might should also remove the hack with get_current_row and either get completely rid of the lowlevel row api or expose it in the QueryExecutor

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dymmond/edgy/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

